### PR TITLE
fix(crawler): detect end of cash flow history without timeout

### DIFF
--- a/apps/crawler/src/scrapers/cash-flow-history.ts
+++ b/apps/crawler/src/scrapers/cash-flow-history.ts
@@ -271,23 +271,21 @@ export async function scrapeCashFlowHistory(
     if (i < monthsToScrape - 1) {
       const currentMonth = await getMonthFromCsvLink(page);
       const prevButton = page.locator("button.fc-button-prev, span.fc-button-prev").first();
-      await prevButton.click();
 
       // 月が変わるまで待機（CSV linkのURLパラメータで判定）
-      await page.waitForFunction(
-        (prevMonth) => {
-          const link = document.querySelector("a[href*='/cf/csv']");
-          if (!link) return false;
-          const href = link.getAttribute("href") || "";
-          const yearMatch = href.match(/year=(\d{4})/);
-          const monthMatch = href.match(/month=(\d{1,2})/);
-          if (!yearMatch || !monthMatch) return false;
-          const newMonth = `${yearMatch[1]}-${monthMatch[1].padStart(2, "0")}`;
-          return newMonth !== prevMonth;
-        },
-        currentMonth,
-        { timeout: 10000 },
-      );
+      // クリックで /cf/fetch が発火するため、取りこぼさないよう先にリスナーを登録し、
+      // レスポンス到着後にCSV linkの月パラメータが変わったかを確認する
+      await Promise.all([
+        page.waitForResponse((res) => res.url().includes("/cf/fetch") && res.status() === 200),
+        prevButton.click(),
+      ]);
+
+      // /cf/fetch 後も月が変わらなければ、これ以上データがないことを意味する
+      const newMonth = await getMonthFromCsvLink(page);
+      if (newMonth === currentMonth) {
+        log(`  No more months available after ${currentMonth}, stopping.`);
+        break;
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

In `SCRAPE_MODE=history`, the crawler calculates how many months to fetch based on the current date (current month + 12 months back). If the MoneyForward ME account has fewer months of data than requested (e.g., account is less than a year old), the crawler reaches the oldest available month and clicks the "previous month" button, but the page has no earlier data to show.

The current implementation uses `page.waitForFunction` with a 10-second timeout to detect month changes by polling the CSV download link's URL parameters. When no earlier data exists, the parameters never change, and the function times out with a `TimeoutError`. This error propagates unhandled, causing `scrapeCashFlowHistory()` to throw before returning any results. Since transaction saving happens after the function returns, all previously scraped data is lost.

## Solution

Replace `page.waitForFunction` (timeout-based polling) with `page.waitForResponse` to wait for the `/cf/fetch` POST request that MoneyForward ME fires on every month navigation. After the response returns with `200 OK`, compare the CSV link's month parameter before and after:

- **Changed** → page navigated to a new month, continue scraping
- **Unchanged** → no earlier data exists, `break` out of the loop and return all results collected so far

Benefits:
- **Faster**: Detection is immediate after the server responds, no 10-second timeout wait
- **More accurate**: Distinguishes "no more data" (server responded, month unchanged) from "slow page load" (server hasn't responded yet)
- **Data-safe**: All previously scraped months are returned and saved to the database

## Test

Tested with `SCRAPE_MODE=history` where the crawler requested 15 months but only 13 months of data existed in MoneyForward ME:

- **Before (main)**: `page.waitForFunction: Timeout 10000ms exceeded` → error thrown, 0 months saved
- **After (this branch)**: `No more months available after 2025-03, stopping.` → 13 months saved