### PR TITLE
[codex] Add root format:check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "typecheck": "turbo typecheck",
     "lint": "oxlint --type-aware --fix",
     "format": "oxfmt",
+    "format:check": "oxfmt --check .",
     "knip": "knip"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- add the missing root `format:check` script
- keep it aligned with the documented `pnpm exec oxfmt --check .` validation path

## Root Cause

The repository documentation references `pnpm format:check`, but the root `package.json` only exposed `format`, so pnpm could not resolve the script.

## Validation

- `pnpm format:check`

Linear: HIR-61