### PR TITLE
HIR-81: Split crawler main into phases

### DIFF
--- a/apps/crawler/src/crawler-phases.test.ts
+++ b/apps/crawler/src/crawler-phases.test.ts
@@ -1,0 +1,65 @@
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import { getDebugScreenshotPath, loadCrawlerConfig } from "./crawler-phases.js";
+
+describe("loadCrawlerConfig", () => {
+  test("DBがある場合はmonth modeを既定にする", () => {
+    const config = loadCrawlerConfig(
+      {},
+      () => true,
+      () => true,
+    );
+
+    expect(config.scrapeMode).toBe("month");
+    expect(config.isHistoryMode).toBe(false);
+    expect(config.authState).toBe("configured");
+  });
+
+  test("DBがない場合はhistory modeを既定にする", () => {
+    const config = loadCrawlerConfig(
+      {},
+      () => false,
+      () => false,
+    );
+
+    expect(config.scrapeMode).toBe("history");
+    expect(config.isHistoryMode).toBe(true);
+    expect(config.authState).toBe("none");
+  });
+
+  test("環境変数の指定を優先する", () => {
+    const env: NodeJS.ProcessEnv = {
+      CLEANUP_GROUPS: "true",
+      DB_PATH: "/tmp/test.db",
+      DEBUG: "true",
+      HEADED: "true",
+      SCRAPE_MODE: "history",
+      SKIP_REFRESH: "true",
+    };
+
+    const config = loadCrawlerConfig(
+      env,
+      (filePath) => filePath === "/tmp/test.db",
+      () => false,
+    );
+
+    expect(config.skipRefresh).toBe(true);
+    expect(config.cleanupGroups).toBe(true);
+    expect(config.dbPath).toBe("/tmp/test.db");
+    expect(config.dbExists).toBe(true);
+    expect(config.scrapeMode).toBe("history");
+    expect(config.isHistoryMode).toBe(true);
+    expect(config.isDebug).toBe(true);
+    expect(config.isHeaded).toBe(true);
+  });
+});
+
+describe("getDebugScreenshotPath", () => {
+  test("debug directory配下のerror画像パスを返す", () => {
+    const debugDir = path.join("/tmp", "apps", "crawler", "debug");
+
+    expect(getDebugScreenshotPath(1234567890, debugDir)).toBe(
+      path.join(debugDir, "error-1234567890.png"),
+    );
+  });
+});

--- a/apps/crawler/src/crawler-phases.ts
+++ b/apps/crawler/src/crawler-phases.ts
@@ -1,0 +1,320 @@
+import { existsSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { analyzeFinancialData } from "@mf-dashboard/analytics";
+import { initDb, type Db } from "@mf-dashboard/db";
+import { updateAccountCategory, buildAccountIdMap } from "@mf-dashboard/db/repository/accounts";
+import { deleteGroupsNotIn } from "@mf-dashboard/db/repository/groups";
+import { saveScrapedData, saveGroupOnlyData } from "@mf-dashboard/db/repository/save-scraped-data";
+import {
+  hasTransactionsForMonth,
+  saveTransactionsForMonth,
+} from "@mf-dashboard/db/repository/transactions";
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { loginWithAuthState } from "./auth/login.js";
+import { hasAuthState } from "./auth/state.js";
+import { createBrowserContext } from "./browser/context.js";
+import { buildCleanupGroupIds } from "./cleanup-groups.js";
+import { buildScrapedData, buildGroupOnlyScrapedData } from "./data-builder.js";
+import { getHistoryMaxMonths, getHistoryMonth } from "./history-months.js";
+import { runHooks } from "./hooks/runner.js";
+import { debug, error, info, log, phase, warn } from "./logger.js";
+import { sendFailureNotifications, sendSuccessNotifications } from "./notification.js";
+import { scrapeAllGroups, type GroupData, type ScrapeResult } from "./scraper.js";
+import { scrapeCashFlowHistory } from "./scrapers/cash-flow-history.js";
+import { isNoGroup, switchGroup, NO_GROUP_ID } from "./scrapers/group.js";
+import { scrapeInstitutionCategories } from "./scrapers/institution-categories.js";
+
+const DEFAULT_ENV_PATH = path.resolve(import.meta.dirname, "../../../.env");
+const DEFAULT_DB_PATH = path.join(import.meta.dirname, "../../../data/moneyforward.db");
+const DEBUG_DIR = path.resolve(import.meta.dirname, "../debug");
+
+export interface CrawlerConfig {
+  skipRefresh: boolean;
+  cleanupGroups: boolean;
+  authState: "configured" | "none";
+  dbPath: string;
+  dbExists: boolean;
+  scrapeMode: string;
+  isHistoryMode: boolean;
+  isDebug: boolean;
+  isHeaded: boolean;
+}
+
+export interface CrawlerRuntime {
+  db: Db;
+  browser: Browser;
+  context: BrowserContext;
+  page: Page;
+}
+
+export function runLoadPhase(): CrawlerConfig {
+  phase("Load");
+  loadEnvFile();
+
+  const config = loadCrawlerConfig();
+  logCrawlerOptions(config);
+  return config;
+}
+
+function loadEnvFile(envPath = DEFAULT_ENV_PATH): void {
+  try {
+    process.loadEnvFile(envPath);
+  } catch {
+    // .env file not found (e.g., CI environment)
+  }
+}
+
+export function loadCrawlerConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  fileExists: (filePath: string) => boolean = existsSync,
+  authStateExists: () => boolean = hasAuthState,
+): CrawlerConfig {
+  const skipRefresh = env.SKIP_REFRESH === "true";
+  const cleanupGroups = env.CLEANUP_GROUPS === "true";
+  const dbPath = env.DB_PATH || DEFAULT_DB_PATH;
+  const dbExists = fileExists(dbPath);
+  const scrapeMode = env.SCRAPE_MODE || (dbExists ? "month" : "history");
+
+  return {
+    skipRefresh,
+    cleanupGroups,
+    authState: authStateExists() ? "configured" : "none",
+    dbPath,
+    dbExists,
+    scrapeMode,
+    isHistoryMode: scrapeMode === "history",
+    isDebug: env.DEBUG === "true",
+    isHeaded: env.HEADED === "true",
+  };
+}
+
+function logCrawlerOptions(config: CrawlerConfig): void {
+  phase("Options");
+  log(`SKIP_REFRESH:   ${config.skipRefresh}`);
+  info(`CLEANUP_GROUPS: ${config.cleanupGroups}`);
+  log(`SCRAPE_MODE:    ${config.scrapeMode} (DB exists: ${config.dbExists})`);
+  log(`DEBUG:          ${config.isDebug}`);
+  log(`HEADED:         ${config.isHeaded}`);
+  log(`AUTH_STATE:     ${config.authState}`);
+}
+
+export async function runSetupPhase(config: CrawlerConfig): Promise<CrawlerRuntime> {
+  phase("Setup");
+  info("Initializing database");
+  const db = await initDb();
+
+  let browser: Browser | null = null;
+  try {
+    log("Launching browser");
+    browser = await chromium.launch({
+      headless: !config.isHeaded,
+    });
+
+    const context = await createBrowserContext(browser, { useAuthState: true });
+    const page = await context.newPage();
+
+    return {
+      db,
+      browser,
+      context,
+      page,
+    };
+  } catch (err) {
+    if (browser) {
+      await browser.close();
+    }
+    throw err;
+  }
+}
+
+export async function runAuthPhase(page: Page, context: BrowserContext): Promise<void> {
+  phase("Auth");
+  info("Authenticating");
+  await loginWithAuthState(page, context);
+
+  info("Running hooks");
+  await runHooks(page);
+}
+
+export async function runScrapePhase(
+  page: Page,
+  config: Pick<CrawlerConfig, "skipRefresh">,
+): Promise<ScrapeResult> {
+  phase("Scrape");
+  const scrapeResult = await scrapeAllGroups(page, {
+    skipRefresh: config.skipRefresh,
+  });
+
+  info(`Scraped ${scrapeResult.groupDataList.length} groups`);
+  for (const groupData of scrapeResult.groupDataList) {
+    log(`  - ${groupData.group.name}${isNoGroup(groupData.group.id) ? " (no group)" : ""}`);
+  }
+
+  return scrapeResult;
+}
+
+export async function runSavePhase(db: Db, scrapeResult: ScrapeResult): Promise<void> {
+  phase("Save");
+  const noGroupData = scrapeResult.groupDataList.find((groupData) => isNoGroup(groupData.group.id));
+
+  if (noGroupData) {
+    info(`Saving full data for ${noGroupData.group.name}`);
+    const scrapedData = buildScrapedData(scrapeResult.globalData, noGroupData);
+    debug("Scraped data:", JSON.stringify(scrapedData, null, 2));
+    await saveScrapedData(db, scrapedData);
+  } else {
+    warn("No no-group data found; skipped full data save");
+  }
+
+  const groupOnlyData = scrapeResult.groupDataList.filter(
+    (groupData) => !isNoGroup(groupData.group.id),
+  );
+
+  for (const groupData of groupOnlyData) {
+    info(`Saving group-only data for ${groupData.group.name}`);
+    const scrapedData = buildGroupOnlyScrapedData(groupData);
+    await saveGroupOnlyData(db, scrapedData);
+  }
+}
+
+export async function runCleanupPhase(
+  db: Db,
+  groupDataList: GroupData[],
+  config: Pick<CrawlerConfig, "cleanupGroups">,
+): Promise<void> {
+  phase("Cleanup");
+
+  if (!config.cleanupGroups) {
+    log("Skipping group cleanup (CLEANUP_GROUPS=false)");
+    return;
+  }
+
+  const result = buildCleanupGroupIds(groupDataList);
+  if (result) {
+    await deleteGroupsNotIn(db, result.ids);
+    info("Cleaned up groups not found in MoneyForward");
+  } else {
+    warn(
+      "Skipped group cleanup because no groups were scraped; group selector retrieval may have failed.",
+    );
+  }
+}
+
+export async function runInstitutionCategoryPhase(db: Db, page: Page): Promise<void> {
+  phase("Institution Categories");
+  log("Scraping institution categories");
+  const categoryMap = await scrapeInstitutionCategories(page);
+  info(`Updated ${categoryMap.size} account categories`);
+
+  for (const [mfId, category] of categoryMap.entries()) {
+    await updateAccountCategory(db, mfId, category);
+  }
+}
+
+export async function runCashFlowHistoryPhase(
+  db: Db,
+  page: Page,
+  config: Pick<CrawlerConfig, "isHistoryMode">,
+): Promise<void> {
+  phase("Cash Flow History");
+
+  if (!config.isHistoryMode) {
+    log("Skipping cash flow history (SCRAPE_MODE is not history)");
+    return;
+  }
+
+  const accountIdMap = await buildAccountIdMap(db);
+  const now = new Date();
+  const maxMonths = getHistoryMaxMonths(now);
+
+  let monthsToFetch = 1;
+  for (let i = 1; i < maxMonths; i++) {
+    const month = getHistoryMonth(now, i);
+    if (!(await hasTransactionsForMonth(db, month))) {
+      monthsToFetch = i + 1;
+    }
+  }
+
+  info(`Fetching ${monthsToFetch} months`);
+
+  await switchGroup(page, NO_GROUP_ID);
+
+  const historyResults = await scrapeCashFlowHistory(page, monthsToFetch);
+
+  for (const { month, data: monthData } of historyResults) {
+    const savedCount = await saveTransactionsForMonth(db, month, monthData.items, accountIdMap);
+    log(`  ${month}: saved ${savedCount} transactions`);
+  }
+}
+
+export async function runAnalyticsPhase(db: Db, groupDataList: GroupData[]): Promise<void> {
+  phase("Analytics");
+
+  if (groupDataList.length === 0) {
+    warn("No group available for analytics");
+    return;
+  }
+
+  const results = await Promise.all(
+    groupDataList.map(async (groupData) => {
+      info(`Running financial analysis for ${groupData.group.name}`);
+      const report = await analyzeFinancialData(db, groupData.group.id);
+      if (report) {
+        info(`Analysis completed and saved for ${groupData.group.name}`);
+      } else {
+        log(`No changes detected, skipped analysis for ${groupData.group.name}`);
+      }
+      return report;
+    }),
+  );
+  info(`Analytics finished: ${results.filter(Boolean).length}/${groupDataList.length} groups`);
+}
+
+export async function runNotificationPhase(
+  groupDataList: GroupData[],
+  defaultGroup: ScrapeResult["defaultGroup"],
+): Promise<void> {
+  phase("Notification");
+
+  try {
+    await sendSuccessNotifications(groupDataList, defaultGroup);
+  } catch (err) {
+    error("Failed to send notification:", err);
+  }
+}
+
+export async function handleCrawlerFailure(
+  err: unknown,
+  page: Page | undefined,
+  config: Pick<CrawlerConfig, "isDebug">,
+): Promise<void> {
+  error("Error occurred:", err);
+
+  if (config.isDebug && page) {
+    try {
+      const screenshotPath = await saveDebugScreenshot(page);
+      info(`Debug screenshot saved to ${screenshotPath}`);
+    } catch (screenshotError) {
+      error("Failed to save debug screenshot:", screenshotError);
+    }
+  }
+
+  const errorForNotification = err instanceof Error ? err : new Error(String(err));
+  try {
+    await sendFailureNotifications(errorForNotification);
+  } catch (notificationError) {
+    error("Failed to send error notification:", notificationError);
+  }
+}
+
+async function saveDebugScreenshot(page: Page, timestamp = Date.now()): Promise<string> {
+  const screenshotPath = getDebugScreenshotPath(timestamp);
+  await mkdir(path.dirname(screenshotPath), { recursive: true });
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  return screenshotPath;
+}
+
+export function getDebugScreenshotPath(timestamp = Date.now(), debugDir = DEBUG_DIR): string {
+  return path.join(debugDir, `error-${timestamp}.png`);
+}

--- a/apps/crawler/src/data-builder.ts
+++ b/apps/crawler/src/data-builder.ts
@@ -1,14 +1,19 @@
 import type { ScrapedData } from "@mf-dashboard/db/types";
 import type { GlobalData, GroupData } from "./scraper.js";
 
+export function formatUpdatedAt(now = new Date()): string {
+  return now.toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" });
+}
+
 /**
  * GlobalData + GroupData から ScrapedData を構築
  * 「グループ選択なし」の全データ保存用
  */
-export function buildScrapedData(globalData: GlobalData, groupData: GroupData): ScrapedData {
-  const now = new Date();
-  const updatedAt = now.toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" });
-
+export function buildScrapedData(
+  globalData: GlobalData,
+  groupData: GroupData,
+  updatedAt = formatUpdatedAt(),
+): ScrapedData {
   return {
     summary: groupData.summary,
     items: groupData.items,
@@ -28,10 +33,10 @@ export function buildScrapedData(globalData: GlobalData, groupData: GroupData): 
  * GroupData から ScrapedData を構築
  * 各グループのグループ固有データ保存用
  */
-export function buildGroupOnlyScrapedData(groupData: GroupData): ScrapedData {
-  const now = new Date();
-  const updatedAt = now.toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" });
-
+export function buildGroupOnlyScrapedData(
+  groupData: GroupData,
+  updatedAt = formatUpdatedAt(),
+): ScrapedData {
   return {
     summary: groupData.summary,
     items: groupData.items,

--- a/apps/crawler/src/index.ts
+++ b/apps/crawler/src/index.ts
@@ -1,276 +1,50 @@
-import { existsSync } from "node:fs";
-import path from "node:path";
-import { analyzeFinancialData } from "@mf-dashboard/analytics";
-import { initDb, closeDb } from "@mf-dashboard/db";
-import { updateAccountCategory, buildAccountIdMap } from "@mf-dashboard/db/repository/accounts";
-import { deleteGroupsNotIn } from "@mf-dashboard/db/repository/groups";
-import { saveScrapedData, saveGroupOnlyData } from "@mf-dashboard/db/repository/save-scraped-data";
+import { closeDb } from "@mf-dashboard/db";
 import {
-  hasTransactionsForMonth,
-  saveTransactionsForMonth,
-} from "@mf-dashboard/db/repository/transactions";
-import { chromium } from "playwright";
-import { loginWithAuthState } from "./auth/login.js";
-import { hasAuthState } from "./auth/state.js";
-import { createBrowserContext } from "./browser/context.js";
-import { buildCleanupGroupIds } from "./cleanup-groups.js";
-import { buildScrapedData, buildGroupOnlyScrapedData } from "./data-builder.js";
-import { sendDiscordNotification, sendDiscordErrorNotification } from "./discord.js";
-import { getHistoryMaxMonths, getHistoryMonth } from "./history-months.js";
-import { runHooks } from "./hooks/runner.js";
-import { log, debug, info, error, section, warn } from "./logger.js";
-import { scrapeAllGroups } from "./scraper.js";
-import { scrapeCashFlowHistory } from "./scrapers/cash-flow-history.js";
-import { isNoGroup, switchGroup, NO_GROUP_ID, createGroupScope } from "./scrapers/group.js";
-import { scrapeInstitutionCategories } from "./scrapers/institution-categories.js";
-import { sendSlackNotification, sendErrorNotification } from "./slack.js";
-import type { ScrapedData } from "./types.js";
-
-try {
-  process.loadEnvFile(path.resolve(import.meta.dirname, "../../../.env"));
-} catch {
-  // .env file not found (e.g., CI environment)
-}
-
-const isDebug = process.env.DEBUG === "true";
-const isHeaded = process.env.HEADED === "true";
+  handleCrawlerFailure,
+  runAnalyticsPhase,
+  runAuthPhase,
+  runCashFlowHistoryPhase,
+  runCleanupPhase,
+  runInstitutionCategoryPhase,
+  runLoadPhase,
+  runNotificationPhase,
+  runSavePhase,
+  runScrapePhase,
+  runSetupPhase,
+  type CrawlerRuntime,
+} from "./crawler-phases.js";
+import { info } from "./logger.js";
+import { createGroupScope } from "./scrapers/group.js";
 
 async function main() {
-  const skipRefresh = process.env.SKIP_REFRESH === "true";
-  const cleanupGroups = process.env.CLEANUP_GROUPS === "true";
-  const authState = hasAuthState() ? "configured" : "none";
-  const dbPath =
-    process.env.DB_PATH || path.join(import.meta.dirname, "../../../data/moneyforward.db");
-  const dbExists = existsSync(dbPath);
-  const scrapeMode = process.env.SCRAPE_MODE || (dbExists ? "month" : "history");
-  const isHistoryMode = scrapeMode === "history";
-
-  section("Options");
-  log(`SKIP_REFRESH:   ${skipRefresh}`);
-  info(`CLEANUP_GROUPS: ${cleanupGroups}`);
-  log(`SCRAPE_MODE:    ${scrapeMode} (DB exists: ${dbExists})`);
-  log(`DEBUG:          ${isDebug}`);
-  log(`HEADED:         ${isHeaded}`);
-  log(`AUTH_STATE:     ${authState}`);
-
-  section("Setup");
-  log("Initializing database");
-  const db = await initDb();
-
-  const browser = await chromium.launch({
-    headless: !isHeaded,
-  });
-
-  const context = await createBrowserContext(browser, { useAuthState: true });
-
-  const page = await context.newPage();
+  const config = runLoadPhase();
+  let runtime: CrawlerRuntime | null = null;
 
   try {
-    log("Authenticating...");
-    await loginWithAuthState(page, context);
+    runtime = await runSetupPhase(config);
+    await runAuthPhase(runtime.page, runtime.context);
 
-    log("Running hooks...");
-    await runHooks(page);
-
-    await using groupScope = await createGroupScope(page);
-    const defaultGroup = groupScope.originalGroup;
-
-    // ============================================================
-    // Scrape: 全グループのデータを取得
-    // ============================================================
-    section("Scrape (All Groups)");
-    const scrapeResult = await scrapeAllGroups(page, {
-      skipRefresh,
-    });
-    const { globalData, groupDataList } = scrapeResult;
-
-    info(`Scraped ${groupDataList.length} groups`);
-    for (const groupData of groupDataList) {
-      log(`  - ${groupData.group.name}${isNoGroup(groupData.group.id) ? " (no group)" : ""}`);
-    }
-
-    // ============================================================
-    // Save: データベースに保存
-    // ============================================================
-
-    // 「グループ選択なし」のデータを構築して保存（全アカウント + トランザクション等）
-    const noGroupData = groupDataList.find((gd) => isNoGroup(gd.group.id));
-    if (noGroupData) {
-      section(`Save: ${noGroupData.group.name} (Full)`);
-      const scrapedData = buildScrapedData(globalData, noGroupData);
-      debug("Scraped data:", JSON.stringify(scrapedData, null, 2));
-      await saveScrapedData(db, scrapedData);
-    }
-
-    // 各グループはグループ固有データのみ保存（リンク + assetHistory + spendingTargets）
-    for (const groupData of groupDataList) {
-      if (isNoGroup(groupData.group.id)) continue;
-
-      section(`Save: ${groupData.group.name} (Group Only)`);
-      const scrapedData = buildGroupOnlyScrapedData(groupData);
-      await saveGroupOnlyData(db, scrapedData);
-    }
-
-    // CLEANUP_GROUPS=true の場合のみ、MoneyForward に存在しないグループを DB から削除
-    if (cleanupGroups) {
-      const result = buildCleanupGroupIds(groupDataList);
-      if (result) {
-        await deleteGroupsNotIn(db, result.ids);
-        info("Cleaned up groups not found in MoneyForward");
-      } else {
-        warn(
-          "Skipped group cleanup because no groups were scraped; group selector retrieval may have failed.",
-        );
-      }
-    }
-
-    // 金融機関カテゴリはデフォルトグループ（または最初のグループ）で一度だけ取得
-    log("Scraping institution categories...");
-    const categoryMap = await scrapeInstitutionCategories(page);
-    log(`Updated ${categoryMap.size} account categories`);
-    for (const [mfId, category] of categoryMap.entries()) {
-      await updateAccountCategory(db, mfId, category);
-    }
-
-    if (isHistoryMode) {
-      section("Cash Flow History");
-
-      // accountIdMapを構築（トランザクション保存時のaccount_id設定用）
-      const accountIdMap = await buildAccountIdMap(db);
-
-      // 先にDBをチェックしてスキップ可能な月数を計算
-      // 今月 + 去年の全月分を取得対象とする
-      // 例: 2026年1月 → 2026年1月 + 2025年1月〜12月 = 13ヶ月
-      const now = new Date();
-      const maxMonths = getHistoryMaxMonths(now); // 今年の経過月数 + 去年12ヶ月（JST基準）
-
-      // DBにない最古の月まで取得
-      let monthsToFetch = 1; // 今月は常に取得
-      for (let i = 1; i < maxMonths; i++) {
-        const month = getHistoryMonth(now, i);
-        if (!(await hasTransactionsForMonth(db, month))) {
-          monthsToFetch = i + 1;
-        }
-      }
-
-      log(`Fetching ${monthsToFetch} months`);
-
-      // 「グループ選択なし」に切り替えて全金融機関のtransactionsを取得
-      // transactionsはgroupIdを持たないため、一度だけ取得すれば良い
-      await switchGroup(page, NO_GROUP_ID);
-
-      // UIボタンで月を切り替えながらデータを取得
-      const historyResults = await scrapeCashFlowHistory(page, monthsToFetch);
-
-      for (const { month, data: monthData } of historyResults) {
-        const savedCount = await saveTransactionsForMonth(db, month, monthData.items, accountIdMap);
-        log(`  ${month}: saved ${savedCount} transactions`);
-      }
-    }
-
-    // 分析実行（計算は常に行う、LLM insightsは環境変数がある場合のみ）
-    section("Analytics");
-    const analyticsGroups = groupDataList;
-    if (analyticsGroups.length > 0) {
-      const results = await Promise.all(
-        analyticsGroups.map(async (groupData) => {
-          info(`Running financial analysis for ${groupData.group.name}...`);
-          const report = await analyzeFinancialData(db, groupData.group.id);
-          if (report) {
-            info(`Analysis completed and saved for ${groupData.group.name}`);
-          } else {
-            log(`No changes detected, skipped analysis for ${groupData.group.name}`);
-          }
-          return report;
-        }),
-      );
-      info(
-        `Analytics finished: ${results.filter(Boolean).length}/${analyticsGroups.length} groups`,
-      );
-    } else {
-      warn("No group available for analytics");
-    }
-
-    // 通知はデフォルトグループまたは最初のグループのデータを使用
-    section("Notification");
-    try {
-      // デフォルトグループのデータを探す、なければ最初のグループ
-      const notifyGroupData =
-        groupDataList.find((gd) => gd.group.id === defaultGroup?.id) || groupDataList[0];
-
-      if (!notifyGroupData) {
-        warn("No data available for notification");
-      } else {
-        // アカウント問題はデフォルトグループのアカウントから取得
-        const accountIssues = notifyGroupData.registeredAccounts.accounts
-          .filter((a) => a.status === "updating" || a.status === "error")
-          .map((a) => ({
-            name: a.name,
-            status: a.status as "updating" | "error",
-            errorMessage: a.errorMessage,
-          }));
-
-        const now = new Date();
-        const updatedAt = now.toLocaleString("ja-JP", {
-          timeZone: "Asia/Tokyo",
-        });
-
-        const notifyPayload: ScrapedData = {
-          summary: notifyGroupData.summary,
-          items: notifyGroupData.items,
-          updatedAt,
-          groupName: notifyGroupData.group.name,
-          accountIssues,
-        };
-
-        const results = await Promise.allSettled([
-          sendSlackNotification(notifyPayload),
-          sendDiscordNotification(notifyPayload),
-        ]);
-
-        for (const result of results) {
-          if (result.status === "rejected") {
-            error("Failed to send notification:", result.reason);
-          }
-        }
-      }
-    } catch (err) {
-      error("Failed to send notification:", err);
-    }
+    await using groupScope = await createGroupScope(runtime.page);
+    const scrapeResult = await runScrapePhase(runtime.page, config);
+    await runSavePhase(runtime.db, scrapeResult);
+    await runCleanupPhase(runtime.db, scrapeResult.groupDataList, config);
+    await runInstitutionCategoryPhase(runtime.db, runtime.page);
+    await runCashFlowHistoryPhase(runtime.db, runtime.page, config);
+    await runAnalyticsPhase(runtime.db, scrapeResult.groupDataList);
+    await runNotificationPhase(scrapeResult.groupDataList, groupScope.originalGroup);
 
     info("Completed!");
   } catch (err) {
-    error("Error occurred:", err);
-
-    // Take screenshot on error for debugging
-    if (isDebug) {
-      const screenshotPath = `error-${Date.now()}.png`;
-      await page.screenshot({ path: screenshotPath, fullPage: true });
-      log(`Screenshot saved to ${screenshotPath}`);
-    }
-
-    // Send error notification
-    if (err instanceof Error) {
-      try {
-        const results = await Promise.allSettled([
-          sendErrorNotification(err),
-          sendDiscordErrorNotification(err),
-        ]);
-
-        for (const result of results) {
-          if (result.status === "rejected") {
-            error("Failed to send error notification:", result.reason);
-          }
-        }
-      } catch (err) {
-        error("Failed to send error notification:", err);
-      }
-    }
-
-    process.exit(1);
+    await handleCrawlerFailure(err, runtime?.page, config);
+    process.exitCode = 1;
   } finally {
-    await browser.close();
-    closeDb();
+    try {
+      if (runtime) {
+        await runtime.browser.close();
+      }
+    } finally {
+      closeDb();
+    }
   }
 }
 

--- a/apps/crawler/src/logger.ts
+++ b/apps/crawler/src/logger.ts
@@ -8,10 +8,18 @@ function time(): string {
   });
 }
 
-export function section(title: string) {
+function section(title: string) {
   if (isCI) return;
   // oxlint-disable-next-line no-console
   console.log(`\n--- ${title} ---`);
+}
+
+export function phase(title: string) {
+  if (isCI) {
+    info(`Phase: ${title}`);
+  } else {
+    section(title);
+  }
 }
 
 export function log(...args: unknown[]) {

--- a/apps/crawler/src/notification.test.ts
+++ b/apps/crawler/src/notification.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "vitest";
+import { buildNotificationPayload, selectNotificationGroup } from "./notification.js";
+import type { GroupData } from "./scraper.js";
+
+function makeGroupData(id: string, name: string): GroupData {
+  return {
+    group: { id, name, isCurrent: false },
+    registeredAccounts: {
+      accounts: [
+        {
+          mfId: `${id}-account-a`,
+          name: "Account A",
+          type: "自動連携",
+          status: "ok",
+          lastUpdated: "2026-07-15",
+          url: "/accounts/show/account-a",
+          totalAssets: 1000,
+        },
+        {
+          mfId: `${id}-account-b`,
+          name: "Account B",
+          type: "自動連携",
+          status: "updating",
+          lastUpdated: "2026-07-15",
+          url: "/accounts/show/account-b",
+          totalAssets: 2000,
+        },
+        {
+          mfId: `${id}-account-c`,
+          name: "Account C",
+          type: "自動連携",
+          status: "error",
+          lastUpdated: "2026-07-15",
+          url: "/accounts/show/account-c",
+          totalAssets: 3000,
+          errorMessage: "Connection failed",
+        },
+      ],
+    },
+    assetHistory: { points: [] },
+    spendingTargets: { categories: [] },
+    summary: {
+      totalAssets: "6,000",
+      dailyChange: "+100",
+      dailyChangePercent: "+1.7%",
+      monthlyChange: "+500",
+      monthlyChangePercent: "+8.3%",
+    },
+    items: [
+      {
+        name: "合計",
+        balance: "6,000",
+        previousBalance: "5,900",
+        change: "+100",
+      },
+    ],
+  };
+}
+
+describe("selectNotificationGroup", () => {
+  test("default groupに一致するデータを選ぶ", () => {
+    const groupA = makeGroupData("group-a", "Group A");
+    const groupB = makeGroupData("group-b", "Group B");
+
+    expect(selectNotificationGroup([groupA, groupB], groupB.group)).toBe(groupB);
+  });
+
+  test("default groupがない場合は先頭データを選ぶ", () => {
+    const groupA = makeGroupData("group-a", "Group A");
+    const groupB = makeGroupData("group-b", "Group B");
+
+    expect(selectNotificationGroup([groupA, groupB], null)).toBe(groupA);
+  });
+});
+
+describe("buildNotificationPayload", () => {
+  test("通知用payloadにgroup dataとaccount issueを反映する", () => {
+    const groupData = makeGroupData("group-a", "Group A");
+    const payload = buildNotificationPayload(groupData, new Date("2026-07-15T09:00:00.000Z"));
+
+    expect(payload.summary).toBe(groupData.summary);
+    expect(payload.items).toBe(groupData.items);
+    expect(payload.groupName).toBe("Group A");
+    expect(payload.updatedAt).toContain("2026");
+    expect(payload.accountIssues).toEqual([
+      {
+        name: "Account B",
+        status: "updating",
+        errorMessage: undefined,
+      },
+      {
+        name: "Account C",
+        status: "error",
+        errorMessage: "Connection failed",
+      },
+    ]);
+  });
+});

--- a/apps/crawler/src/notification.ts
+++ b/apps/crawler/src/notification.ts
@@ -1,0 +1,71 @@
+import type { Group } from "@mf-dashboard/db/types";
+import { formatUpdatedAt } from "./data-builder.js";
+import { sendDiscordNotification, sendDiscordErrorNotification } from "./discord.js";
+import { error, warn } from "./logger.js";
+import type { GroupData } from "./scraper.js";
+import { sendSlackNotification, sendErrorNotification } from "./slack.js";
+import type { ScrapedData } from "./types.js";
+
+export function selectNotificationGroup(
+  groupDataList: GroupData[],
+  defaultGroup: Group | null,
+): GroupData | undefined {
+  return (
+    groupDataList.find((groupData) => groupData.group.id === defaultGroup?.id) ?? groupDataList[0]
+  );
+}
+
+export function buildNotificationPayload(groupData: GroupData, now = new Date()): ScrapedData {
+  const accountIssues = groupData.registeredAccounts.accounts
+    .filter((account) => account.status === "updating" || account.status === "error")
+    .map((account) => ({
+      name: account.name,
+      status: account.status as "updating" | "error",
+      errorMessage: account.errorMessage,
+    }));
+
+  return {
+    summary: groupData.summary,
+    items: groupData.items,
+    updatedAt: formatUpdatedAt(now),
+    groupName: groupData.group.name,
+    accountIssues,
+  };
+}
+
+export async function sendSuccessNotifications(
+  groupDataList: GroupData[],
+  defaultGroup: Group | null,
+) {
+  const notifyGroupData = selectNotificationGroup(groupDataList, defaultGroup);
+
+  if (!notifyGroupData) {
+    warn("No data available for notification");
+    return;
+  }
+
+  const notifyPayload = buildNotificationPayload(notifyGroupData);
+  const results = await Promise.allSettled([
+    sendSlackNotification(notifyPayload),
+    sendDiscordNotification(notifyPayload),
+  ]);
+
+  logNotificationFailures(results, "Failed to send notification:");
+}
+
+export async function sendFailureNotifications(err: Error) {
+  const results = await Promise.allSettled([
+    sendErrorNotification(err),
+    sendDiscordErrorNotification(err),
+  ]);
+
+  logNotificationFailures(results, "Failed to send error notification:");
+}
+
+function logNotificationFailures(results: PromiseSettledResult<void>[], message: string) {
+  for (const result of results) {
+    if (result.status === "rejected") {
+      error(message, result.reason);
+    }
+  }
+}

--- a/apps/crawler/src/scraper.ts
+++ b/apps/crawler/src/scraper.ts
@@ -1,6 +1,6 @@
 import type { Group, ScrapedData } from "@mf-dashboard/db/types";
 import type { Page } from "playwright";
-import { log, warn, section } from "./logger.js";
+import { log, warn, phase } from "./logger.js";
 import { getAssetHistory } from "./scrapers/asset-history.js";
 import { getAssetItems } from "./scrapers/asset-items.js";
 import { getAssetSummary } from "./scrapers/asset-summary.js";
@@ -152,7 +152,7 @@ function buildGroupsToProcess(allGroups: Group[]): Group[] {
 }
 
 async function runPhase1(page: Page, options: ScrapeOptions): Promise<GlobalData> {
-  section("Phase 1: Global Data");
+  phase("Scrape: Global Data");
   await switchGroup(page, NO_GROUP_ID);
   return scrapeGlobalData(page, options);
 }
@@ -162,7 +162,7 @@ async function runPhase2(
   groupsToProcess: Group[],
   defaultGroup: Group | null,
 ): Promise<GroupData[]> {
-  section("Phase 2: Group Data");
+  phase("Scrape: Group Data");
   const groupDataList: GroupData[] = [];
 
   for (const groupEntry of groupsToProcess) {

--- a/apps/crawler/tests/unit-setup.ts
+++ b/apps/crawler/tests/unit-setup.ts
@@ -10,8 +10,10 @@ try {
 // Global mock for logger to suppress console output in unit tests
 vi.mock("../src/logger.js", () => ({
   log: vi.fn(),
+  info: vi.fn(),
   debug: vi.fn(),
   warn: vi.fn(),
   error: vi.fn(),
   section: vi.fn(),
+  phase: vi.fn(),
 }));


### PR DESCRIPTION
## Summary
- Split the crawler entrypoint into explicit load/setup/auth/scrape/save/cleanup/history/analytics/notification phases.
- Moved notification payload selection/building into a dedicated crawler notification module.
- Save debug screenshots under `apps/crawler/debug/` and keep failure notifications running if screenshot capture fails.
- Added unit coverage for config loading, debug screenshot path, and notification payload behavior.

## Validation
- `pnpm --filter @mf-dashboard/crawler test`
- `pnpm --filter @mf-dashboard/crawler typecheck`

Refs HIR-81
