### PR TITLE
fix(crawler): use exact text '一括更新' for refresh button selector

### DIFF
--- a/apps/crawler/src/scrapers/refresh.ts
+++ b/apps/crawler/src/scrapers/refresh.ts
@@ -66,7 +66,7 @@ export async function clickRefreshButton(page: Page): Promise<RefreshResult> {
   await page.goto(mfUrls.home);
   await page.waitForLoadState("networkidle");
 
-  const refreshButton = page.locator('a:has-text("更新")').first();
+  const refreshButton = page.locator('a:has-text("一括更新")').first();
   await refreshButton.click();
 
   info("Refreshing accounts...");


### PR DESCRIPTION
## やりたいこと / 背景

スクレイピングの定期実行で、更新ボタンのロケータ `a:has-text("更新")` がお知らせ記事に誤マッチして click がタイムアウトする問題を修正します。

## やったこと

更新ボタンのセレクタを「一括更新」という固有テキストで一致させるよう変更しました。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where the account refresh functionality was not targeting the correct button, preventing bulk updates from completing as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hiroppy/mf-dashboard/pull/132)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->