### PR TITLE
取得を停止しているアカウントをエラーとして扱わない

### DIFF
--- a/apps/crawler/src/scrapers/registered-accounts.ts
+++ b/apps/crawler/src/scrapers/registered-accounts.ts
@@ -91,8 +91,10 @@ export async function getRegisteredAccounts(page: Page): Promise<RegisteredAccou
           } else if (statusText?.includes("更新中")) {
             status = "updating";
             errorMessage = statusText.trim();
+          } else if (statusText?.includes("取得を停止しています")) {
+            status = "suspended";
           } else if (statusText && statusText.trim()) {
-            // 正常でも更新中でもない場合はエラー扱い
+            // 正常でも更新中でも停止中でもない場合はエラー扱い
             status = "error";
             errorMessage = statusText.trim();
           }

--- a/apps/crawler/tests/e2e/scraper.test.ts
+++ b/apps/crawler/tests/e2e/scraper.test.ts
@@ -153,7 +153,7 @@ describe("registeredAccounts", () => {
 
   test("各口座に有効なステータスがある", () => {
     for (const account of data.registeredAccounts.accounts) {
-      expect(["ok", "error", "updating", "unknown"]).toContain(account.status);
+      expect(["ok", "error", "updating", "unknown", "suspended"]).toContain(account.status);
     }
   });
 });

--- a/apps/web/src/app/accounts/page.tsx
+++ b/apps/web/src/app/accounts/page.tsx
@@ -1,4 +1,5 @@
 import { getAccountsGroupedByCategory } from "@mf-dashboard/db";
+import type { AccountStatusType } from "@mf-dashboard/db/types";
 import { mfUrls } from "@mf-dashboard/meta/urls";
 import type { Metadata } from "next";
 import { AccountCard } from "../../components/info/account-card";
@@ -16,7 +17,7 @@ interface GroupedAccounts {
     mfId: string;
     name: string;
     type: string;
-    status: string;
+    status: AccountStatusType;
     lastUpdated: string | null;
     totalAssets: number;
   }[];

--- a/apps/web/src/components/info/account-card.stories.tsx
+++ b/apps/web/src/components/info/account-card.stories.tsx
@@ -48,7 +48,7 @@ export const Manual: Story = {
     mfId: "manual001",
     name: "現金",
     type: "手動",
-    status: "",
+    status: "unknown",
     lastUpdated: null,
     totalAssets: 100000,
   },

--- a/apps/web/src/components/info/account-card.tsx
+++ b/apps/web/src/components/info/account-card.tsx
@@ -1,3 +1,4 @@
+import type { AccountStatusType } from "@mf-dashboard/db/types";
 import { formatLastUpdated } from "../../lib/format";
 import { AccountStatusBadge } from "../ui/account-status-badge";
 import { AmountDisplay } from "../ui/amount-display";
@@ -8,7 +9,7 @@ type AccountCardProps = {
   mfId: string;
   name: string;
   type: string;
-  status: string;
+  status: AccountStatusType;
   lastUpdated: string | null;
   totalAssets: number;
   groupId?: string;

--- a/apps/web/src/components/info/account-summary-card.stories.tsx
+++ b/apps/web/src/components/info/account-summary-card.stories.tsx
@@ -21,7 +21,7 @@ const mockAccount = {
   type: "証券",
   categoryName: "証券",
   institution: "サンプル証券",
-  status: "ok",
+  status: "ok" as const,
   lastUpdated: "2025-04-26T10:30:00",
   errorMessage: null,
   totalAssets: 15000000,

--- a/apps/web/src/components/info/holdings-table.stories.tsx
+++ b/apps/web/src/components/info/holdings-table.stories.tsx
@@ -251,7 +251,7 @@ const mockAccount = {
   type: "証券",
   categoryName: "証券",
   institution: "サンプル証券",
-  status: "ok",
+  status: "ok" as const,
   lastUpdated: "2025-04-26T10:30:00",
   errorMessage: null,
   totalAssets: 15000000,

--- a/apps/web/src/components/info/unrealized-gain-card.stories.tsx
+++ b/apps/web/src/components/info/unrealized-gain-card.stories.tsx
@@ -177,7 +177,7 @@ const mockAccount = {
   type: "証券",
   categoryName: "証券",
   institution: "SBI証券",
-  status: "ok",
+  status: "ok" as const,
   lastUpdated: "2025-04-26T10:30:00",
   errorMessage: null,
   totalAssets: 15000000,

--- a/apps/web/src/components/ui/account-status-badge.stories.tsx
+++ b/apps/web/src/components/ui/account-status-badge.stories.tsx
@@ -25,6 +25,10 @@ export const Error: Story = {
   args: { status: "error" },
 };
 
+export const Suspended: Story = {
+  args: { status: "suspended" },
+};
+
 export const Unknown: Story = {
   args: { status: "unknown" },
 };

--- a/apps/web/src/components/ui/account-status-badge.tsx
+++ b/apps/web/src/components/ui/account-status-badge.tsx
@@ -1,7 +1,8 @@
+import type { AccountStatusType } from "@mf-dashboard/db/types";
 import { Badge } from "./badge";
 
 interface AccountStatusBadgeProps {
-  status: string;
+  status: AccountStatusType;
 }
 
 export function AccountStatusBadge({ status }: AccountStatusBadgeProps) {
@@ -12,6 +13,8 @@ export function AccountStatusBadge({ status }: AccountStatusBadgeProps) {
       return <Badge variant="warning">更新中</Badge>;
     case "error":
       return <Badge variant="destructive">エラー</Badge>;
+    case "suspended":
+      return <Badge variant="secondary">停止中</Badge>;
     default:
       return <Badge variant="secondary">不明</Badge>;
   }

--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -51,7 +51,7 @@ erDiagram
     account_statuses {
         integer id PK
         integer account_id FK,UK "CASCADE"
-        text status
+        text status "ok/error/updating/suspended/unknown"
         text last_updated
         integer total_assets
         text error_message

--- a/packages/db/src/queries/account.test.ts
+++ b/packages/db/src/queries/account.test.ts
@@ -130,7 +130,7 @@ describe("normalizeAccount", () => {
 
     const result = normalizeAccount(account);
 
-    expect(result.status).toBe("ok");
+    expect(result.status).toBe("unknown");
     expect(result.totalAssets).toBe(0);
     expect(result.categoryName).toBe("未分類");
     expect(result.categoryDisplayOrder).toBe(999);
@@ -142,7 +142,7 @@ describe("normalizeAccount", () => {
       mfId: "mf1",
       name: "Bank A",
       type: "bank",
-      status: "alert",
+      status: "error",
       lastUpdated: "2025-04-15",
       totalAssets: 100000,
       categoryId: 1,
@@ -152,7 +152,7 @@ describe("normalizeAccount", () => {
 
     const result = normalizeAccount(account);
 
-    expect(result.status).toBe("alert");
+    expect(result.status).toBe("error");
     expect(result.totalAssets).toBe(100000);
     expect(result.categoryName).toBe("銀行");
     expect(result.categoryDisplayOrder).toBe(1);
@@ -232,7 +232,7 @@ describe("groupAccountsByCategory", () => {
         mfId: "mf1",
         name: "Bank A",
         type: "bank",
-        status: "ok",
+        status: "ok" as const,
         lastUpdated: null,
         totalAssets: 100000,
         categoryId: 1,
@@ -244,7 +244,7 @@ describe("groupAccountsByCategory", () => {
         mfId: "mf2",
         name: "Investment A",
         type: "investment",
-        status: "ok",
+        status: "ok" as const,
         lastUpdated: null,
         totalAssets: 500000,
         categoryId: 2,
@@ -256,7 +256,7 @@ describe("groupAccountsByCategory", () => {
         mfId: "mf3",
         name: "Bank B",
         type: "bank",
-        status: "ok",
+        status: "ok" as const,
         lastUpdated: null,
         totalAssets: 200000,
         categoryId: 1,
@@ -281,7 +281,7 @@ describe("groupAccountsByCategory", () => {
         mfId: "mf1",
         name: "Bank A",
         type: "bank",
-        status: "ok",
+        status: "ok" as const,
         lastUpdated: null,
         totalAssets: 100000,
         categoryId: 1,
@@ -293,7 +293,7 @@ describe("groupAccountsByCategory", () => {
         mfId: "mf2",
         name: "Bank B",
         type: "bank",
-        status: "ok",
+        status: "ok" as const,
         lastUpdated: null,
         totalAssets: 500000,
         categoryId: 1,
@@ -305,7 +305,7 @@ describe("groupAccountsByCategory", () => {
         mfId: "mf3",
         name: "Bank C",
         type: "bank",
-        status: "ok",
+        status: "ok" as const,
         lastUpdated: null,
         totalAssets: 200000,
         categoryId: 1,
@@ -328,7 +328,7 @@ describe("groupAccountsByCategory", () => {
         mfId: "mf1",
         name: "Investment",
         type: "investment",
-        status: "ok",
+        status: "ok" as const,
         lastUpdated: null,
         totalAssets: 100000,
         categoryId: 2,
@@ -340,7 +340,7 @@ describe("groupAccountsByCategory", () => {
         mfId: "mf2",
         name: "Bank",
         type: "bank",
-        status: "ok",
+        status: "ok" as const,
         lastUpdated: null,
         totalAssets: 100000,
         categoryId: 1,
@@ -418,7 +418,7 @@ describe("getAccountsWithAssets", () => {
 
     const result = await getAccountsWithAssets(undefined, db);
 
-    expect(result[0].status).toBe("ok");
+    expect(result[0].status).toBe("unknown");
     expect(result[0].totalAssets).toBe(0);
     expect(result[0].categoryName).toBe("未分類");
   });
@@ -522,7 +522,7 @@ describe("getAccountByMfId", () => {
 
     const result = await getAccountByMfId("mf1", undefined, db);
 
-    expect(result!.status).toBe("ok");
+    expect(result!.status).toBe("unknown");
     expect(result!.totalAssets).toBe(0);
     expect(result!.categoryName).toBe("未分類");
   });

--- a/packages/db/src/queries/account.ts
+++ b/packages/db/src/queries/account.ts
@@ -1,6 +1,7 @@
 import { eq, and, sql, inArray } from "drizzle-orm";
 import { getDb, type Db, schema } from "../index";
 import { resolveGroupId, getAccountIdsForGroup } from "../shared/group-filter";
+import { toAccountStatusType, type AccountStatusType } from "../types";
 
 /**
  * グループの最終スクレイプ日時を取得
@@ -31,7 +32,7 @@ export function normalizeAccount<
 >(
   account: T,
 ): Omit<T, "status" | "totalAssets" | "categoryName" | "categoryDisplayOrder"> & {
-  status: string;
+  status: AccountStatusType;
   lastUpdated: T["lastUpdated"];
   totalAssets: number;
   categoryName: string;
@@ -39,7 +40,7 @@ export function normalizeAccount<
 } {
   return {
     ...account,
-    status: account.status ?? "ok",
+    status: toAccountStatusType(account.status),
     totalAssets: account.totalAssets ?? 0,
     categoryName: account.categoryName ?? "未分類",
     categoryDisplayOrder: account.categoryDisplayOrder ?? 999,
@@ -151,7 +152,7 @@ export async function getAccountByMfId(mfId: string, groupIdParam?: string, db: 
     mfId: account.mfId,
     name: account.name,
     type: account.type,
-    status: account.status ?? "ok",
+    status: toAccountStatusType(account.status),
     lastUpdated: account.lastUpdated ?? null,
     totalAssets: account.totalAssets ?? 0,
     errorMessage: account.errorMessage ?? null,

--- a/packages/db/src/schema/schema.ts
+++ b/packages/db/src/schema/schema.ts
@@ -79,7 +79,7 @@ export const accountStatuses = sqliteTable("account_statuses", {
     .notNull()
     .unique()
     .references(() => accounts.id, { onDelete: "cascade" }),
-  status: text("status").notNull(), // "ok" / "error" / "updating"
+  status: text("status").notNull(), // "ok" / "error" / "updating" / "suspended" / "unknown"
   lastUpdated: text("last_updated"), // ISO 8601形式
   totalAssets: integer("total_assets").default(0), // /accountsページから取得した資産額
   errorMessage: text("error_message"),

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -6,7 +6,22 @@
 export type AccountType = "自動連携" | "手動";
 
 /** Account status */
-export type AccountStatusType = "ok" | "error" | "updating" | "unknown";
+export type AccountStatusType = "ok" | "error" | "updating" | "suspended" | "unknown";
+
+const ACCOUNT_STATUS_VALUES: readonly string[] = [
+  "ok",
+  "error",
+  "updating",
+  "suspended",
+  "unknown",
+];
+
+export function toAccountStatusType(value: string | null | undefined): AccountStatusType {
+  if (value && ACCOUNT_STATUS_VALUES.includes(value)) {
+    return value as AccountStatusType;
+  }
+  return "unknown";
+}
 
 /** Holding type: asset or liability */
 export type HoldingType = "asset" | "liability";
@@ -78,7 +93,7 @@ export interface AccountStatus {
   mfId: string;
   name: string;
   type: string;
-  status: "ok" | "error" | "updating" | "unknown";
+  status: AccountStatusType;
   lastUpdated: string;
   url: string;
   totalAssets: number;


### PR DESCRIPTION
# 概要

ユーザが意図して連携停止をしている口座をエラーでなくサスペンドの扱いに変更します。
これにより、不要なエラー表示が減ります。

## 修正

- `AccountStatusType` に `suspended` を追加し、「取得を停止しています」状態のアカウントをエラーと区別する
- `toAccountStatusType()` ガード関数を追加し、DB文字列を安全に `AccountStatusType` へ変換する（不正値は `unknown` にフォールバック）
- クローラーで「取得を停止しています」テキストを検出した場合に `suspended` ステータスをセットする
- UI に「停止中」バッジ（secondary variant）を追加する
- `suspended` アカウントは既存の `updating` / `error` フィルターと同様に Slack/Discord 通知から自動除外される