### PR TITLE
Hide suspended accounts by default on /accounts page

### DIFF
--- a/apps/web/src/app/accounts/account-list.client.test.ts
+++ b/apps/web/src/app/accounts/account-list.client.test.ts
@@ -34,10 +34,7 @@ const baseGrouped = [
   {
     categoryName: "銀行",
     displayOrder: 1,
-    accounts: [
-      makeAccount({ id: 1, status: "ok" }),
-      makeAccount({ id: 2, status: "suspended" }),
-    ],
+    accounts: [makeAccount({ id: 1, status: "ok" }), makeAccount({ id: 2, status: "suspended" })],
   },
   {
     categoryName: "クレジットカード",

--- a/apps/web/src/app/accounts/account-list.client.test.ts
+++ b/apps/web/src/app/accounts/account-list.client.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { countSuspended, filterSuspended } from "./account-list.client";
+
+type Account = {
+  id: number;
+  mfId: string;
+  name: string;
+  type: string;
+  status: "ok" | "error" | "updating" | "suspended" | "unknown";
+  lastUpdated: string | null;
+  totalAssets: number;
+  categoryId: number | null;
+  categoryName: string;
+  categoryDisplayOrder: number;
+};
+
+function makeAccount(overrides: Partial<Account> = {}): Account {
+  return {
+    id: 1,
+    mfId: "acc-1",
+    name: "口座A",
+    type: "自動連携",
+    status: "ok",
+    lastUpdated: null,
+    totalAssets: 0,
+    categoryId: 1,
+    categoryName: "銀行",
+    categoryDisplayOrder: 1,
+    ...overrides,
+  };
+}
+
+const baseGrouped = [
+  {
+    categoryName: "銀行",
+    displayOrder: 1,
+    accounts: [
+      makeAccount({ id: 1, status: "ok" }),
+      makeAccount({ id: 2, status: "suspended" }),
+    ],
+  },
+  {
+    categoryName: "クレジットカード",
+    displayOrder: 2,
+    accounts: [makeAccount({ id: 3, status: "suspended" })],
+  },
+  {
+    categoryName: "証券",
+    displayOrder: 3,
+    accounts: [makeAccount({ id: 4, status: "error" })],
+  },
+];
+
+describe("countSuspended", () => {
+  it("suspended アカウントの件数を返す", () => {
+    expect(countSuspended(baseGrouped)).toBe(2);
+  });
+
+  it("suspended が0件の場合は0を返す", () => {
+    const groups = [
+      {
+        categoryName: "銀行",
+        displayOrder: 1,
+        accounts: [makeAccount({ status: "ok" }), makeAccount({ status: "error" })],
+      },
+    ];
+    expect(countSuspended(groups)).toBe(0);
+  });
+
+  it("空配列の場合は0を返す", () => {
+    expect(countSuspended([])).toBe(0);
+  });
+});
+
+describe("filterSuspended", () => {
+  it("suspended アカウントを除外する", () => {
+    const result = filterSuspended(baseGrouped);
+    const bankAccounts = result.find((g) => g.categoryName === "銀行")?.accounts;
+    expect(bankAccounts).toHaveLength(1);
+    expect(bankAccounts?.[0].status).toBe("ok");
+  });
+
+  it("suspended のみのカテゴリを除外する", () => {
+    const result = filterSuspended(baseGrouped);
+    const names = result.map((g) => g.categoryName);
+    expect(names).not.toContain("クレジットカード");
+  });
+
+  it("suspended でないアカウントのカテゴリは残す", () => {
+    const result = filterSuspended(baseGrouped);
+    const names = result.map((g) => g.categoryName);
+    expect(names).toContain("銀行");
+    expect(names).toContain("証券");
+  });
+
+  it("空配列の場合は空配列を返す", () => {
+    expect(filterSuspended([])).toEqual([]);
+  });
+});

--- a/apps/web/src/app/accounts/account-list.client.tsx
+++ b/apps/web/src/app/accounts/account-list.client.tsx
@@ -35,11 +35,7 @@ export function AccountListClient({ groupedAccounts, groupId }: AccountListClien
     <div className="space-y-6">
       {suspendedCount > 0 && (
         <div className="flex items-center gap-2">
-          <Switch
-            id="show-suspended"
-            checked={showSuspended}
-            onCheckedChange={setShowSuspended}
-          />
+          <Switch id="show-suspended" checked={showSuspended} onCheckedChange={setShowSuspended} />
           <label htmlFor="show-suspended" className="text-sm text-muted-foreground cursor-pointer">
             停止中を表示する（{suspendedCount}件）
           </label>

--- a/apps/web/src/app/accounts/account-list.client.tsx
+++ b/apps/web/src/app/accounts/account-list.client.tsx
@@ -13,9 +13,7 @@ interface AccountListClientProps {
 }
 
 export function countSuspended(groupedAccounts: GroupedAccounts): number {
-  return groupedAccounts
-    .flatMap((g) => g.accounts)
-    .filter((a) => a.status === "suspended").length;
+  return groupedAccounts.flatMap((g) => g.accounts).filter((a) => a.status === "suspended").length;
 }
 
 export function filterSuspended(groupedAccounts: GroupedAccounts): GroupedAccounts {
@@ -43,10 +41,7 @@ export function AccountListClient({ groupedAccounts, groupId }: AccountListClien
             onCheckedChange={setShowSuspended}
             aria-label="停止中のアカウントを表示する"
           />
-          <label
-            htmlFor="show-suspended"
-            className="text-sm text-muted-foreground cursor-pointer"
-          >
+          <label htmlFor="show-suspended" className="text-sm text-muted-foreground cursor-pointer">
             停止中を表示する（{suspendedCount}件）
           </label>
         </div>

--- a/apps/web/src/app/accounts/account-list.client.tsx
+++ b/apps/web/src/app/accounts/account-list.client.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import type { getAccountsGroupedByCategory } from "@mf-dashboard/db";
+import { useState } from "react";
+import { AccountCard } from "../../components/info/account-card";
+import { Switch } from "../../components/ui/switch";
+
+type GroupedAccounts = Awaited<ReturnType<typeof getAccountsGroupedByCategory>>;
+
+interface AccountListClientProps {
+  groupedAccounts: GroupedAccounts;
+  groupId?: string;
+}
+
+export function countSuspended(groupedAccounts: GroupedAccounts): number {
+  return groupedAccounts
+    .flatMap((g) => g.accounts)
+    .filter((a) => a.status === "suspended").length;
+}
+
+export function filterSuspended(groupedAccounts: GroupedAccounts): GroupedAccounts {
+  return groupedAccounts
+    .map((group) => ({
+      ...group,
+      accounts: group.accounts.filter((a) => a.status !== "suspended"),
+    }))
+    .filter((group) => group.accounts.length > 0);
+}
+
+export function AccountListClient({ groupedAccounts, groupId }: AccountListClientProps) {
+  const [showSuspended, setShowSuspended] = useState(false);
+
+  const suspendedCount = countSuspended(groupedAccounts);
+  const filteredGroups = showSuspended ? groupedAccounts : filterSuspended(groupedAccounts);
+
+  return (
+    <div className="space-y-6">
+      {suspendedCount > 0 && (
+        <div className="flex items-center gap-2">
+          <Switch
+            id="show-suspended"
+            checked={showSuspended}
+            onCheckedChange={setShowSuspended}
+            aria-label="停止中のアカウントを表示する"
+          />
+          <label
+            htmlFor="show-suspended"
+            className="text-sm text-muted-foreground cursor-pointer"
+          >
+            停止中を表示する（{suspendedCount}件）
+          </label>
+        </div>
+      )}
+
+      {filteredGroups.length === 0 ? (
+        <div className="text-center py-12 text-muted-foreground">連携サービスがありません。</div>
+      ) : (
+        <div className="space-y-8">
+          {filteredGroups.map((group) => (
+            <div key={group.categoryName} className="space-y-3">
+              <h2 className="text-lg font-semibold text-foreground border-b pb-2">
+                {group.categoryName}
+              </h2>
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {group.accounts.map((account) => (
+                  <AccountCard
+                    key={account.id}
+                    mfId={account.mfId}
+                    name={account.name}
+                    type={account.type}
+                    status={account.status}
+                    lastUpdated={account.lastUpdated}
+                    totalAssets={account.totalAssets}
+                    groupId={groupId}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/accounts/account-list.client.tsx
+++ b/apps/web/src/app/accounts/account-list.client.tsx
@@ -39,7 +39,6 @@ export function AccountListClient({ groupedAccounts, groupId }: AccountListClien
             id="show-suspended"
             checked={showSuspended}
             onCheckedChange={setShowSuspended}
-            aria-label="停止中のアカウントを表示する"
           />
           <label htmlFor="show-suspended" className="text-sm text-muted-foreground cursor-pointer">
             停止中を表示する（{suspendedCount}件）
@@ -48,7 +47,11 @@ export function AccountListClient({ groupedAccounts, groupId }: AccountListClien
       )}
 
       {filteredGroups.length === 0 ? (
-        <div className="text-center py-12 text-muted-foreground">連携サービスがありません。</div>
+        <div className="text-center py-12 text-muted-foreground">
+          {suspendedCount > 0
+            ? "表示できるアカウントはありません。停止中を表示してください。"
+            : "連携サービスがありません。"}
+        </div>
       ) : (
         <div className="space-y-8">
           {filteredGroups.map((group) => (

--- a/apps/web/src/app/accounts/page.tsx
+++ b/apps/web/src/app/accounts/page.tsx
@@ -2,9 +2,9 @@ import { getAccountsGroupedByCategory } from "@mf-dashboard/db";
 import type { AccountStatusType } from "@mf-dashboard/db/types";
 import { mfUrls } from "@mf-dashboard/meta/urls";
 import type { Metadata } from "next";
-import { AccountCard } from "../../components/info/account-card";
 import { PageLayout } from "../../components/layout/page-layout";
 import { Badge } from "../../components/ui/badge";
+import { AccountListClient } from "./account-list.client";
 
 export const metadata: Metadata = {
   title: "連携サービス一覧",
@@ -38,46 +38,6 @@ function AccountStatusBadges({ groupedAccounts }: { groupedAccounts: GroupedAcco
   );
 }
 
-function AccountList({
-  groupedAccounts,
-  groupId,
-}: {
-  groupedAccounts: GroupedAccounts[];
-  groupId?: string;
-}) {
-  if (groupedAccounts.length === 0) {
-    return (
-      <div className="text-center py-12 text-muted-foreground">連携サービスがありません。</div>
-    );
-  }
-
-  return (
-    <div className="space-y-8">
-      {groupedAccounts.map((group) => (
-        <div key={group.categoryName} className="space-y-3">
-          <h2 className="text-lg font-semibold text-foreground border-b pb-2">
-            {group.categoryName}
-          </h2>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {group.accounts.map((account) => (
-              <AccountCard
-                key={account.id}
-                mfId={account.mfId}
-                name={account.name}
-                type={account.type}
-                status={account.status}
-                lastUpdated={account.lastUpdated}
-                totalAssets={account.totalAssets}
-                groupId={groupId}
-              />
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
 export async function AccountsContent({ groupId }: { groupId?: string }) {
   const groupedAccounts = await getAccountsGroupedByCategory(groupId);
 
@@ -87,7 +47,7 @@ export async function AccountsContent({ groupId }: { groupId?: string }) {
       href={mfUrls.accounts}
       options={<AccountStatusBadges groupedAccounts={groupedAccounts} />}
     >
-      <AccountList groupedAccounts={groupedAccounts} groupId={groupId} />
+      <AccountListClient groupedAccounts={groupedAccounts} groupId={groupId} />
     </PageLayout>
   );
 }


### PR DESCRIPTION
## やりたいこと

/accounts ページで [停止中] のアカウントをデフォルト非表示にできるようにします。

## やったこと

AccountList を Client Component として分離し、停止中アカウントをデフォルトで除外するフィルタリングとトグル UI を追加しました。停止中アカウントが1件以上ある場合のみ「停止中を表示する（N件）」スイッチが表示されます。

## レビューしてほしいこと

- AccountListClient への分離方針（TransactionTableClient と同様のパターン）が適切か
- トグルの配置（一覧上部）と UX が妥当か

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to toggle display of suspended accounts in the account list
  * Empty state messaging when no accounts are visible after filtering

* **Refactor**
  * Reorganized account list rendering into a dedicated component for improved code separation

* **Tests**
  * Added comprehensive test coverage for account filtering and suspended account counting logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->