### PR TITLE
fix: align rate withdrawal basis

### DIFF
--- a/apps/web/src/components/charts/compound-simulator/calculate-compound.test.ts
+++ b/apps/web/src/components/charts/compound-simulator/calculate-compound.test.ts
@@ -912,6 +912,45 @@ describe("calculateCompound", () => {
         expect(w.yearlyWithdrawal).toBe(firstYrWithdrawal);
       }
     });
+
+    it("should base first rate withdrawal on withdrawal-start assets before monthly growth", () => {
+      const annualWithdrawalRate = 4;
+      const withdrawalStartYear = 5;
+      const result = calculateCompound({
+        initialAmount: 10_000_000,
+        monthlyContribution: 0,
+        annualReturnRate: 12,
+        contributionYears: 0,
+        withdrawalStartYear,
+        annualWithdrawalRate,
+        withdrawalYears: 1,
+        taxFree: true,
+      });
+
+      const withdrawalStart = result.find((p) => p.year === withdrawalStartYear)!;
+      const firstWithdrawalYear = result.find((p) => p.year === withdrawalStartYear + 1)!;
+
+      expect(firstWithdrawalYear.yearlyWithdrawal).toBe(
+        Math.round((withdrawalStart.total * annualWithdrawalRate) / 100),
+      );
+    });
+
+    it("should not reseed rate withdrawal when withdrawal-start assets are zero", () => {
+      const result = calculateCompound({
+        initialAmount: 0,
+        monthlyContribution: 100_000,
+        annualReturnRate: 0,
+        contributionYears: 2,
+        withdrawalStartYear: 0,
+        annualWithdrawalRate: 4,
+        withdrawalYears: 2,
+        taxFree: true,
+      });
+
+      const withdrawals = result.filter((p) => p.isWithdrawing);
+      expect(withdrawals.map((p) => p.yearlyWithdrawal)).toEqual([0, 0]);
+      expect(result[2].total).toBe(2_400_000);
+    });
   });
 
   describe("overlap with rate mode", () => {

--- a/apps/web/src/components/charts/compound-simulator/calculate-compound.ts
+++ b/apps/web/src/components/charts/compound-simulator/calculate-compound.ts
@@ -60,6 +60,7 @@ export function calculateCompound({
   let currentMonthlyWithdrawal = monthlyWithdrawal;
   let rateBasedMonthlyWithdrawal = 0;
   let rateFirstWithdrawalYear = -1;
+  let rateBasedWithdrawalSeeded = false;
 
   for (let year = 0; year <= totalYears; year++) {
     const isContributing = year > 0 && year <= contributionYears;
@@ -82,6 +83,16 @@ export function calculateCompound({
 
     let yearlyWithdrawalTotal = 0;
 
+    if (isWithdrawing && isRateMode) {
+      if (!rateBasedWithdrawalSeeded) {
+        rateBasedMonthlyWithdrawal = (currentTotal * (annualWithdrawalRate ?? 0)) / 100 / 12;
+        rateFirstWithdrawalYear = year;
+        rateBasedWithdrawalSeeded = true;
+      } else if (year > rateFirstWithdrawalYear) {
+        rateBasedMonthlyWithdrawal *= 1 + ri;
+      }
+    }
+
     for (let month = 0; month < 12; month++) {
       currentTotal *= 1 + monthlyRate;
 
@@ -93,12 +104,6 @@ export function calculateCompound({
       if (isWithdrawing && currentTotal > 0) {
         let baseWithdrawal: number;
         if (isRateMode) {
-          if (rateBasedMonthlyWithdrawal === 0) {
-            rateBasedMonthlyWithdrawal = (currentTotal * annualWithdrawalRate) / 100 / 12;
-            rateFirstWithdrawalYear = year;
-          } else if (month === 0 && year > rateFirstWithdrawalYear) {
-            rateBasedMonthlyWithdrawal *= 1 + ri;
-          }
           baseWithdrawal = rateBasedMonthlyWithdrawal;
         } else {
           baseWithdrawal = currentMonthlyWithdrawal;

--- a/apps/web/src/components/charts/compound-simulator/compound-simulator-utils.test.ts
+++ b/apps/web/src/components/charts/compound-simulator/compound-simulator-utils.test.ts
@@ -6,6 +6,7 @@ import {
   getTimelinePattern,
   computeSummaryYear,
   computeMonthlyWithdrawalForSummary,
+  computeRateWithdrawalBasis,
   computeMcDrawdownEndValue,
   computeTotalWithdrawalAmount,
   buildFanChartData,
@@ -153,6 +154,38 @@ describe("computeMonthlyWithdrawalForSummary", () => {
   test("rate mode: returns 0 when projection not found", () => {
     const result = computeMonthlyWithdrawalForSummary("rate", projections, 99, 0);
     expect(result).toBe(0);
+  });
+});
+
+describe("computeRateWithdrawalBasis", () => {
+  test("uses gross portfolio value so taxable rate-mode display matches calculation basis", () => {
+    const projection: YearlyProjection = {
+      year: 5,
+      principal: 10_000_000,
+      interest: 6_074_720,
+      tax: 1_548_697,
+      total: 16_074_720,
+      yearlyWithdrawal: 0,
+      isContributing: false,
+      isWithdrawing: false,
+    };
+
+    expect(computeRateWithdrawalBasis(projection)).toBe(17_623_417);
+  });
+
+  test("matches total for tax-free projections", () => {
+    const projection: YearlyProjection = {
+      year: 5,
+      principal: 10_000_000,
+      interest: 7_623_417,
+      tax: 0,
+      total: 17_623_417,
+      yearlyWithdrawal: 0,
+      isContributing: false,
+      isWithdrawing: false,
+    };
+
+    expect(computeRateWithdrawalBasis(projection)).toBe(projection.total);
   });
 });
 

--- a/apps/web/src/components/charts/compound-simulator/compound-simulator-utils.ts
+++ b/apps/web/src/components/charts/compound-simulator/compound-simulator-utils.ts
@@ -60,6 +60,11 @@ export function computeMonthlyWithdrawalForSummary(
   return fixedAmount;
 }
 
+export function computeRateWithdrawalBasis(projection: YearlyProjection | undefined): number {
+  if (!projection) return 0;
+  return projection.principal + projection.interest + projection.tax;
+}
+
 export function computeMcDrawdownEndValue(
   withdrawalYears: number,
   yearlyData: MonteCarloYearData[],

--- a/apps/web/src/components/charts/compound-simulator/compound-simulator.tsx
+++ b/apps/web/src/components/charts/compound-simulator/compound-simulator.tsx
@@ -34,6 +34,7 @@ import {
   computeTotalYears,
   computeWithdrawalMilestones,
   computeSecurityScore,
+  computeRateWithdrawalBasis,
 } from "./compound-simulator-utils";
 import { generateSummary } from "./generate-summary";
 import { adjustedPension } from "./pension-utils";
@@ -531,6 +532,9 @@ export function CompoundSimulator({
     withdrawalStartYear,
     fixedMonthlyWithdrawal,
   );
+  const rateWithdrawalBasis = computeRateWithdrawalBasis(contributionEnd);
+  const initialAnnualWithdrawal = Math.round((rateWithdrawalBasis * withdrawalRate) / 100);
+  const initialMonthlyWithdrawal = Math.round((rateWithdrawalBasis * withdrawalRate) / 100 / 12);
 
   const withdrawalMilestones =
     withdrawalMode === "rate"
@@ -919,24 +923,15 @@ export function CompoundSimulator({
                   <p className="text-xs text-muted-foreground">
                     初年度年額{" "}
                     <span className="font-semibold">
-                      約
-                      {formatCurrency(
-                        Math.round(((contributionEnd?.total ?? 0) * withdrawalRate) / 100),
-                      )}
+                      約{formatCurrency(initialAnnualWithdrawal)}
                     </span>
-                    （
-                    {formatCurrency(
-                      Math.round(((contributionEnd?.total ?? 0) * withdrawalRate) / 100 / 12),
-                    )}
-                    /月）
+                    （{formatCurrency(initialMonthlyWithdrawal)}/月）
                   </p>
                   {currentAge != null && (adjustedMonthlyPension > 0 || monthlyOtherIncome > 0) && (
                     <p className="text-xs text-muted-foreground">
                       取崩し {formatCurrency(monthlyWithdrawalForSummary)}/月 ={" "}
-                      {formatCurrency(
-                        Math.round(((contributionEnd?.total ?? 0) * withdrawalRate) / 100 / 12),
-                      )}{" "}
-                      - 年金{formatCurrency(adjustedMonthlyPension)}
+                      {formatCurrency(initialMonthlyWithdrawal)} - 年金
+                      {formatCurrency(adjustedMonthlyPension)}
                       {monthlyOtherIncome > 0 && <> - その他{formatCurrency(monthlyOtherIncome)}</>}
                     </p>
                   )}

--- a/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.test.ts
+++ b/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.test.ts
@@ -498,6 +498,51 @@ describe("simulateMonteCarlo", () => {
       }
     });
 
+    it("should base first rate withdrawal on withdrawal-start median before monthly growth", () => {
+      const annualWithdrawalRate = 4;
+      const withdrawalStartYear = 5;
+      const result = simulateMonteCarlo({
+        initialAmount: 10_000_000,
+        monthlyContribution: 0,
+        annualReturnRate: 12,
+        volatility: 0,
+        inflationRate: 0,
+        contributionYears: 0,
+        withdrawalStartYear,
+        annualWithdrawalRate,
+        withdrawalYears: 1,
+        taxFree: true,
+      });
+
+      const withdrawalStart = result.yearlyData.find((d) => d.year === withdrawalStartYear)!;
+      const firstWithdrawalYear = result.yearlyData.find(
+        (d) => d.year === withdrawalStartYear + 1,
+      )!;
+
+      expect(firstWithdrawalYear.medianYearlyWithdrawal).toBe(
+        Math.round((withdrawalStart.p50 * annualWithdrawalRate) / 100),
+      );
+    });
+
+    it("should not reseed rate withdrawal when withdrawal-start median is zero", () => {
+      const result = simulateMonteCarlo({
+        initialAmount: 0,
+        monthlyContribution: 100_000,
+        annualReturnRate: 0,
+        volatility: 0,
+        inflationRate: 0,
+        contributionYears: 2,
+        withdrawalStartYear: 0,
+        annualWithdrawalRate: 4,
+        withdrawalYears: 2,
+        taxFree: true,
+      });
+
+      const withdrawals = result.yearlyData.filter((d) => d.isWithdrawing);
+      expect(withdrawals.map((d) => d.medianYearlyWithdrawal)).toEqual([0, 0]);
+      expect(result.yearlyData[2].p50).toBe(2_400_000);
+    });
+
     it("should keep withdrawal constant in real terms with positive inflation (trinity study)", () => {
       // Trinity Study: withdrawal is inflation-adjusted (nominal increases with inflation).
       // In the MC simulation (which works in real terms), this means the withdrawal

--- a/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.ts
+++ b/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.ts
@@ -124,10 +124,12 @@ export function simulateMonteCarlo({
   const extraPaths: Float64Array[] = [];
   const extraCostBasis: Float64Array[] = [];
   const extraInitialWithdrawal: (Float64Array | null)[] = [];
+  const extraInitialWithdrawalSeeded: (Uint8Array | null)[] = [];
   for (let d = 0; d < numExtra; d++) {
     extraPaths.push(new Float64Array(NUM_SIMULATIONS).fill(initialAmount));
     extraCostBasis.push(new Float64Array(NUM_SIMULATIONS).fill(initialAmount));
     extraInitialWithdrawal.push(isRateMode ? new Float64Array(NUM_SIMULATIONS) : null);
+    extraInitialWithdrawalSeeded.push(isRateMode ? new Uint8Array(NUM_SIMULATIONS) : null);
   }
 
   // Sensitivity analysis: rate variants (for rate mode)
@@ -139,10 +141,12 @@ export function simulateMonteCarlo({
   const ratePaths: Float64Array[] = [];
   const rateCostBasis: Float64Array[] = [];
   const rateInitialW: Float64Array[] = [];
+  const rateInitialWSeeded: Uint8Array[] = [];
   for (let d = 0; d < numRateExtra; d++) {
     ratePaths.push(new Float64Array(NUM_SIMULATIONS).fill(initialAmount));
     rateCostBasis.push(new Float64Array(NUM_SIMULATIONS).fill(initialAmount));
     rateInitialW.push(new Float64Array(NUM_SIMULATIONS));
+    rateInitialWSeeded.push(new Uint8Array(NUM_SIMULATIONS));
   }
 
   const paths = new Float64Array(NUM_SIMULATIONS).fill(initialAmount);
@@ -172,6 +176,7 @@ export function simulateMonteCarlo({
   // MC portfolio values are in real terms (drift subtracts inflation).
   // Rate mode: constant real withdrawal (Trinity Study inflation-adjusted).
   const initialWithdrawalAmount = isRateMode ? new Float64Array(NUM_SIMULATIONS) : null;
+  const initialWithdrawalSeeded = isRateMode ? new Uint8Array(NUM_SIMULATIONS) : null;
   // Track cumulative net withdrawals per path for total-return failure metric
   const cumulativeWithdrawals = new Float64Array(NUM_SIMULATIONS);
   // Deflate nominal withdrawal by inflation accumulated before withdrawal starts.
@@ -189,6 +194,41 @@ export function simulateMonteCarlo({
       year > withdrawalStartYear && year <= withdrawalStartYear + withdrawalYears;
 
     if (yearlyWithdrawals) yearlyWithdrawals.fill(0);
+
+    if (isWithdrawing && isRateMode) {
+      if (initialWithdrawalAmount && initialWithdrawalSeeded) {
+        for (let i = 0; i < NUM_SIMULATIONS; i++) {
+          if (initialWithdrawalSeeded[i] === 0) {
+            initialWithdrawalAmount[i] = (paths[i] * (annualWithdrawalRate ?? 0)) / 100 / 12;
+            initialWithdrawalSeeded[i] = 1;
+          }
+        }
+      }
+
+      for (let d = 0; d < numExtra; d++) {
+        const ewa = extraInitialWithdrawal[d];
+        const ewaSeeded = extraInitialWithdrawalSeeded[d];
+        if (ewa && ewaSeeded) {
+          for (let i = 0; i < NUM_SIMULATIONS; i++) {
+            if (ewaSeeded[i] === 0) {
+              ewa[i] = (extraPaths[d][i] * (annualWithdrawalRate ?? 0)) / 100 / 12;
+              ewaSeeded[i] = 1;
+            }
+          }
+        }
+      }
+
+      for (let d = 0; d < numRateExtra; d++) {
+        const adjRate = annualWithdrawalRate! + validRateDeltas[d];
+        const rwaSeeded = rateInitialWSeeded[d];
+        for (let i = 0; i < NUM_SIMULATIONS; i++) {
+          if (rwaSeeded[i] === 0) {
+            rateInitialW[d][i] = (ratePaths[d][i] * adjRate) / 100 / 12;
+            rwaSeeded[i] = 1;
+          }
+        }
+      }
+    }
 
     for (let month = 0; month < 12; month++) {
       if (isWithdrawing && !isRateMode) {
@@ -208,9 +248,6 @@ export function simulateMonteCarlo({
         if (isWithdrawing && paths[i] > 0) {
           let baseWithdrawal: number;
           if (isRateMode && initialWithdrawalAmount) {
-            if (initialWithdrawalAmount[i] === 0) {
-              initialWithdrawalAmount[i] = (paths[i] * annualWithdrawalRate) / 100 / 12;
-            }
             baseWithdrawal = initialWithdrawalAmount[i];
           } else {
             baseWithdrawal = currentMonthlyWithdrawal;
@@ -240,7 +277,6 @@ export function simulateMonteCarlo({
             let baseW: number;
             const ewa = extraInitialWithdrawal[d];
             if (isRateMode && ewa) {
-              if (ewa[i] === 0) ewa[i] = (extraPaths[d][i] * annualWithdrawalRate!) / 100 / 12;
               baseW = ewa[i];
             } else {
               baseW = currentMonthlyWithdrawal;
@@ -269,9 +305,7 @@ export function simulateMonteCarlo({
             rateCostBasis[d][i] += monthlyContribution;
           }
           if (isWithdrawing && ratePaths[d][i] > 0) {
-            const adjRate = annualWithdrawalRate! + validRateDeltas[d];
             const rwa = rateInitialW[d];
-            if (rwa[i] === 0) rwa[i] = (ratePaths[d][i] * adjRate) / 100 / 12;
             const baseW = rwa[i];
             const pensionActiveR = pensionStartYear != null && year >= pensionStartYear;
             const incomeR = (pensionActiveR ? monthlyPensionIncome : 0) + monthlyOtherIncome;


### PR DESCRIPTION
## Summary

- Fixes `%指定` withdrawal initialization so the first-year withdrawal is based on assets at the withdrawal start boundary, before the first monthly return is applied.
- Aligns deterministic, Monte Carlo, and visible initial-withdrawal estimates to the same rate-withdrawal basis.
- Adds regression coverage for deterministic calculation, Monte Carlo zero-volatility behavior, and taxable display basis.

## Root Cause

Rate-based withdrawal amounts were initialized inside the monthly simulation loop. That made the initial withdrawal amount use the balance after one month of growth instead of the documented `withdrawal-start assets × withdrawal rate` basis.

A related UI estimate used taxable `total` after subtracting displayed tax, while the calculation uses the gross portfolio basis for the configured take-home withdrawal rate. The display now uses `principal + after-tax interest + tax` so it matches the calculation basis.

Linear: HIR-57

## Validation

- `pnpm --filter @mf-dashboard/web test:unit`
- `pnpm turbo typecheck`
- `git diff --check`
- Playwright rendered check on `http://localhost:3001` with desktop `1280x900` and mobile `390x844`; confirmed `%指定` shows `初年度年額 約704,937円（58,745円/月）` for the reproduced scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rate-based withdrawal now applies inflation annually (year-level) instead of monthly for more accurate projections in percentage-based withdrawal mode.

* **New Features**
  * Withdrawal basis calculation updated so displayed initial-year and monthly withdrawal amounts reflect the corrected rate-based basis.

* **Tests**
  * Added/expanded tests covering rate-based withdrawal logic in the compound simulator and Monte Carlo simulations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->