### PR TITLE
fix: handle split liquid asset categories

### DIFF
--- a/apps/crawler/src/scrapers/asset-history.ts
+++ b/apps/crawler/src/scrapers/asset-history.ts
@@ -17,7 +17,7 @@ export async function getAssetHistory(page: Page): Promise<AssetHistory> {
 
   // ヘッダーからカテゴリ名を動的取得
   const headers = await page.locator("table.table-bordered thead th").allTextContents();
-  // headers: ["日付", "合計", "預金・現金・暗号資産", "株式(現物)", ..., "詳細"]
+  // headers: ["日付", "合計", "預金・現金", "暗号資産", "株式(現物)", ..., "詳細"]
   const categoryNames = headers.slice(2, -1).map((h) => h.trim()); // 日付と合計と詳細を除外
 
   const rows = page.locator("table.table-bordered tbody tr");

--- a/apps/crawler/src/scrapers/portfolio.test.ts
+++ b/apps/crawler/src/scrapers/portfolio.test.ts
@@ -18,6 +18,12 @@ describe("identifyTableTypeFromTitle", () => {
     expect(identifyTableTypeFromTitle("預金・現金・暗号資産")).toBe("預金・現金・暗号資産");
   });
 
+  test("現在の分離済み流動資産カテゴリはそのまま返す", () => {
+    expect(identifyTableTypeFromTitle("預金・現金")).toBe("預金・現金");
+    expect(identifyTableTypeFromTitle("暗号資産")).toBe("暗号資産");
+    expect(identifyTableTypeFromTitle("電子マネー・プリペイド")).toBe("電子マネー・プリペイド");
+  });
+
   test("「株式(現物)」はそのまま返す", () => {
     expect(identifyTableTypeFromTitle("株式(現物)")).toBe("株式(現物)");
   });
@@ -29,7 +35,6 @@ describe("identifyTableTypeFromTitle", () => {
   test("不明なタイトルは「不明」を返す", () => {
     expect(identifyTableTypeFromTitle("")).toBe("不明");
     expect(identifyTableTypeFromTitle("不明なカテゴリ")).toBe("不明");
-    expect(identifyTableTypeFromTitle("ポイント")).toBe("不明"); // "ポイント・マイル"ではない
   });
 });
 

--- a/apps/crawler/src/scrapers/portfolio.test.ts
+++ b/apps/crawler/src/scrapers/portfolio.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect } from "vitest";
-import { identifyTableTypeFromTitle, parseOptionalJapaneseNumber } from "./portfolio.js";
+import {
+  identifyTableTypeFromTitle,
+  isPointCategory,
+  parseOptionalJapaneseNumber,
+  parsePnsPortfolioItem,
+} from "./portfolio.js";
 
 describe("identifyTableTypeFromTitle", () => {
   test("「ポイント・マイル」はそのまま返す", () => {
@@ -22,6 +27,7 @@ describe("identifyTableTypeFromTitle", () => {
     expect(identifyTableTypeFromTitle("預金・現金")).toBe("預金・現金");
     expect(identifyTableTypeFromTitle("暗号資産")).toBe("暗号資産");
     expect(identifyTableTypeFromTitle("電子マネー・プリペイド")).toBe("電子マネー・プリペイド");
+    expect(identifyTableTypeFromTitle("ポイント")).toBe("ポイント");
   });
 
   test("「株式(現物)」はそのまま返す", () => {
@@ -35,6 +41,76 @@ describe("identifyTableTypeFromTitle", () => {
   test("不明なタイトルは「不明」を返す", () => {
     expect(identifyTableTypeFromTitle("")).toBe("不明");
     expect(identifyTableTypeFromTitle("不明なカテゴリ")).toBe("不明");
+  });
+});
+
+describe("isPointCategory", () => {
+  test("現在とlegacyのポイントカテゴリを判定する", () => {
+    expect(isPointCategory("ポイント")).toBe(true);
+    expect(isPointCategory("ポイント・マイル")).toBe(true);
+    expect(isPointCategory("年金")).toBe(false);
+  });
+});
+
+describe("parsePnsPortfolioItem", () => {
+  test("現在の「ポイント」カテゴリはポイント用カラムでパースする", () => {
+    const item = parsePnsPortfolioItem("ポイント", [
+      "Point Service A",
+      "not used",
+      "999",
+      "not used",
+      "1,234",
+      "not used",
+      "Institution A",
+    ]);
+
+    expect(item).toEqual({
+      name: "Point Service A",
+      type: "ポイント",
+      institution: "Institution A",
+      balance: 1234,
+    });
+  });
+
+  test("legacyの「ポイント・マイル」カテゴリもポイント用カラムでパースする", () => {
+    const item = parsePnsPortfolioItem("ポイント・マイル", [
+      "Point Service B",
+      "not used",
+      "999",
+      "not used",
+      "2,345",
+      "not used",
+      "Institution B",
+    ]);
+
+    expect(item).toEqual({
+      name: "Point Service B",
+      type: "ポイント・マイル",
+      institution: "Institution B",
+      balance: 2345,
+    });
+  });
+
+  test("保険カテゴリは保険・年金用カラムでパースする", () => {
+    const item = parsePnsPortfolioItem("保険", [
+      "Insurance A",
+      "1,000",
+      "3,000",
+      "200",
+      "10%",
+      "not used",
+      "not used",
+    ]);
+
+    expect(item).toEqual({
+      name: "Insurance A",
+      type: "保険",
+      institution: "",
+      balance: 3000,
+      avgCostPrice: 1000,
+      unrealizedGain: 200,
+      unrealizedGainPct: 10,
+    });
   });
 });
 

--- a/apps/crawler/src/scrapers/portfolio.test.ts
+++ b/apps/crawler/src/scrapers/portfolio.test.ts
@@ -2,8 +2,10 @@ import { describe, test, expect } from "vitest";
 import {
   identifyTableTypeFromTitle,
   isPointCategory,
+  parseDepositPortfolioItem,
   parseOptionalJapaneseNumber,
   parsePnsPortfolioItem,
+  resolveDepositTableCategory,
 } from "./portfolio.js";
 
 describe("identifyTableTypeFromTitle", () => {
@@ -41,6 +43,37 @@ describe("identifyTableTypeFromTitle", () => {
   test("不明なタイトルは「不明」を返す", () => {
     expect(identifyTableTypeFromTitle("")).toBe("不明");
     expect(identifyTableTypeFromTitle("不明なカテゴリ")).toBe("不明");
+  });
+});
+
+describe("resolveDepositTableCategory", () => {
+  test("現在の分離済み流動資産カテゴリを返す", () => {
+    expect(resolveDepositTableCategory("預金・現金")).toBe("預金・現金");
+    expect(resolveDepositTableCategory("暗号資産")).toBe("暗号資産");
+    expect(resolveDepositTableCategory("電子マネー・プリペイド")).toBe("電子マネー・プリペイド");
+  });
+
+  test("legacyカテゴリと未知のタイトルはlegacy預金カテゴリとして扱う", () => {
+    expect(resolveDepositTableCategory("預金・現金・暗号資産")).toBe("預金・現金・暗号資産");
+    expect(resolveDepositTableCategory("")).toBe("預金・現金・暗号資産");
+    expect(resolveDepositTableCategory("その他")).toBe("預金・現金・暗号資産");
+  });
+});
+
+describe("parseDepositPortfolioItem", () => {
+  test("section title由来のsplitカテゴリを保持する", () => {
+    const item = parseDepositPortfolioItem("暗号資産", "Crypto Asset A", "Institution A", "1,234");
+
+    expect(item).toEqual({
+      name: "Crypto Asset A",
+      type: "暗号資産",
+      institution: "Institution A",
+      balance: 1234,
+    });
+  });
+
+  test("名前が空の行は無視する", () => {
+    expect(parseDepositPortfolioItem("預金・現金", " ", "Institution A", "1,234")).toBeNull();
   });
 });
 

--- a/apps/crawler/src/scrapers/portfolio.ts
+++ b/apps/crawler/src/scrapers/portfolio.ts
@@ -5,8 +5,7 @@ import type { Locator, Page } from "playwright";
 import { debug } from "../logger.js";
 import { parseDecimalNumber, parseJapaneseNumber, parsePercentage } from "../parsers.js";
 
-// Asset category constant for points (used for category check in parsing)
-const POINT = "ポイント・マイル";
+const POINT_CATEGORIES = new Set(["ポイント・マイル", "ポイント"]);
 const UNKNOWN_CATEGORY = "不明";
 
 // Column indices for each table type
@@ -109,6 +108,43 @@ export function parseOptionalJapaneseNumber(text: string): number | undefined {
     return undefined;
   }
   return parseJapaneseNumber(trimmed);
+}
+
+export function isPointCategory(category: string): boolean {
+  return POINT_CATEGORIES.has(category);
+}
+
+export function parsePnsPortfolioItem(
+  category: string,
+  cellTexts: readonly string[],
+): PortfolioItem | null {
+  const name = cellTexts[0]?.trim() ?? "";
+  if (!name) return null;
+
+  if (isPointCategory(category)) {
+    return {
+      name,
+      type: category,
+      institution: cellTexts[POINT_COLUMNS.INSTITUTION]?.trim() ?? "",
+      balance: parseJapaneseNumber(cellTexts[POINT_COLUMNS.BALANCE] ?? "0"),
+    };
+  }
+
+  return {
+    name,
+    type: category,
+    institution: "",
+    balance: parseJapaneseNumber(cellTexts[INSURANCE_PENSION_COLUMNS.BALANCE] ?? "0"),
+    avgCostPrice: orUndefined(
+      parseJapaneseNumber(cellTexts[INSURANCE_PENSION_COLUMNS.AVG_COST] ?? ""),
+    ),
+    unrealizedGain: parseOptionalJapaneseNumber(
+      cellTexts[INSURANCE_PENSION_COLUMNS.UNREALIZED_GAIN] ?? "",
+    ),
+    unrealizedGainPct: parsePercentage(
+      cellTexts[INSURANCE_PENSION_COLUMNS.UNREALIZED_GAIN_PCT] ?? "",
+    ),
+  };
 }
 
 // Parse stocks from .table-eq
@@ -259,45 +295,12 @@ async function parseInsuranceAndPoints(page: Page): Promise<PortfolioItem[]> {
 
     for (let i = 0; i < rowCount; i++) {
       const cells = rows.nth(i).locator("td");
-
-      if (category === POINT) {
-        // 並列取得（ポイント）
-        const [name, institution, balanceText] = await Promise.all([
-          getCellText(cells, 0),
-          getCellText(cells, POINT_COLUMNS.INSTITUTION),
-          getCellText(cells, POINT_COLUMNS.BALANCE, "0"),
-        ]);
-        if (!name) continue;
-
-        items.push({
-          name,
-          type: category,
-          institution,
-          balance: parseJapaneseNumber(balanceText),
-        });
-      } else {
-        // 並列取得（保険・年金）
-        const [name, balanceText, avgCostText, unrealizedGainText, unrealizedGainPctText] =
-          await Promise.all([
-            getCellText(cells, 0),
-            getCellText(cells, INSURANCE_PENSION_COLUMNS.BALANCE, "0"),
-            getCellText(cells, INSURANCE_PENSION_COLUMNS.AVG_COST),
-            getCellText(cells, INSURANCE_PENSION_COLUMNS.UNREALIZED_GAIN),
-            getCellText(cells, INSURANCE_PENSION_COLUMNS.UNREALIZED_GAIN_PCT),
-          ]);
-        if (!name) continue;
-
-        // Insurance and Pension share the same 8-column structure
-        items.push({
-          name,
-          type: category,
-          institution: "",
-          balance: parseJapaneseNumber(balanceText),
-          avgCostPrice: orUndefined(parseJapaneseNumber(avgCostText)),
-          unrealizedGain: parseOptionalJapaneseNumber(unrealizedGainText),
-          unrealizedGainPct: parsePercentage(unrealizedGainPctText),
-        });
-      }
+      const cellCount = await cells.count();
+      const cellTexts = await Promise.all(
+        Array.from({ length: cellCount }, (_, index) => getCellText(cells, index)),
+      );
+      const item = parsePnsPortfolioItem(category, cellTexts);
+      if (item) items.push(item);
     }
   }
   return items;

--- a/apps/crawler/src/scrapers/portfolio.ts
+++ b/apps/crawler/src/scrapers/portfolio.ts
@@ -5,6 +5,13 @@ import type { Locator, Page } from "playwright";
 import { debug } from "../logger.js";
 import { parseDecimalNumber, parseJapaneseNumber, parsePercentage } from "../parsers.js";
 
+const LEGACY_DEPOSIT_CATEGORY = "預金・現金・暗号資産";
+const DEPOSIT_TABLE_CATEGORIES = new Set([
+  LEGACY_DEPOSIT_CATEGORY,
+  "預金・現金",
+  "暗号資産",
+  "電子マネー・プリペイド",
+]);
 const POINT_CATEGORIES = new Set(["ポイント・マイル", "ポイント"]);
 const UNKNOWN_CATEGORY = "不明";
 
@@ -71,28 +78,68 @@ async function getInstitutionFromCell(cells: Locator, index: number): Promise<st
   }
 }
 
+async function getPrecedingSectionTitle(table: Locator): Promise<string> {
+  return table.evaluate((el) => {
+    let prev = el.previousElementSibling;
+    while (prev) {
+      const h1 = prev.tagName === "H1" ? prev : prev.querySelector("h1.heading-normal");
+      if (h1) {
+        return h1.textContent?.trim() || "";
+      }
+      prev = prev.previousElementSibling;
+    }
+    return "";
+  });
+}
+
+export function resolveDepositTableCategory(titleText: string): string {
+  const category = titleText.trim();
+  return DEPOSIT_TABLE_CATEGORIES.has(category) ? category : LEGACY_DEPOSIT_CATEGORY;
+}
+
+export function parseDepositPortfolioItem(
+  category: string,
+  nameText: string,
+  institution: string,
+  balanceText: string,
+): PortfolioItem | null {
+  const name = nameText.trim();
+  if (!name) return null;
+
+  return {
+    name,
+    type: category,
+    institution,
+    balance: parseJapaneseNumber(balanceText),
+  };
+}
+
 // Parse deposits from .table-depo
 async function parseDeposits(page: Page): Promise<PortfolioItem[]> {
-  const rows = page.locator("table.table-depo tbody tr");
-  const count = await rows.count();
+  const tables = page.locator("table.table-depo");
+  const tableCount = await tables.count();
   const items: PortfolioItem[] = [];
 
-  for (let i = 0; i < count; i++) {
-    const cells = rows.nth(i).locator("td");
-    // 並列取得
-    const [name, institution, balanceText] = await Promise.all([
-      getCellText(cells, DEPOSIT_COLUMNS.NAME),
-      getInstitutionFromCell(cells, DEPOSIT_COLUMNS.INSTITUTION),
-      getCellText(cells, DEPOSIT_COLUMNS.BALANCE, "0"),
-    ]);
-    if (!name) continue;
+  for (let t = 0; t < tableCount; t++) {
+    const table = tables.nth(t);
+    const sectionTitle = await getPrecedingSectionTitle(table);
+    const category = resolveDepositTableCategory(sectionTitle);
+    debug(`  .table-depo[${t}] title: "${sectionTitle}" -> ${category}`);
 
-    items.push({
-      name,
-      type: "預金・現金・暗号資産",
-      institution,
-      balance: parseJapaneseNumber(balanceText),
-    });
+    const rows = table.locator("tbody tr");
+    const count = await rows.count();
+
+    for (let i = 0; i < count; i++) {
+      const cells = rows.nth(i).locator("td");
+      // 並列取得
+      const [name, institution, balanceText] = await Promise.all([
+        getCellText(cells, DEPOSIT_COLUMNS.NAME),
+        getInstitutionFromCell(cells, DEPOSIT_COLUMNS.INSTITUTION),
+        getCellText(cells, DEPOSIT_COLUMNS.BALANCE, "0"),
+      ]);
+      const item = parseDepositPortfolioItem(category, name, institution, balanceText);
+      if (item) items.push(item);
+    }
   }
   return items;
 }
@@ -272,21 +319,7 @@ async function parseInsuranceAndPoints(page: Page): Promise<PortfolioItem[]> {
   for (let t = 0; t < tableCount; t++) {
     const table = tables.nth(t);
 
-    // Get section title from preceding h1.heading-normal element
-    const sectionTitle = await table.evaluate((el) => {
-      // Look for h1.heading-normal in preceding siblings
-      let prev = el.previousElementSibling;
-      while (prev) {
-        // Check if this element or its children contain h1.heading-normal
-        const h1 = prev.tagName === "H1" ? prev : prev.querySelector("h1.heading-normal");
-        if (h1) {
-          return h1.textContent?.trim() || "";
-        }
-        prev = prev.previousElementSibling;
-      }
-      return "";
-    });
-
+    const sectionTitle = await getPrecedingSectionTitle(table);
     const category = identifyTableTypeFromTitle(sectionTitle);
     debug(`  .table-pns[${t}] title: "${sectionTitle}" -> ${category}`);
 

--- a/apps/crawler/src/scrapers/portfolio.ts
+++ b/apps/crawler/src/scrapers/portfolio.ts
@@ -6,7 +6,7 @@ import { debug } from "../logger.js";
 import { parseDecimalNumber, parseJapaneseNumber, parsePercentage } from "../parsers.js";
 
 // Asset category constant for points (used for category check in parsing)
-const POINT = ASSET_CATEGORIES[5]; // "ポイント・マイル"
+const POINT = "ポイント・マイル";
 const UNKNOWN_CATEGORY = "不明";
 
 // Column indices for each table type
@@ -219,7 +219,7 @@ async function parseFunds(page: Page): Promise<PortfolioItem[]> {
 // Get category from section title (h1.heading-normal before the table)
 // Returns the title if it's a valid asset category, otherwise returns "不明"
 export function identifyTableTypeFromTitle(titleText: string): string {
-  // ASSET_CATEGORIES: ["預金・現金・暗号資産", "株式(現物)", "投資信託", "保険", "年金", "ポイント・マイル"]
+  // ASSET_CATEGORIES includes both legacy combined labels and current split labels.
   const validCategories = new Set(ASSET_CATEGORIES);
   if (validCategories.has(titleText as (typeof ASSET_CATEGORIES)[number])) {
     return titleText;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -55,6 +55,8 @@
 
   /* === Asset category colors === */
   --color-asset-deposit: #0e7490; /* 本家: #2881d7 */
+  --color-asset-crypto: #7c3aed;
+  --color-asset-prepaid: #0f766e;
   --color-asset-stock: #dd3121; /* 本家: #df3727 */
   --color-asset-fund: #c45505; /* 本家: #fcad4c */
   --color-asset-insurance: #be185d; /* 本家: #ff689a */

--- a/apps/web/src/components/info/insights-savings-card.tsx
+++ b/apps/web/src/components/info/insights-savings-card.tsx
@@ -29,7 +29,7 @@ export function InsightsSavingsCard({ metrics, insights }: InsightsSavingsCardPr
           <div>
             <MetricLabel
               title="流動資産"
-              description="預金・現金・暗号資産、電子マネー・プリペイドなど、すぐに現金化できる資産の合計です。"
+              description="預金・現金、暗号資産、電子マネー・プリペイドなど、すぐに現金化できる資産の合計です。"
             />
             <div className="text-xl font-semibold">
               {formatCurrency(metrics.savings.liquidAssets)}

--- a/apps/web/src/lib/colors.test.ts
+++ b/apps/web/src/lib/colors.test.ts
@@ -23,6 +23,10 @@ describe("getCategoryColor", () => {
 describe("getAssetCategoryColor", () => {
   it("資産カテゴリの var() 参照を返す", () => {
     expect(getAssetCategoryColor("預金・現金・暗号資産")).toBe("var(--color-asset-deposit)");
+    expect(getAssetCategoryColor("預金・現金")).toBe("var(--color-asset-deposit)");
+    expect(getAssetCategoryColor("暗号資産")).toBe("var(--color-asset-crypto)");
+    expect(getAssetCategoryColor("電子マネー・プリペイド")).toBe("var(--color-asset-prepaid)");
+    expect(getAssetCategoryColor("ポイント")).toBe("var(--color-asset-point)");
   });
 });
 

--- a/apps/web/src/lib/colors.ts
+++ b/apps/web/src/lib/colors.ts
@@ -2,11 +2,15 @@ import type { CategoryName } from "@mf-dashboard/meta/categories";
 
 const CATEGORY_VAR_MAP: Record<CategoryName, string> = {
   "預金・現金・暗号資産": "--color-asset-deposit",
+  "預金・現金": "--color-asset-deposit",
+  暗号資産: "--color-asset-crypto",
+  "電子マネー・プリペイド": "--color-asset-prepaid",
   "株式(現物)": "--color-asset-stock",
   投資信託: "--color-asset-fund",
   保険: "--color-asset-insurance",
   年金: "--color-asset-pension",
   "ポイント・マイル": "--color-asset-point",
+  ポイント: "--color-asset-point",
   "現金・カード": "--color-cat-cash-card",
   住宅: "--color-cat-housing",
   "水道・光熱費": "--color-cat-utility",

--- a/packages/db/src/queries/analytics.test.ts
+++ b/packages/db/src/queries/analytics.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { AnalyticsMetrics } from "./analytics";
-import { calculateHealthScore, isLiquidAssetCategory } from "./analytics";
+import { calculateHealthScore, isInvestmentCategory, isLiquidAssetCategory } from "./analytics";
 
 type FullMetrics = Omit<AnalyticsMetrics, "healthScore">;
 
@@ -211,9 +211,27 @@ describe("isLiquidAssetCategory", () => {
     expect(isLiquidAssetCategory("預金・現金・暗号資産")).toBe(true);
   });
 
+  it("normalizes surrounding whitespace before matching", () => {
+    expect(isLiquidAssetCategory(" 預金・現金 ")).toBe(true);
+  });
+
   it("does not classify non-liquid asset categories as liquid", () => {
     expect(isLiquidAssetCategory("投資信託")).toBe(false);
     expect(isLiquidAssetCategory("株式(現物)")).toBe(false);
     expect(isLiquidAssetCategory("暗号資産・FX・貴金属")).toBe(false);
+  });
+});
+
+describe("isInvestmentCategory", () => {
+  it("matches investment categories", () => {
+    expect(isInvestmentCategory("投資信託")).toBe(true);
+    expect(isInvestmentCategory("株式(現物)")).toBe(true);
+    expect(isInvestmentCategory("暗号資産・FX・貴金属")).toBe(true);
+  });
+
+  it("does not classify split liquid asset categories as investment", () => {
+    expect(isInvestmentCategory("暗号資産")).toBe(false);
+    expect(isInvestmentCategory("預金・現金")).toBe(false);
+    expect(isInvestmentCategory("電子マネー・プリペイド")).toBe(false);
   });
 });

--- a/packages/db/src/queries/analytics.test.ts
+++ b/packages/db/src/queries/analytics.test.ts
@@ -234,4 +234,9 @@ describe("isInvestmentCategory", () => {
     expect(isInvestmentCategory("預金・現金")).toBe(false);
     expect(isInvestmentCategory("電子マネー・プリペイド")).toBe(false);
   });
+
+  it("does not classify empty or whitespace-only strings as investment", () => {
+    expect(isInvestmentCategory("")).toBe(false);
+    expect(isInvestmentCategory("   ")).toBe(false);
+  });
 });

--- a/packages/db/src/queries/analytics.test.ts
+++ b/packages/db/src/queries/analytics.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { AnalyticsMetrics } from "./analytics";
-import { calculateHealthScore } from "./analytics";
+import { calculateHealthScore, isLiquidAssetCategory } from "./analytics";
 
 type FullMetrics = Omit<AnalyticsMetrics, "healthScore">;
 
@@ -197,5 +197,23 @@ describe("calculateHealthScore", () => {
 
     expect(getGrowth(negGrowth)).toBeLessThan(getGrowth(zeroGrowth));
     expect(getGrowth(zeroGrowth)).toBe(Math.round(15 / 2));
+  });
+});
+
+describe("isLiquidAssetCategory", () => {
+  it("matches current Money Forward split liquid asset categories", () => {
+    expect(isLiquidAssetCategory("預金・現金")).toBe(true);
+    expect(isLiquidAssetCategory("暗号資産")).toBe(true);
+    expect(isLiquidAssetCategory("電子マネー・プリペイド")).toBe(true);
+  });
+
+  it("keeps compatibility with the legacy combined liquid asset category", () => {
+    expect(isLiquidAssetCategory("預金・現金・暗号資産")).toBe(true);
+  });
+
+  it("does not classify non-liquid asset categories as liquid", () => {
+    expect(isLiquidAssetCategory("投資信託")).toBe(false);
+    expect(isLiquidAssetCategory("株式(現物)")).toBe(false);
+    expect(isLiquidAssetCategory("暗号資産・FX・貴金属")).toBe(false);
   });
 });

--- a/packages/db/src/queries/analytics.ts
+++ b/packages/db/src/queries/analytics.ts
@@ -80,7 +80,18 @@ export interface AnalyticsReport {
 // 定数
 // ============================================================================
 
-const LIQUID_ASSET_CATEGORIES = ["預金・現金・暗号資産", "電子マネー・プリペイド"];
+const LIQUID_ASSET_CATEGORIES = new Set([
+  // Legacy Money Forward label used before deposits and crypto were split.
+  "預金・現金・暗号資産",
+  // Current Money Forward labels.
+  "預金・現金",
+  "暗号資産",
+  "電子マネー・プリペイド",
+]);
+
+export function isLiquidAssetCategory(category: string): boolean {
+  return LIQUID_ASSET_CATEGORIES.has(category.trim());
+}
 const INVESTMENT_CATEGORIES = [
   "株式(現物)",
   "投資信託",
@@ -139,7 +150,7 @@ async function collectData(groupId: string, db: Db): Promise<CollectedData> {
   const categoryBreakdown = await getAssetBreakdownByCategory(groupId, db);
 
   const liquidAssets = categoryBreakdown
-    .filter((c) => LIQUID_ASSET_CATEGORIES.some((lc) => c.category.includes(lc)))
+    .filter((c) => isLiquidAssetCategory(c.category))
     .reduce((sum, c) => sum + c.amount, 0);
 
   const holdings = holdingsRaw

--- a/packages/db/src/queries/analytics.ts
+++ b/packages/db/src/queries/analytics.ts
@@ -215,6 +215,7 @@ function calculateSavings(data: CollectedData): AnalyticsMetrics["savings"] {
 
 export function isInvestmentCategory(categoryName: string): boolean {
   const normalizedCategoryName = categoryName.trim();
+  if (!normalizedCategoryName) return false;
   if (isLiquidAssetCategory(normalizedCategoryName)) return false;
   return INVESTMENT_CATEGORIES.some(
     (category) =>

--- a/packages/db/src/queries/analytics.ts
+++ b/packages/db/src/queries/analytics.ts
@@ -213,8 +213,13 @@ function calculateSavings(data: CollectedData): AnalyticsMetrics["savings"] {
   return { totalAssets, liquidAssets, monthlyExpenseAvg, emergencyFundMonths };
 }
 
-function isInvestmentCategory(categoryName: string): boolean {
-  return INVESTMENT_CATEGORIES.some((c) => categoryName.includes(c) || c.includes(categoryName));
+export function isInvestmentCategory(categoryName: string): boolean {
+  const normalizedCategoryName = categoryName.trim();
+  if (isLiquidAssetCategory(normalizedCategoryName)) return false;
+  return INVESTMENT_CATEGORIES.some(
+    (category) =>
+      normalizedCategoryName.includes(category) || category.includes(normalizedCategoryName),
+  );
 }
 
 function calculateInvestment(data: CollectedData): AnalyticsMetrics["investment"] {

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -224,7 +224,15 @@ for (const ic of instCategories) {
 // ---------------------------------------------------------------------------
 // 3. 資産カテゴリ
 // ---------------------------------------------------------------------------
-const assetCats = ["預金・現金・暗号資産", "株式(現物)", "投資信託", "年金", "ポイント・マイル"];
+const assetCats = [
+  "預金・現金",
+  "暗号資産",
+  "電子マネー・プリペイド",
+  "株式(現物)",
+  "投資信託",
+  "年金",
+  "ポイント",
+];
 
 const assetCatIds: Record<string, number> = {};
 for (const name of assetCats) {
@@ -435,21 +443,21 @@ const holdingDefs: HoldingDef[] = [
     accountName: "三井住友銀行",
     name: "普通預金",
     type: "asset",
-    assetCategory: "預金・現金・暗号資産",
+    assetCategory: "預金・現金",
     amount: 852481,
   },
   {
     accountName: "楽天銀行",
     name: "普通預金",
     type: "asset",
-    assetCategory: "預金・現金・暗号資産",
+    assetCategory: "預金・現金",
     amount: 623718,
   },
   {
     accountName: "住信SBIネット銀行",
     name: "SBIハイブリッド預金",
     type: "asset",
-    assetCategory: "預金・現金・暗号資産",
+    assetCategory: "預金・現金",
     amount: 347592,
   },
   // ---- 貯蓄用口座（グループ選択なしのみに所属） ----
@@ -457,7 +465,7 @@ const holdingDefs: HoldingDef[] = [
     accountName: "ゆうちょ銀行（貯蓄用）",
     name: "通常貯金",
     type: "asset",
-    assetCategory: "預金・現金・暗号資産",
+    assetCategory: "預金・現金",
     amount: 487293, // 貯蓄用の残高
   },
 
@@ -566,7 +574,7 @@ const holdingDefs: HoldingDef[] = [
     accountName: "Suica",
     name: "Suica残高",
     type: "asset",
-    assetCategory: "預金・現金・暗号資産",
+    assetCategory: "電子マネー・プリペイド",
     amount: 3842,
   },
 
@@ -575,7 +583,7 @@ const holdingDefs: HoldingDef[] = [
     accountName: "楽天ポイント",
     name: "楽天ポイント残高",
     type: "asset",
-    assetCategory: "ポイント・マイル",
+    assetCategory: "ポイント",
     amount: 15237,
   },
 
@@ -1707,6 +1715,7 @@ const dailyAssetData = generateDailyAssetData(GROUP_ID, totalAssets);
 //   - 年金:     月2からiDeCo積立 (0→最終 ¥350,000)
 //   - ポイント:  月1から少額蓄積 (0→最終 ¥15,480)
 //   - 預金・現金: total - 他カテゴリ合計 (残り全部)
+//   - 電子マネー: 少額残高を別カテゴリとして保持
 const TOTAL_DAYS = dailyAssetData.length;
 
 // 最終日のカテゴリ別目標額
@@ -1714,6 +1723,8 @@ const FINAL_FUND = 1999859; // 1,049,966 + 580,372 + 369,521
 const FINAL_STOCK = 703040; // 281,400 + 258,700 + 162,940
 const FINAL_PENSION = 350038;
 const FINAL_POINT = 15237;
+const FINAL_PREPAID = 3842;
+const FINAL_CRYPTO = 0;
 
 // 各カテゴリの「開始日インデックス」を月から算出
 // 月idx: 0=2025-02, 1=2025-03, ..., 11=2026-01
@@ -1774,7 +1785,14 @@ function stockAmount(dayIdx: number): number {
 }
 
 // 預金・現金の最終目標額 (holdings から)
-const FINAL_DEPOSIT = totalAssets - FINAL_FUND - FINAL_STOCK - FINAL_PENSION - FINAL_POINT;
+const FINAL_DEPOSIT =
+  totalAssets -
+  FINAL_FUND -
+  FINAL_STOCK -
+  FINAL_PENSION -
+  FINAL_POINT -
+  FINAL_PREPAID -
+  FINAL_CRYPTO;
 
 // 各グループの最終資産額を計算
 const groupFinalAssets: Record<string, number> = {};
@@ -1792,12 +1810,16 @@ const INVESTMENT_FINAL_PENSION = FINAL_PENSION;
 const LIVING_DEPOSITS = holdingDefs
   .filter((h) => {
     if (h.type !== "asset") return false;
-    if (h.assetCategory !== "預金・現金・暗号資産") return false;
+    if (h.assetCategory !== "預金・現金" && h.assetCategory !== "電子マネー・プリペイド")
+      return false;
     const cat = accountCategoryMap[h.accountName];
     return livingCategories.has(cat);
   })
   .reduce((s, h) => s + h.amount, 0);
-const LIVING_FINAL_DEPOSIT = LIVING_DEPOSITS; // ゆうちょ銀行を除く
+const LIVING_FINAL_PREPAID = holdingDefs
+  .filter((h) => h.type === "asset" && h.assetCategory === "電子マネー・プリペイド")
+  .reduce((s, h) => s + h.amount, 0);
+const LIVING_FINAL_DEPOSIT = LIVING_DEPOSITS - LIVING_FINAL_PREPAID; // ゆうちょ銀行を除く
 const LIVING_FINAL_POINT = FINAL_POINT;
 
 await db.transaction(async (tx) => {
@@ -1830,31 +1852,49 @@ await db.transaction(async (tx) => {
       // グループに応じてカテゴリを計算・挿入
       if (groupId === GROUP_ID) {
         // グループ選択なし: 全カテゴリ
-        let fund: number, stock: number, pension: number, point: number, deposit: number;
+        let fund: number,
+          stock: number,
+          pension: number,
+          point: number,
+          prepaid: number,
+          deposit: number;
         if (i === lastIdx) {
           fund = FINAL_FUND;
           stock = FINAL_STOCK;
           pension = FINAL_PENSION;
           point = FINAL_POINT;
+          prepaid = FINAL_PREPAID;
           deposit = FINAL_DEPOSIT;
         } else {
           fund = categoryAmount(i, FINAL_FUND, fundStartDay);
           stock = stockAmount(i);
           pension = categoryAmount(i, FINAL_PENSION, pensionStartDay);
           point = categoryAmount(i, FINAL_POINT, pointStartDay);
-          deposit = Math.max(0, total - fund - stock - pension - point);
+          prepaid = categoryAmount(i, FINAL_PREPAID, pointStartDay);
+          deposit = Math.max(0, total - fund - stock - pension - point - prepaid);
         }
 
         await tx
           .insert(schema.assetHistoryCategories)
           .values({
             assetHistoryId: ahId,
-            categoryName: "預金・現金・暗号資産",
+            categoryName: "預金・現金",
             amount: deposit,
             createdAt: ts,
             updatedAt: ts,
           })
           .run();
+        if (prepaid > 0)
+          await tx
+            .insert(schema.assetHistoryCategories)
+            .values({
+              assetHistoryId: ahId,
+              categoryName: "電子マネー・プリペイド",
+              amount: prepaid,
+              createdAt: ts,
+              updatedAt: ts,
+            })
+            .run();
         if (fund > 0)
           await tx
             .insert(schema.assetHistoryCategories)
@@ -1893,7 +1933,7 @@ await db.transaction(async (tx) => {
             .insert(schema.assetHistoryCategories)
             .values({
               assetHistoryId: ahId,
-              categoryName: "ポイント・マイル",
+              categoryName: "ポイント",
               amount: point,
               createdAt: ts,
               updatedAt: ts,
@@ -1947,31 +1987,44 @@ await db.transaction(async (tx) => {
             .run();
       } else if (groupId === GROUP_ID_LIVING) {
         // 生活グループ: 預金・現金、ポイント
-        let deposit: number, point: number;
+        let deposit: number, prepaid: number, point: number;
         if (i === lastIdx) {
           deposit = LIVING_FINAL_DEPOSIT;
+          prepaid = LIVING_FINAL_PREPAID;
           point = LIVING_FINAL_POINT;
         } else {
+          prepaid = categoryAmount(i, LIVING_FINAL_PREPAID, pointStartDay);
           point = categoryAmount(i, LIVING_FINAL_POINT, pointStartDay);
-          deposit = Math.max(0, total - point);
+          deposit = Math.max(0, total - prepaid - point);
         }
 
         await tx
           .insert(schema.assetHistoryCategories)
           .values({
             assetHistoryId: ahId,
-            categoryName: "預金・現金・暗号資産",
+            categoryName: "預金・現金",
             amount: deposit,
             createdAt: ts,
             updatedAt: ts,
           })
           .run();
+        if (prepaid > 0)
+          await tx
+            .insert(schema.assetHistoryCategories)
+            .values({
+              assetHistoryId: ahId,
+              categoryName: "電子マネー・プリペイド",
+              amount: prepaid,
+              createdAt: ts,
+              updatedAt: ts,
+            })
+            .run();
         if (point > 0)
           await tx
             .insert(schema.assetHistoryCategories)
             .values({
               assetHistoryId: ahId,
-              categoryName: "ポイント・マイル",
+              categoryName: "ポイント",
               amount: point,
               createdAt: ts,
               updatedAt: ts,

--- a/packages/meta/src/categories.ts
+++ b/packages/meta/src/categories.ts
@@ -35,11 +35,15 @@ export const EXPENSE_LARGE_CATEGORIES = [
 /** 資産カテゴリ名 */
 export const ASSET_CATEGORIES = [
   "預金・現金・暗号資産",
+  "預金・現金",
+  "暗号資産",
+  "電子マネー・プリペイド",
   "株式(現物)",
   "投資信託",
   "保険",
   "年金",
   "ポイント・マイル",
+  "ポイント",
 ] as const;
 
 /** 全大項目（収入+支出） */


### PR DESCRIPTION
## Summary
- Treat current Money Forward split categories (預金・現金 / 暗号資産 / 電子マネー・プリペイド) as liquid assets while keeping legacy 預金・現金・暗号資産 compatibility
- Update demo seed to generate split asset-history categories and add colors/category metadata for split labels
- Update crawler category recognition/tests for split labels

## Verification
- pnpm format
- pnpm --filter @mf-dashboard/db test -- src/queries/analytics.test.ts
- pnpm --filter @mf-dashboard/web test -- src/lib/colors.test.ts
- pnpm --filter @mf-dashboard/crawler test -- src/scrapers/portfolio.test.ts
- pnpm --filter @mf-dashboard/db build:demo
- pnpm typecheck
- pnpm lint
- pnpm knip
- pnpm format --check

## Data checks
- Real DB current group savings: liquidAssets 9,226,512; emergencyFundMonths 7.5
- demo.db savings: liquidAssets 2,314,926; emergencyFundMonths 9.6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Asset categories are now more detailed, splitting deposits, crypto assets, prepaid/e-money, and points.
  - Portfolio/asset history and insights now recognize these categories individually.
  - Updated theme colors to distinguish crypto and prepaid/e-money.

- **Bug Fixes**
  - Improved liquid-asset and investment-category classification (including whitespace normalization).
  - Enhanced point-category parsing to correctly handle point vs point/mile.

- **Documentation**
  - Refreshed the “流動資産” metric description text.

- **Tests**
  - Expanded coverage for category recognition and portfolio parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->