### PR TITLE
feat(crawler): make max wait time configurable via MAX_WAIT_MINUTES 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,6 @@ NEXT_PUBLIC_GITHUB_REPO=
 AI_PROVIDER=
 AI_API_KEY=
 AI_MODEL=
+
+# [optional] Crawler: max wait time for account updates in minutes (default: 20)
+# MAX_WAIT_MINUTES=20

--- a/apps/crawler/src/scrapers/refresh.ts
+++ b/apps/crawler/src/scrapers/refresh.ts
@@ -3,7 +3,9 @@ import type { Page } from "playwright";
 import { mfUrls } from "@mf-dashboard/meta/urls";
 import { debug, info, warn } from "../logger.js";
 
-const MAX_WAIT_TIME_MS = 20 * 60 * 1000; // 20 minutes max
+const DEFAULT_MAX_WAIT_MINUTES = 20;
+const MAX_WAIT_TIME_MS =
+  (Number(process.env.MAX_WAIT_MINUTES) || DEFAULT_MAX_WAIT_MINUTES) * 60 * 1000; // default: 20 minutes
 const POLL_INTERVAL_MS = 30000; // 30 seconds
 
 async function navigateToAccountsPage(page: Page): Promise<void> {


### PR DESCRIPTION
# 概要

私の環境でもありがたく使用させていただいています。
私のアカウントでは毎日 GitHub Actions 上でクローラーを実行させているのですが、20分を超過してもクローラーが完了できず打ち切りになっています。また、Actions のこすとから20分の決め打ちではなく環境変数でタイムアウトになる時間を変更したく差し替えられるようにいたしました
