### PR TITLE
fix(ci): Playwright install-deps を必要なブラウザのみに絞る

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,5 +1,10 @@
 name: Setup Node
 description: Setup pnpm and Node.js with dependencies
+inputs:
+  playwright-browsers:
+    description: "Space-separated list of Playwright browsers to install (e.g. chromium webkit)"
+    default: "chromium webkit"
+    required: false
 runs:
   using: composite
   steps:
@@ -14,17 +19,21 @@ runs:
       id: playwright-version
       run: echo "version=$(pnpm list @playwright/test playwright --json --recursive | jq -r '[.[] | (.devDependencies["@playwright/test"].version, .dependencies["@playwright/test"].version, .devDependencies["playwright"].version, .dependencies["playwright"].version)] | map(select(. != null)) | first')" >> $GITHUB_OUTPUT
       shell: bash
+    - name: Set Playwright cache key
+      id: playwright-cache-key
+      run: echo "value=playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-$(echo '${{ inputs.playwright-browsers }}' | tr ' ' '-')" >> $GITHUB_OUTPUT
+      shell: bash
     - name: Cache Playwright browsers
       id: playwright-cache
       uses: actions/cache@v5
       with:
         path: ~/.cache/ms-playwright
-        key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+        key: ${{ steps.playwright-cache-key.outputs.value }}
     - name: Install Playwright browsers
       if: steps.playwright-cache.outputs.cache-hit != 'true'
-      run: pnpm dlx playwright@${{ steps.playwright-version.outputs.version }} install --with-deps
+      run: pnpm dlx playwright@${{ steps.playwright-version.outputs.version }} install --with-deps ${{ inputs.playwright-browsers }}
       shell: bash
     - name: Install Playwright system dependencies
       if: steps.playwright-cache.outputs.cache-hit == 'true'
-      run: pnpm dlx playwright@${{ steps.playwright-version.outputs.version }} install-deps
+      run: pnpm dlx playwright@${{ steps.playwright-version.outputs.version }} install-deps ${{ inputs.playwright-browsers }}
       shell: bash

--- a/.github/workflows/daily-update.yml
+++ b/.github/workflows/daily-update.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-node
+        with:
+          playwright-browsers: chromium
       - uses: ./.github/actions/auth-state-cache
         with:
           mode: restore

--- a/.github/workflows/e2e-crawler.yml
+++ b/.github/workflows/e2e-crawler.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-node
+        with:
+          playwright-browsers: chromium
       - uses: ./.github/actions/auth-state-cache
         with:
           mode: restore


### PR DESCRIPTION
## やりたいこと

`playwright install-deps` が常に全ブラウザ（Chromium・Firefox・WebKit）のOS依存パッケージをインストールするため、Firefox 向けのパッケージのダウンロードが Azure Ubuntu ミラーの速度低下と重なって 25 分タイムアウトを引き起こしていました。
ワークフローごとに必要なブラウザだけをインストールできるようにします。

```
# Firefox専用の依存ライブラリの libflite1 の DL 時間が 8min 以上かかっている
Tue, 12 May 2026 21:14:58 GMT
Get:61 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libflite1 amd64 2.2-6build3 [13.6 MB]
Tue, 12 May 2026 21:23:29 GMT
Get:62 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libserd-0-0 amd64 0.32.2-1 [43.6 kB]
```

## やったこと

- `playwright-browsers` input を追加し、インストール対象ブラウザを呼び出し側から指定
  - デフォルトは `chromium webkit`（Web E2E の mobile-safari に対応）
- Chromium のみ使用する `daily-update` と `e2e-crawler` のワークフローでは `chromium` を指定
  - Firefox 依存パッケージ（libflite1・GStreamer・各種コーデック群）のインストールを省略


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Parameterized Playwright browser configuration in GitHub Actions workflows, enabling selective and optimized browser installation
  * Enhanced caching strategy that segregates cache based on selected browser sets, improving overall CI/CD performance
  * Applied configuration changes across automated testing workflows for consistent behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiroppy/mf-dashboard/pull/131)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->