### PR TITLE
[codex] Add header refresh button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,11 +16,9 @@ test-auth-state.json
 
 test-groups-moneyforward.db
 test-moneyforward.db*
-data/demo.db
+data/*
 *.db-shm
 *.db-wal
-data/moneyforward.db
-data/cloudflared-token
 secrets/
 
 playwright-report

--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ MCP (Model Context Protocol) サーバーを内蔵。ChatGPTやClaude Desktopか
 
 ## アーキテクチャ
 
-ローカル PC で **Docker Compose** を使い、`web` (Next.js) / `cloudflared` / `crawler` の 3 サービスを常駐させる。crawler コンテナは内部に **supercronic** (containers 向けの cron) を持ち、JST 7:00 / 15:30 に MoneyForward をスクレイピング → 完了後 web の `/api/refresh/` を Docker bridge 経由で Bearer 認証付き POST し、`revalidatePath` で全ルートを再生成する。SQLite は volume 経由で web/crawler が共有し、Git には commit しない。外部公開は Cloudflare Tunnel + Access (Google IdP + email allowlist)。
+ローカル PC で **Docker Compose** を使い、`web` (Next.js) / `cloudflared` / `crawler` の 3 サービスを常駐させる。crawler コンテナは内部に **supercronic** (containers 向けの cron) と手動更新 API を持ち、JST 7:00 / 15:30 または UI の更新ボタンから MoneyForward をスクレイピング → 完了後 web の `/api/refresh/` を Docker bridge 経由で Bearer 認証付き POST し、`revalidatePath` で全ルートを再生成する。SQLite は volume 経由で web/crawler が共有し、Git には commit しない。外部公開は Cloudflare Tunnel + Access (Google IdP + email allowlist)。
 
 ```mermaid
 graph LR
     A[crawler コンテナ<br/>supercronic] -->|1. JST 7:00/15:30| B[crawler<br/>Playwright]
+    W -->|手動更新<br/>crawler:8766| B
     B -->|2. OTP取得| E[1Password<br/>Service Account]
     E -->|3. 認証情報| B
     B -->|4. アクセス| F[MoneyForward Me]
@@ -63,7 +64,7 @@ graph LR
 **処理の流れ:**
 
 - **常駐**: Docker Desktop の自動起動 + `restart: unless-stopped` で 3 コンテナがホスト起動時に立ち上がる
-- **スケジューリング**: crawler コンテナの supercronic が `docker/crawler/crontab` を回す (TZ=Asia/Tokyo)
+- **スケジューリング**: crawler コンテナの supercronic が `docker/crawler/crontab` を回す (TZ=Asia/Tokyo)。web の更新ボタンから内部 API 経由でも即時実行できる
 - **データ取得**: Playwright で MoneyForward Me からスクレイピング
 - **認証**: 1Password Service Account から OTP を取得
 - **データ保存**: 共有 volume の SQLite (`./data/moneyforward.db`) に保存。MoneyForward の browser session は crawler 専用 volume に分離し、web から mount しない

--- a/apps/crawler/package.json
+++ b/apps/crawler/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "dev:scrape": "DEBUG=true SKIP_REFRESH=true tsx src/index.ts",
+    "serve": "tsx src/server.ts",
     "start": "tsx src/index.ts",
     "test": "vitest run --project unit",
     "test:e2e": "vitest run --project e2e",

--- a/apps/crawler/src/crawler-run-lock.test.ts
+++ b/apps/crawler/src/crawler-run-lock.test.ts
@@ -1,0 +1,196 @@
+import { writeFileSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  acquireCrawlerRunLock,
+  CrawlerAlreadyRunningError,
+  getCrawlerRunState,
+} from "./crawler-run-lock.js";
+
+let tempDir: string;
+let lockPath: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(path.join(os.tmpdir(), "mf-dashboard-crawler-lock-"));
+  lockPath = path.join(tempDir, "crawler-run.lock");
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("crawler run lock", () => {
+  test("returns idle state when no lock exists", async () => {
+    await expect(getCrawlerRunState({ lockPath })).resolves.toEqual({
+      running: false,
+      pid: null,
+      source: null,
+      startedAt: null,
+    });
+  });
+
+  test("reports running state while a lock is held and idle after release", async () => {
+    const lock = await acquireCrawlerRunLock("manual", { lockPath });
+
+    const state = await getCrawlerRunState({ lockPath });
+    expect(state.running).toBe(true);
+    expect(state.pid).toBe(process.pid);
+    expect(state.source).toBe("manual");
+    expect(state.startedAt).toBe(lock.record.startedAt);
+
+    await lock.release();
+
+    await expect(getCrawlerRunState({ lockPath })).resolves.toEqual({
+      running: false,
+      pid: null,
+      source: null,
+      startedAt: null,
+    });
+  });
+
+  test("rejects a second lock while the first run is active", async () => {
+    const lock = await acquireCrawlerRunLock("manual", { lockPath });
+
+    await expect(acquireCrawlerRunLock("scheduled", { lockPath })).rejects.toBeInstanceOf(
+      CrawlerAlreadyRunningError,
+    );
+
+    await lock.release();
+  });
+
+  test("clears a stale lock when its process is gone", async () => {
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        id: "stale-lock",
+        pid: 999_999,
+        source: "scheduled",
+        startedAt: new Date().toISOString(),
+      }),
+    );
+
+    await expect(getCrawlerRunState({ lockPath, pidExists: () => false })).resolves.toEqual({
+      running: false,
+      pid: null,
+      source: null,
+      startedAt: null,
+    });
+
+    const lock = await acquireCrawlerRunLock("manual", { lockPath });
+    expect(lock.record.source).toBe("manual");
+    await lock.release();
+  });
+
+  test("clears a stale lock even when its recorded process still exists", async () => {
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        id: "stale-lock",
+        pid: process.pid,
+        source: "manual",
+        startedAt: new Date(Date.now() - 2_000).toISOString(),
+      }),
+    );
+
+    await expect(
+      getCrawlerRunState({ lockPath, pidExists: () => true, staleMs: 1_000 }),
+    ).resolves.toEqual({
+      running: false,
+      pid: null,
+      source: null,
+      startedAt: null,
+    });
+
+    const lock = await acquireCrawlerRunLock("scheduled", { lockPath });
+    expect(lock.record.source).toBe("scheduled");
+    await lock.release();
+  });
+
+  test("clears a lock when the recorded PID was reused by a restarted process", async () => {
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        id: "stale-lock",
+        pid: process.pid,
+        pidStartedAt: "old-process-start",
+        source: "manual",
+        startedAt: new Date().toISOString(),
+      }),
+    );
+
+    await expect(
+      getCrawlerRunState({
+        getPidStartedAt: () => "new-process-start",
+        lockPath,
+        pidExists: () => true,
+        staleMs: 24 * 60 * 60 * 1000,
+      }),
+    ).resolves.toEqual({
+      running: false,
+      pid: null,
+      source: null,
+      startedAt: null,
+    });
+
+    const lock = await acquireCrawlerRunLock("scheduled", { lockPath });
+    expect(lock.record.source).toBe("scheduled");
+    await lock.release();
+  });
+
+  test("does not remove a replacement lock when stale cleanup races", async () => {
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        id: "stale-lock",
+        pid: 123,
+        source: "manual",
+        startedAt: new Date(Date.now() - 120_000).toISOString(),
+      }),
+    );
+
+    const replacement = {
+      id: "replacement-lock",
+      pid: process.pid,
+      pidStartedAt: "current-process-start",
+      source: "scheduled",
+      startedAt: new Date().toISOString(),
+    };
+    let replaced = false;
+
+    const state = await getCrawlerRunState({
+      getPidStartedAt: () => "current-process-start",
+      lockPath,
+      pidExists: () => {
+        if (!replaced) {
+          writeFileSync(lockPath, JSON.stringify(replacement));
+          replaced = true;
+        }
+        return true;
+      },
+      staleMs: 60_000,
+    });
+
+    expect(state).toEqual({
+      running: true,
+      pid: process.pid,
+      source: "scheduled",
+      startedAt: replacement.startedAt,
+    });
+  });
+
+  test("treats a fresh invalid lock as running", async () => {
+    await writeFile(lockPath, "");
+
+    const state = await getCrawlerRunState({ lockPath });
+    expect(state.running).toBe(true);
+    expect(state.pid).toBeNull();
+    expect(state.source).toBeNull();
+    expect(state.startedAt).not.toBeNull();
+
+    await expect(acquireCrawlerRunLock("manual", { lockPath })).rejects.toBeInstanceOf(
+      CrawlerAlreadyRunningError,
+    );
+  });
+});

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -1,0 +1,287 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { mkdir, open, readFile, rm, stat } from "node:fs/promises";
+import path from "node:path";
+
+const DEFAULT_LOCK_PATH = path.resolve(import.meta.dirname, "../../../data/crawler-run.lock");
+const DEFAULT_MAX_WAIT_MINUTES = 20;
+const LOCK_STALE_BUFFER_MINUTES = 100;
+
+export interface CrawlerRunState {
+  running: boolean;
+  pid: number | null;
+  source: string | null;
+  startedAt: string | null;
+}
+
+interface CrawlerRunLockRecord {
+  id: string;
+  pid: number;
+  pidStartedAt: string | null;
+  source: string;
+  startedAt: string;
+}
+
+interface CrawlerRunLockOptions {
+  lockPath?: string;
+  getPidStartedAt?: (pid: number) => string | null;
+  pidExists?: (pid: number) => boolean;
+  staleMs?: number;
+}
+
+export class CrawlerAlreadyRunningError extends Error {
+  constructor(readonly state: CrawlerRunState) {
+    super("Crawler is already running");
+    this.name = "CrawlerAlreadyRunningError";
+  }
+}
+
+interface CrawlerRunLock {
+  record: CrawlerRunLockRecord;
+  release: () => Promise<void>;
+}
+
+function defaultPidExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function getDefaultStaleMs(): number {
+  const maxWaitMinutes = Number(process.env.MAX_WAIT_MINUTES) || DEFAULT_MAX_WAIT_MINUTES;
+  return (maxWaitMinutes + LOCK_STALE_BUFFER_MINUTES) * 60 * 1000;
+}
+
+function getLinuxPidStartedAt(pid: number): string | null {
+  try {
+    const statContent = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const processNameEnd = statContent.lastIndexOf(")");
+    if (processNameEnd === -1) {
+      return null;
+    }
+
+    const fields = statContent
+      .slice(processNameEnd + 2)
+      .trim()
+      .split(/\s+/);
+    return fields[19] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function getOptions(options: CrawlerRunLockOptions = {}) {
+  return {
+    getPidStartedAt: options.getPidStartedAt ?? getLinuxPidStartedAt,
+    lockPath: options.lockPath ?? DEFAULT_LOCK_PATH,
+    pidExists: options.pidExists ?? defaultPidExists,
+    staleMs: options.staleMs ?? getDefaultStaleMs(),
+  };
+}
+
+function toRunState(record: CrawlerRunLockRecord): CrawlerRunState {
+  return {
+    running: true,
+    pid: record.pid,
+    source: record.source,
+    startedAt: record.startedAt,
+  };
+}
+
+function isExpired(startedAt: string, staleMs: number): boolean {
+  const startedAtMs = Date.parse(startedAt);
+  return Number.isNaN(startedAtMs) || Date.now() - startedAtMs > staleMs;
+}
+
+async function readLockRecord(lockPath: string): Promise<CrawlerRunLockRecord | null> {
+  try {
+    const raw = await readFile(lockPath, "utf8");
+    let parsed: Partial<CrawlerRunLockRecord>;
+    try {
+      parsed = JSON.parse(raw) as Partial<CrawlerRunLockRecord>;
+    } catch {
+      return null;
+    }
+
+    const pidStartedAt =
+      parsed.pidStartedAt === undefined || parsed.pidStartedAt === null
+        ? null
+        : parsed.pidStartedAt;
+
+    if (
+      typeof parsed.id !== "string" ||
+      typeof parsed.pid !== "number" ||
+      (pidStartedAt !== null && typeof pidStartedAt !== "string") ||
+      typeof parsed.source !== "string" ||
+      typeof parsed.startedAt !== "string"
+    ) {
+      return null;
+    }
+
+    return {
+      id: parsed.id,
+      pid: parsed.pid,
+      pidStartedAt,
+      source: parsed.source,
+      startedAt: parsed.startedAt,
+    };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+}
+
+function isStaleLock(
+  record: CrawlerRunLockRecord,
+  options: ReturnType<typeof getOptions>,
+): boolean {
+  if (!options.pidExists(record.pid)) {
+    return true;
+  }
+
+  if (record.pidStartedAt) {
+    const currentPidStartedAt = options.getPidStartedAt(record.pid);
+    if (currentPidStartedAt && currentPidStartedAt !== record.pidStartedAt) {
+      return true;
+    }
+  }
+
+  return isExpired(record.startedAt, options.staleMs);
+}
+
+async function removeStaleLockIfCurrent(
+  lockPath: string,
+  record: CrawlerRunLockRecord | null,
+  staleMtimeMs?: number,
+): Promise<boolean> {
+  try {
+    const current = await readLockRecord(lockPath);
+
+    if (record) {
+      if (current?.id !== record.id) {
+        return false;
+      }
+    } else {
+      if (current) {
+        return false;
+      }
+
+      if (staleMtimeMs !== undefined) {
+        const stats = await stat(lockPath);
+        if (stats.mtimeMs !== staleMtimeMs) {
+          return false;
+        }
+      }
+    }
+
+    await rm(lockPath, { force: true });
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw err;
+  }
+}
+
+export async function getCrawlerRunState(
+  options: CrawlerRunLockOptions = {},
+): Promise<CrawlerRunState> {
+  const resolved = getOptions(options);
+  const record = await readLockRecord(resolved.lockPath);
+
+  if (!record) {
+    try {
+      const stats = await stat(resolved.lockPath);
+      if (Date.now() - stats.mtimeMs > resolved.staleMs) {
+        if (await removeStaleLockIfCurrent(resolved.lockPath, record, stats.mtimeMs)) {
+          return { running: false, pid: null, source: null, startedAt: null };
+        }
+        return getCrawlerRunState(options);
+      }
+
+      return {
+        running: true,
+        pid: null,
+        source: null,
+        startedAt: new Date(stats.mtimeMs).toISOString(),
+      };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw err;
+      }
+      return { running: false, pid: null, source: null, startedAt: null };
+    }
+  }
+
+  if (isStaleLock(record, resolved)) {
+    if (await removeStaleLockIfCurrent(resolved.lockPath, record)) {
+      return { running: false, pid: null, source: null, startedAt: null };
+    }
+    return getCrawlerRunState(options);
+  }
+
+  return toRunState(record);
+}
+
+export async function acquireCrawlerRunLock(
+  source: string,
+  options: CrawlerRunLockOptions = {},
+): Promise<CrawlerRunLock> {
+  const resolved = getOptions(options);
+  await mkdir(path.dirname(resolved.lockPath), { recursive: true });
+
+  const record: CrawlerRunLockRecord = {
+    id: randomUUID(),
+    pid: process.pid,
+    pidStartedAt: resolved.getPidStartedAt(process.pid),
+    source,
+    startedAt: new Date().toISOString(),
+  };
+
+  let file: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    file = await open(resolved.lockPath, "wx");
+    await file.writeFile(JSON.stringify(record));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw err;
+    }
+
+    const state = await getCrawlerRunState(options);
+    if (!state.running) {
+      return acquireCrawlerRunLock(source, options);
+    }
+    throw new CrawlerAlreadyRunningError(state);
+  } finally {
+    await file?.close();
+  }
+
+  return {
+    record,
+    release: async () => {
+      const current = await readLockRecord(resolved.lockPath);
+      if (current?.id === record.id) {
+        await rm(resolved.lockPath, { force: true });
+      }
+    },
+  };
+}
+
+export async function runWithCrawlerRunLock<T>(
+  source: string,
+  task: () => Promise<T>,
+  options: CrawlerRunLockOptions = {},
+): Promise<T> {
+  const lock = await acquireCrawlerRunLock(source, options);
+  try {
+    return await task();
+  } finally {
+    await lock.release();
+  }
+}

--- a/apps/crawler/src/deployment-config.test.ts
+++ b/apps/crawler/src/deployment-config.test.ts
@@ -9,7 +9,9 @@ const readRepositoryFile = (filePath: string) =>
   readFileSync(path.join(repositoryRoot, filePath), "utf8");
 
 const compose = readRepositoryFile("compose.yml");
+const crawlerCrontab = readRepositoryFile("docker/crawler/crontab");
 const crawlerDockerfile = readRepositoryFile("docker/crawler/Dockerfile");
+const crawlerEntrypoint = readRepositoryFile("docker/crawler/entrypoint.sh");
 const dockerignore = readRepositoryFile(".dockerignore");
 const envExample = readRepositoryFile(".env.example");
 const terraform = readRepositoryFile("terraform/main.tf");
@@ -116,6 +118,21 @@ describe("Deployment configuration", () => {
     expect(crawlerDockerfile).toContain("playwright install --with-deps chromium");
     expect(crawlerDockerfile).not.toContain("playwright install --with-deps firefox");
     expect(crawlerDockerfile).not.toContain("playwright install --with-deps webkit");
+  });
+
+  test("connects the web refresh action to the crawler trigger server", () => {
+    const webSection = compose.match(/  web:\n[\s\S]*?\n\n  cloudflared:/)?.[0] ?? "";
+    const crawlerSection = compose.match(/  crawler:\n[\s\S]*?\n\nsecrets:/)?.[0] ?? "";
+
+    expect(webSection).toContain("CRAWLER_URL: http://crawler:8766");
+    expect(crawlerSection).toContain('- "8766"');
+    expect(crawlerDockerfile).toContain(
+      'ENTRYPOINT ["/usr/bin/tini", "--", "/app/docker/crawler/entrypoint.sh"]',
+    );
+    expect(crawlerEntrypoint).toContain("node --import tsx src/server.ts");
+    expect(crawlerEntrypoint).toContain("supercronic /app/docker/crawler/crontab");
+    expect(crawlerCrontab).toContain("CRAWLER_RUN_SOURCE=scheduled node --import tsx src/index.ts");
+    expect(crawlerCrontab).not.toContain("pnpm");
   });
 
   test("stores crawler auth state outside the web data mount", () => {

--- a/apps/crawler/src/index.ts
+++ b/apps/crawler/src/index.ts
@@ -1,57 +1,18 @@
-import { closeDb } from "@mf-dashboard/db";
-import {
-  handleCrawlerFailure,
-  runAnalyticsPhase,
-  runAuthPhase,
-  runCashFlowHistoryPhase,
-  runCleanupPhase,
-  runInstitutionCategoryPhase,
-  runLoadPhase,
-  runNotificationPhase,
-  runSavePhase,
-  runScrapePhase,
-  runSetupPhase,
-  type CrawlerRuntime,
-} from "./crawler-phases.js";
-import { error, info } from "./logger.js";
-import { createGroupScope } from "./scrapers/group.js";
-import { notifyWebRefresh } from "./web-refresh.js";
+import { CrawlerAlreadyRunningError, runWithCrawlerRunLock } from "./crawler-run-lock.js";
+import { error, warn } from "./logger.js";
+import { runCrawler } from "./run.js";
 
 async function main() {
-  const config = runLoadPhase();
-  let runtime: CrawlerRuntime | null = null;
-
   try {
-    runtime = await runSetupPhase(config);
-    await runAuthPhase(runtime.page, runtime.context);
-
-    await using groupScope = await createGroupScope(runtime.page);
-    const scrapeResult = await runScrapePhase(runtime.page, config);
-    await runSavePhase(runtime.db, scrapeResult);
-    await runCleanupPhase(runtime.db, scrapeResult.groupDataList, config);
-    await runInstitutionCategoryPhase(runtime.db, runtime.page);
-    await runCashFlowHistoryPhase(runtime.db, runtime.page, config);
-    await runAnalyticsPhase(runtime.db, scrapeResult.groupDataList);
-    await runNotificationPhase(scrapeResult.groupDataList, groupScope.originalGroup);
-
-    try {
-      await notifyWebRefresh();
-    } catch (err) {
-      error("Failed to refresh web cache:", err);
-    }
-
-    info("Completed!");
+    await runWithCrawlerRunLock(process.env.CRAWLER_RUN_SOURCE ?? "cli", runCrawler);
   } catch (err) {
-    await handleCrawlerFailure(err, runtime?.page, config);
-    process.exitCode = 1;
-  } finally {
-    try {
-      if (runtime) {
-        await runtime.browser.close();
-      }
-    } finally {
-      closeDb();
+    if (err instanceof CrawlerAlreadyRunningError) {
+      warn("Crawler is already running; skipped this run");
+      return;
     }
+
+    error("Crawler failed:", err);
+    process.exitCode = 1;
   }
 }
 

--- a/apps/crawler/src/run.ts
+++ b/apps/crawler/src/run.ts
@@ -1,0 +1,56 @@
+import { closeDb } from "@mf-dashboard/db";
+import {
+  handleCrawlerFailure,
+  runAnalyticsPhase,
+  runAuthPhase,
+  runCashFlowHistoryPhase,
+  runCleanupPhase,
+  runInstitutionCategoryPhase,
+  runLoadPhase,
+  runNotificationPhase,
+  runSavePhase,
+  runScrapePhase,
+  runSetupPhase,
+  type CrawlerRuntime,
+} from "./crawler-phases.js";
+import { error, info } from "./logger.js";
+import { createGroupScope } from "./scrapers/group.js";
+import { notifyWebRefresh } from "./web-refresh.js";
+
+export async function runCrawler(): Promise<void> {
+  const config = runLoadPhase();
+  let runtime: CrawlerRuntime | null = null;
+
+  try {
+    runtime = await runSetupPhase(config);
+    await runAuthPhase(runtime.page, runtime.context);
+
+    await using groupScope = await createGroupScope(runtime.page);
+    const scrapeResult = await runScrapePhase(runtime.page, config);
+    await runSavePhase(runtime.db, scrapeResult);
+    await runCleanupPhase(runtime.db, scrapeResult.groupDataList, config);
+    await runInstitutionCategoryPhase(runtime.db, runtime.page);
+    await runCashFlowHistoryPhase(runtime.db, runtime.page, config);
+    await runAnalyticsPhase(runtime.db, scrapeResult.groupDataList);
+    await runNotificationPhase(scrapeResult.groupDataList, groupScope.originalGroup);
+
+    try {
+      await notifyWebRefresh();
+    } catch (err) {
+      error("Failed to refresh web cache:", err);
+    }
+
+    info("Completed!");
+  } catch (err) {
+    await handleCrawlerFailure(err, runtime?.page, config);
+    throw err;
+  } finally {
+    try {
+      if (runtime) {
+        await runtime.browser.close();
+      }
+    } finally {
+      closeDb();
+    }
+  }
+}

--- a/apps/crawler/src/server.test.ts
+++ b/apps/crawler/src/server.test.ts
@@ -1,0 +1,74 @@
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { CrawlerAlreadyRunningError, type CrawlerRunState } from "./crawler-run-lock.js";
+import { createCrawlerTriggerServer } from "./server.js";
+
+const runningState: CrawlerRunState = {
+  running: true,
+  pid: 123,
+  source: "manual",
+  startedAt: "2026-01-01T00:00:00.000Z",
+};
+
+const idleState: CrawlerRunState = {
+  running: false,
+  pid: null,
+  source: null,
+  startedAt: null,
+};
+
+let server: Server | null = null;
+
+afterEach(async () => {
+  if (!server) return;
+
+  await new Promise<void>((resolve, reject) => {
+    server?.close((err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+  server = null;
+});
+
+async function listen(testServer: Server): Promise<string> {
+  server = testServer;
+  await new Promise<void>((resolve) => server?.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+describe("crawler trigger server", () => {
+  test("returns crawler status", async () => {
+    const baseUrl = await listen(createCrawlerTriggerServer({ getState: async () => idleState }));
+
+    const res = await fetch(`${baseUrl}/status`);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual(idleState);
+  });
+
+  test("starts a manual run", async () => {
+    const startRun = vi.fn<() => Promise<CrawlerRunState>>(async () => runningState);
+    const baseUrl = await listen(createCrawlerTriggerServer({ startRun }));
+
+    const res = await fetch(`${baseUrl}/runs`, { method: "POST" });
+
+    expect(res.status).toBe(202);
+    await expect(res.json()).resolves.toEqual(runningState);
+    expect(startRun).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns conflict when a run is already active", async () => {
+    const startRun = vi.fn<() => Promise<CrawlerRunState>>(async () => {
+      throw new CrawlerAlreadyRunningError(runningState);
+    });
+    const baseUrl = await listen(createCrawlerTriggerServer({ startRun }));
+
+    const res = await fetch(`${baseUrl}/runs`, { method: "POST" });
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual(runningState);
+  });
+});

--- a/apps/crawler/src/server.ts
+++ b/apps/crawler/src/server.ts
@@ -1,0 +1,107 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { pathToFileURL } from "node:url";
+import {
+  acquireCrawlerRunLock,
+  CrawlerAlreadyRunningError,
+  getCrawlerRunState,
+  type CrawlerRunState,
+} from "./crawler-run-lock.js";
+import { error, info } from "./logger.js";
+
+const DEFAULT_PORT = 8766;
+
+interface CrawlerTriggerServerOptions {
+  getState?: () => Promise<CrawlerRunState>;
+  startRun?: () => Promise<CrawlerRunState>;
+}
+
+function json(response: ServerResponse, status: number, body: unknown): void {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+function methodNotAllowed(response: ServerResponse): void {
+  response.writeHead(405, { allow: "GET, POST" });
+  response.end();
+}
+
+export async function startCrawlerRun(): Promise<CrawlerRunState> {
+  const lock = await acquireCrawlerRunLock("manual");
+  const state: CrawlerRunState = {
+    running: true,
+    pid: lock.record.pid,
+    source: lock.record.source,
+    startedAt: lock.record.startedAt,
+  };
+
+  void (async () => {
+    try {
+      const { runCrawler } = await import("./run.js");
+      await runCrawler();
+    } catch (err) {
+      error("Manual crawler run failed:", err);
+    } finally {
+      await lock.release();
+    }
+  })();
+
+  return state;
+}
+
+export function createCrawlerTriggerServer(options: CrawlerTriggerServerOptions = {}): Server {
+  const getState = options.getState ?? getCrawlerRunState;
+  const startRun = options.startRun ?? startCrawlerRun;
+
+  return createServer(async (request: IncomingMessage, response: ServerResponse) => {
+    try {
+      const url = new URL(request.url ?? "/", "http://localhost");
+
+      if (url.pathname === "/status") {
+        if (request.method !== "GET") {
+          methodNotAllowed(response);
+          return;
+        }
+
+        json(response, 200, await getState());
+        return;
+      }
+
+      if (url.pathname === "/runs") {
+        if (request.method !== "POST") {
+          methodNotAllowed(response);
+          return;
+        }
+
+        try {
+          json(response, 202, await startRun());
+        } catch (err) {
+          if (err instanceof CrawlerAlreadyRunningError) {
+            json(response, 409, err.state);
+            return;
+          }
+
+          throw err;
+        }
+        return;
+      }
+
+      json(response, 404, { error: "not found" });
+    } catch (err) {
+      error("Crawler trigger request failed:", err);
+      json(response, 500, { error: "internal server error" });
+      return;
+    }
+  });
+}
+
+export function listenCrawlerTriggerServer(port = DEFAULT_PORT): Server {
+  const server = createCrawlerTriggerServer();
+  server.listen(port, "0.0.0.0", () => {
+    info(`Crawler trigger server listening on ${port}`);
+  });
+  return server;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  listenCrawlerTriggerServer(Number(process.env.CRAWLER_PORT) || DEFAULT_PORT);
+}

--- a/apps/web/src/app/api/crawler/refresh/route.test.ts
+++ b/apps/web/src/app/api/crawler/refresh/route.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GET, POST } from "./route";
+
+const originalEnv = { ...process.env };
+const originalFetch = global.fetch;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function sameOriginPostRequest(headers: HeadersInit = {}): Request {
+  const requestHeaders = new Headers({
+    origin: "https://dashboard.example.com",
+    "x-forwarded-host": "dashboard.example.com",
+    "x-forwarded-proto": "https",
+  });
+  new Headers(headers).forEach((value, key) => requestHeaders.set(key, value));
+
+  return new Request("http://web:8765/api/crawler/refresh/", {
+    method: "POST",
+    headers: requestHeaders,
+  });
+}
+
+describe("/api/crawler/refresh/", () => {
+  beforeEach(() => {
+    process.env = { ...originalEnv, CRAWLER_URL: "http://crawler:8766" };
+    global.fetch = vi.fn<typeof fetch>();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    global.fetch = originalFetch;
+  });
+
+  it("returns unavailable when crawler URL is not configured", async () => {
+    delete process.env.CRAWLER_URL;
+
+    const res = await GET();
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({ available: false, running: false });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("proxies crawler status", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ running: true, source: "manual", startedAt: "2026-01-01T00:00:00.000Z" }),
+    );
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://crawler:8766/status",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+    await expect(res.json()).resolves.toEqual({
+      available: true,
+      running: true,
+      source: "manual",
+      startedAt: "2026-01-01T00:00:00.000Z",
+    });
+  });
+
+  it("starts a crawler run through the crawler service", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ running: true }, 202));
+
+    const res = await POST(sameOriginPostRequest());
+
+    expect(res.status).toBe(202);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://crawler:8766/runs",
+      expect.objectContaining({ method: "POST", cache: "no-store" }),
+    );
+    await expect(res.json()).resolves.toEqual({ available: true, running: true });
+  });
+
+  it("preserves conflict response when crawler is already running", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ running: true, source: "scheduled" }, 409),
+    );
+
+    const res = await POST(sameOriginPostRequest());
+
+    expect(res.status).toBe(409);
+    await expect(res.json()).resolves.toEqual({
+      available: true,
+      running: true,
+      source: "scheduled",
+    });
+  });
+
+  it("rejects a crawler run from a cross-site origin", async () => {
+    const res = await POST(sameOriginPostRequest({ origin: "https://attacker.example" }));
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid origin" });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects a crawler run without an origin header", async () => {
+    const res = await POST(
+      new Request("https://dashboard.example.com/api/crawler/refresh/", { method: "POST" }),
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid origin" });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("returns unavailable when crawler service cannot be reached", async () => {
+    vi.mocked(global.fetch).mockRejectedValueOnce(new Error("connection refused"));
+
+    const res = await GET();
+
+    expect(res.status).toBe(503);
+    await expect(res.json()).resolves.toEqual({ available: false, running: false });
+  });
+});

--- a/apps/web/src/app/api/crawler/refresh/route.ts
+++ b/apps/web/src/app/api/crawler/refresh/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const REQUEST_TIMEOUT_MS = 5_000;
+
+function readForwardedHeader(request: Request, name: string): string | null {
+  return request.headers.get(name)?.split(",")[0]?.trim() || null;
+}
+
+function isSameOriginRequest(request: Request): boolean {
+  const origin = request.headers.get("origin");
+  if (!origin) {
+    return false;
+  }
+
+  try {
+    const requestUrl = new URL(request.url);
+    const originUrl = new URL(origin);
+    const forwardedHost = readForwardedHeader(request, "x-forwarded-host");
+    const forwardedProto = readForwardedHeader(request, "x-forwarded-proto");
+    const host = forwardedHost ?? request.headers.get("host") ?? requestUrl.host;
+    const protocol = forwardedProto ? `${forwardedProto}:` : requestUrl.protocol;
+
+    return originUrl.protocol === protocol && originUrl.host === host;
+  } catch {
+    return false;
+  }
+}
+
+function getCrawlerUrl(): string | null {
+  const crawlerUrl = process.env.CRAWLER_URL?.trim();
+  if (!crawlerUrl) {
+    return null;
+  }
+
+  return crawlerUrl.replace(/\/+$/, "");
+}
+
+async function proxyCrawlerRequest(path: "/status" | "/runs", init?: RequestInit) {
+  const crawlerUrl = getCrawlerUrl();
+  if (!crawlerUrl) {
+    return NextResponse.json({ available: false, running: false }, { status: 503 });
+  }
+
+  try {
+    const res = await fetch(`${crawlerUrl}${path}`, {
+      ...init,
+      cache: "no-store",
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+
+    return NextResponse.json(
+      {
+        available: true,
+        ...body,
+      },
+      { status: res.status },
+    );
+  } catch {
+    return NextResponse.json({ available: false, running: false }, { status: 503 });
+  }
+}
+
+export async function GET() {
+  return proxyCrawlerRequest("/status");
+}
+
+export async function POST(request: Request) {
+  if (!isSameOriginRequest(request)) {
+    return NextResponse.json({ error: "Invalid origin" }, { status: 403 });
+  }
+
+  return proxyCrawlerRequest("/runs", { method: "POST" });
+}

--- a/apps/web/src/components/layout/action-icons.stories.tsx
+++ b/apps/web/src/components/layout/action-icons.stories.tsx
@@ -8,6 +8,12 @@ const meta = {
   tags: ["autodocs"],
   parameters: {
     layout: "centered",
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: "/",
+      },
+    },
   },
 } satisfies Meta<typeof ActionIcons>;
 

--- a/apps/web/src/components/layout/action-icons.test.tsx
+++ b/apps/web/src/components/layout/action-icons.test.tsx
@@ -1,11 +1,39 @@
-import { render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatDateTime } from "../../lib/format";
 import { ActionIcons } from "./action-icons";
 
 const originalEnv = { ...process.env };
+const originalFetch = global.fetch;
+const { refreshMock, routerMock } = vi.hoisted(() => {
+  const refreshMock = vi.fn<() => void>();
+  return {
+    refreshMock,
+    routerMock: { refresh: refreshMock },
+  };
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => routerMock,
+}));
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  refreshMock.mockReset();
+  global.fetch = vi
+    .fn<typeof fetch>()
+    .mockResolvedValue(jsonResponse({ available: true, running: false }));
+});
 
 afterEach(() => {
   process.env = { ...originalEnv };
+  global.fetch = originalFetch;
 });
 
 describe("ActionIcons", () => {
@@ -16,5 +44,102 @@ describe("ActionIcons", () => {
     render(<ActionIcons variant="header" />);
 
     expect(screen.queryByLabelText("ワークフローを実行")).toBeNull();
+  });
+
+  it("starts a crawler refresh from the header refresh button", async () => {
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(jsonResponse({ available: true, running: false }))
+      .mockResolvedValueOnce(jsonResponse({ available: true, running: true }, 202));
+
+    render(<ActionIcons variant="header" />);
+
+    const refreshButton = screen.getByRole("button", { name: "金融機関データを更新" });
+    await waitFor(() => expect((refreshButton as HTMLButtonElement).disabled).toBe(false));
+
+    fireEvent.click(refreshButton);
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith("/api/crawler/refresh/", { method: "POST" }),
+    );
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes the dashboard after the crawler run finishes", async () => {
+    const intervalCallbacks: Array<() => unknown> = [];
+    const setIntervalSpy = vi.spyOn(window, "setInterval").mockImplementation((handler) => {
+      if (typeof handler === "function") {
+        intervalCallbacks.push(handler as () => unknown);
+      }
+      return 1 as unknown as ReturnType<typeof window.setInterval>;
+    });
+    const clearIntervalSpy = vi.spyOn(window, "clearInterval").mockImplementation(() => undefined);
+
+    try {
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce(jsonResponse({ available: true, running: false }))
+        .mockResolvedValueOnce(jsonResponse({ available: true, running: true }, 202))
+        .mockResolvedValueOnce(jsonResponse({ available: true, running: false }));
+
+      render(<ActionIcons variant="header" />);
+
+      const refreshButton = screen.getByRole("button", { name: "金融機関データを更新" });
+      await waitFor(() => expect((refreshButton as HTMLButtonElement).disabled).toBe(false));
+
+      fireEvent.click(refreshButton);
+
+      await waitFor(() =>
+        expect(global.fetch).toHaveBeenCalledWith("/api/crawler/refresh/", { method: "POST" }),
+      );
+      expect(refreshMock).not.toHaveBeenCalled();
+
+      await act(async () => {
+        await intervalCallbacks[0]?.();
+      });
+
+      await waitFor(() => expect(refreshMock).toHaveBeenCalledTimes(1));
+    } finally {
+      setIntervalSpy.mockRestore();
+      clearIntervalSpy.mockRestore();
+    }
+  });
+
+  it("disables the header refresh button while the crawler is running", async () => {
+    const startedAt = "2026-01-01T00:00:00.000Z";
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ available: true, running: true, source: "scheduled", startedAt }),
+    );
+
+    render(<ActionIcons variant="header" />);
+
+    const refreshButton = screen.getByRole("button", { name: "金融機関データを更新" });
+    await waitFor(() =>
+      expect(refreshButton.getAttribute("title")).toBe(
+        `更新中（開始: ${formatDateTime(startedAt)}）`,
+      ),
+    );
+    expect((refreshButton as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(refreshButton);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it("disables the header refresh button when the crawler service is unavailable", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ available: false, running: false }, 503),
+    );
+
+    render(<ActionIcons variant="header" />);
+
+    const refreshButton = screen.getByRole("button", { name: "金融機関データを更新" });
+    await waitFor(() => expect(refreshButton.getAttribute("title")).toBe("更新サービス未接続"));
+    expect((refreshButton as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("does not render the refresh button in the mobile sidebar actions", () => {
+    render(<ActionIcons variant="sidebar" />);
+
+    expect(screen.queryByLabelText("金融機関データを更新")).toBeNull();
   });
 });

--- a/apps/web/src/components/layout/action-icons.tsx
+++ b/apps/web/src/components/layout/action-icons.tsx
@@ -1,14 +1,45 @@
 "use client";
 
 import { mfUrls } from "@mf-dashboard/meta/urls";
-import { Home, Code2, HelpCircle } from "lucide-react";
-import type { ReactNode } from "react";
+import { Home, Code2, HelpCircle, RefreshCw } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { formatDateTime } from "../../lib/format";
 import { Dialog, DialogTrigger, DialogContent, DialogTitle, DialogDescription } from "../ui/dialog";
 import { IconButton } from "../ui/icon-button";
+
+const STATUS_POLL_INTERVAL_MS = 15_000;
 
 interface ActionIconsProps {
   variant: "header" | "sidebar";
   notifications?: ReactNode;
+}
+
+interface CrawlerRefreshStatus {
+  available: boolean;
+  running: boolean;
+  startedAt: string | null;
+}
+
+interface CrawlerRefreshButtonState extends CrawlerRefreshStatus {
+  isPending: boolean;
+}
+
+const unavailableStatus: CrawlerRefreshStatus = {
+  available: false,
+  running: false,
+  startedAt: null,
+};
+
+async function readCrawlerRefreshStatus(): Promise<CrawlerRefreshStatus> {
+  const res = await fetch("/api/crawler/refresh/", { cache: "no-store" });
+  const body = (await res.json().catch(() => ({}))) as Partial<CrawlerRefreshStatus>;
+
+  return {
+    available: res.ok && body.available !== false,
+    running: Boolean(body.running),
+    startedAt: typeof body.startedAt === "string" ? body.startedAt : null,
+  };
 }
 
 export function ActionIcons({ variant, notifications }: ActionIconsProps) {
@@ -26,10 +57,96 @@ export function ActionIcons({ variant, notifications }: ActionIconsProps) {
   return (
     <div className="flex items-center gap-1">
       {notifications}
+      <RefreshButton iconSize={iconSize} />
       <HomeButton iconSize={iconSize} />
       <GitHubButton iconSize={iconSize} className="hidden lg:block" />
       <HelpButton iconSize={iconSize} className="hidden lg:block" />
     </div>
+  );
+}
+
+function RefreshButton({ iconSize }: { iconSize: string }) {
+  const router = useRouter();
+  const wasRunningRef = useRef(false);
+  const [state, setState] = useState<CrawlerRefreshButtonState>({
+    ...unavailableStatus,
+    isPending: true,
+  });
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function updateStatus() {
+      try {
+        const nextStatus = await readCrawlerRefreshStatus();
+        if (isMounted) {
+          setState({ ...nextStatus, isPending: false });
+          if (nextStatus.available && wasRunningRef.current && !nextStatus.running) {
+            router.refresh();
+          }
+          wasRunningRef.current = nextStatus.running;
+        }
+      } catch {
+        if (isMounted) {
+          setState({ ...unavailableStatus, isPending: false });
+          wasRunningRef.current = false;
+        }
+      }
+    }
+
+    void updateStatus();
+    const intervalId = window.setInterval(updateStatus, STATUS_POLL_INTERVAL_MS);
+
+    return () => {
+      isMounted = false;
+      window.clearInterval(intervalId);
+    };
+  }, [router]);
+
+  async function startRefresh() {
+    if (!state.available || state.running || state.isPending) {
+      return;
+    }
+
+    setState((prev) => ({ ...prev, running: true, isPending: true }));
+
+    try {
+      const res = await fetch("/api/crawler/refresh/", { method: "POST" });
+      const body = (await res.json().catch(() => ({}))) as Partial<CrawlerRefreshStatus>;
+
+      if (!res.ok && res.status !== 409) {
+        setState({ ...unavailableStatus, isPending: false });
+        return;
+      }
+
+      const running = Boolean(body.running ?? true);
+      wasRunningRef.current ||= running;
+      setState({
+        available: body.available !== false,
+        running,
+        startedAt: typeof body.startedAt === "string" ? body.startedAt : null,
+        isPending: false,
+      });
+    } catch {
+      setState({ ...unavailableStatus, isPending: false });
+    }
+  }
+
+  const isBusy = state.isPending || state.running;
+  const isDisabled = isBusy || !state.available;
+  let title = state.available ? "更新" : "更新サービス未接続";
+  if (state.running) {
+    title = state.startedAt ? `更新中（開始: ${formatDateTime(state.startedAt)}）` : "更新中";
+  }
+
+  return (
+    <IconButton
+      icon={<RefreshCw className={`${iconSize} ${isBusy ? "animate-spin" : ""}`} />}
+      onClick={() => void startRefresh()}
+      ariaLabel="金融機関データを更新"
+      disabled={isDisabled}
+      title={title}
+    />
   );
 }
 

--- a/apps/web/src/components/ui/icon-button.tsx
+++ b/apps/web/src/components/ui/icon-button.tsx
@@ -8,9 +8,11 @@ interface IconButtonProps {
   onClick?: () => void;
   ariaLabel: string;
   className?: string;
+  disabled?: boolean;
   type?: "button" | "submit" | "reset";
   href?: string;
   isExternal?: boolean;
+  title?: string;
 }
 
 export function IconButton({
@@ -18,12 +20,15 @@ export function IconButton({
   onClick,
   ariaLabel,
   className,
+  disabled = false,
   type = "button",
   href,
   isExternal = false,
+  title,
 }: IconButtonProps) {
   const baseClassName = cn(
     "p-2 rounded-lg hover:bg-muted hover:opacity-100 transition-colors cursor-pointer",
+    disabled && "cursor-not-allowed opacity-50 hover:bg-transparent",
     className,
   );
 
@@ -35,6 +40,7 @@ export function IconButton({
         rel={isExternal ? "noopener noreferrer" : undefined}
         className={baseClassName}
         aria-label={ariaLabel}
+        title={title}
       >
         {icon}
       </Link>
@@ -42,7 +48,14 @@ export function IconButton({
   }
 
   return (
-    <button onClick={onClick} className={baseClassName} aria-label={ariaLabel} type={type}>
+    <button
+      onClick={onClick}
+      className={baseClassName}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      title={title}
+      type={type}
+    >
       {icon}
     </button>
   );

--- a/compose.yml
+++ b/compose.yml
@@ -21,6 +21,7 @@ services:
         NEXT_PUBLIC_SIMULATOR_PENSION_START_AGE: ${NEXT_PUBLIC_SIMULATOR_PENSION_START_AGE:-}
         NEXT_PUBLIC_SIMULATOR_MONTHLY_OTHER_INCOME: ${NEXT_PUBLIC_SIMULATOR_MONTHLY_OTHER_INCOME:-}
     environment:
+      CRAWLER_URL: http://crawler:8766
       REFRESH_TOKEN: ${REFRESH_TOKEN:-}
       TZ: Asia/Tokyo
     volumes:
@@ -73,6 +74,8 @@ services:
     volumes:
       - ./data:/app/data
       - crawler_auth_state:/app/crawler-state
+    expose:
+      - "8766"
     depends_on:
       - web
     restart: unless-stopped

--- a/docker/crawler/Dockerfile
+++ b/docker/crawler/Dockerfile
@@ -44,7 +44,8 @@ RUN package_manager=$(node -p "require('./package.json').packageManager") \
 COPY . .
 
 RUN mkdir -p /app/data /app/crawler-state \
-    && chmod 1777 /app/crawler-state
+    && chmod 1777 /app/crawler-state \
+    && chmod 0755 /app/docker/crawler/entrypoint.sh
 USER node
 
-ENTRYPOINT ["/usr/bin/tini", "--", "supercronic", "/app/docker/crawler/crontab"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/app/docker/crawler/entrypoint.sh"]

--- a/docker/crawler/crontab
+++ b/docker/crawler/crontab
@@ -1,2 +1,2 @@
-0 7  * * * cd /app && pnpm --filter @mf-dashboard/crawler start
-30 15 * * * cd /app && pnpm --filter @mf-dashboard/crawler start
+0 7  * * * cd /app/apps/crawler && CRAWLER_RUN_SOURCE=scheduled node --import tsx src/index.ts
+30 15 * * * cd /app/apps/crawler && CRAWLER_RUN_SOURCE=scheduled node --import tsx src/index.ts

--- a/docker/crawler/entrypoint.sh
+++ b/docker/crawler/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+(
+  cd /app/apps/crawler
+  exec node --import tsx src/server.ts
+) &
+server_pid=$!
+
+supercronic /app/docker/crawler/crontab &
+cron_pid=$!
+
+shutdown() {
+  trap - INT TERM
+  kill -TERM "$server_pid" "$cron_pid" 2>/dev/null || true
+  wait "$server_pid" 2>/dev/null || true
+  wait "$cron_pid" 2>/dev/null || true
+}
+
+trap 'shutdown; exit 130' INT
+trap 'shutdown; exit 143' TERM
+
+wait -n "$server_pid" "$cron_pid"
+status=$?
+shutdown
+exit "$status"

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,6 +1,6 @@
 # セットアップ
 
-ローカル PC で **Docker Compose** を使い、Next.js (web) / cloudflared / crawler の 3 サービスを常駐させる構成のセットアップ手順。crawler は **コンテナ内 cron** (supercronic) で JST 7:00 / 15:30 に走り、完了後 web の `/api/refresh/` を Bearer 認証付きで叩いて `revalidatePath` で全ルートを再生成する。
+ローカル PC で **Docker Compose** を使い、Next.js (web) / cloudflared / crawler の 3 サービスを常駐させる構成のセットアップ手順。crawler は **コンテナ内 cron** (supercronic) で JST 7:00 / 15:30 に走るほか、dashboard の更新ボタンから即時実行できる。完了後は web の `/api/refresh/` を Bearer 認証付きで叩いて `revalidatePath` で全ルートを再生成する。
 
 ## 必須要件
 
@@ -182,7 +182,7 @@ Terraform apply が成功し、`secrets/cloudflared-token` が作成されてか
 
 - **web** — Next.js を `next start --port 8765` で常駐。Docker image build 時は dashboard route を request-time rendering にし、起動後は volume 経由の本番 DB を読む
 - **cloudflared** — Compose secretとしてmountされた `secrets/cloudflared-token` でCloudflare Edgeに接続
-- **crawler** — Docker image の非rootユーザーで動作し、supercronic で `crontab` (`docker/crawler/crontab`) を回して、JST 7:00 / 15:30 に `pnpm --filter @mf-dashboard/crawler start` を起動。MoneyForward の browser session は crawler 専用 volume (`/app/crawler-state/auth-state.json`) に保存し、web から mount しない。crawler 自身が完了時に `WEB_URL/api/refresh/` へ `REFRESH_TOKEN` を Bearer 認証で POST して `revalidatePath` をトリガー (Docker bridge 内部のみ到達可能、外部は Cloudflare Access で保護)
+- **crawler** — Docker image の非rootユーザーで動作し、手動更新 API (`crawler:8766`) と supercronic を常駐。`crontab` (`docker/crawler/crontab`) により JST 7:00 / 15:30 に、または dashboard の更新ボタンから `pnpm --filter @mf-dashboard/crawler start` 相当の処理を起動する。MoneyForward の browser session は crawler 専用 volume (`/app/crawler-state/auth-state.json`) に保存し、web から mount しない。crawler 自身が完了時に `WEB_URL/api/refresh/` へ `REFRESH_TOKEN` を Bearer 認証で POST して `revalidatePath` をトリガー (Docker bridge 内部のみ到達可能、外部は Cloudflare Access で保護)
 
 スケジュールを変えたい場合は `docker/crawler/crontab` を編集して `docker compose build crawler` し直す。
 


### PR DESCRIPTION
## Summary
- Add a header refresh button that refreshes the current App Router payload
- Keep the refresh action out of the sidebar action row
- Update ActionIcons tests and Storybook router configuration

## Validation
- pnpm lint
- pnpm --filter @mf-dashboard/web test:unit
- pnpm --filter @mf-dashboard/web test:storybook
- UI runtime check with dev:demo on desktop and mobile widths