### PR TITLE
HIR-88: Clarify spending stability scoring

### DIFF
--- a/packages/db/src/queries/analytics.test.ts
+++ b/packages/db/src/queries/analytics.test.ts
@@ -59,6 +59,14 @@ function createMockMetrics(
   };
 }
 
+function createSpendingAnomalies(count: number): FullMetrics["spending"]["anomalies"] {
+  return Array.from({ length: count }, (_, index) => ({
+    category: `category-${index + 1}`,
+    amount: 100000 - index * 1000,
+    deviation: 3 - index * 0.1,
+  }));
+}
+
 describe("calculateHealthScore", () => {
   it("should return perfect score for ideal metrics", () => {
     const metrics = createMockMetrics({
@@ -147,17 +155,22 @@ describe("calculateHealthScore", () => {
     const anomaly0 = calculateHealthScore(createMockMetrics({ spending: { anomalies: [] } }));
     const anomaly1 = calculateHealthScore(
       createMockMetrics({
-        spending: { anomalies: [{ category: "a", amount: 100000, deviation: 3 }] },
+        spending: { anomalies: createSpendingAnomalies(1) },
       }),
     );
     const anomaly2 = calculateHealthScore(
       createMockMetrics({
-        spending: {
-          anomalies: [
-            { category: "a", amount: 100000, deviation: 3 },
-            { category: "b", amount: 80000, deviation: 2.5 },
-          ],
-        },
+        spending: { anomalies: createSpendingAnomalies(2) },
+      }),
+    );
+    const anomaly3 = calculateHealthScore(
+      createMockMetrics({
+        spending: { anomalies: createSpendingAnomalies(3) },
+      }),
+    );
+    const anomaly4 = calculateHealthScore(
+      createMockMetrics({
+        spending: { anomalies: createSpendingAnomalies(4) },
       }),
     );
 
@@ -167,6 +180,8 @@ describe("calculateHealthScore", () => {
     expect(get(anomaly0)).toBe(15);
     expect(get(anomaly1)).toBe(10);
     expect(get(anomaly2)).toBe(5);
+    expect(get(anomaly3)).toBe(0);
+    expect(get(anomaly4)).toBe(0);
   });
 
   it("should have 5 categories that sum to totalScore", () => {

--- a/packages/db/src/queries/analytics.ts
+++ b/packages/db/src/queries/analytics.ts
@@ -107,6 +107,8 @@ const INVESTMENT_CATEGORIES = [
   "暗号資産・FX・貴金属",
 ];
 const ANALYSIS_MONTHS = 12;
+const SPENDING_STABILITY_MAX_SCORE = 15;
+const SPENDING_STABILITY_ANOMALY_PENALTY = 5;
 
 // ============================================================================
 // データ収集
@@ -510,10 +512,10 @@ function scoreGrowth(monthlyGrowthRate: number): number {
 }
 
 function scoreSpendingStability(anomalyCount: number): number {
-  if (anomalyCount === 0) return 15;
-  if (anomalyCount === 1) return 10;
-  if (anomalyCount === 2) return 5;
-  return 0;
+  return Math.max(
+    0,
+    SPENDING_STABILITY_MAX_SCORE - anomalyCount * SPENDING_STABILITY_ANOMALY_PENALTY,
+  );
 }
 
 export function calculateHealthScore(
@@ -543,7 +545,7 @@ export function calculateHealthScore(
     {
       name: "支出安定性",
       score: scoreSpendingStability(metrics.spending.anomalies.length),
-      maxScore: 15,
+      maxScore: SPENDING_STABILITY_MAX_SCORE,
     },
   ];
   const totalScore = categories.reduce((sum, c) => sum + c.score, 0);


### PR DESCRIPTION
## Summary
- Confirmed spending stability is scored from spending anomaly count: 0 anomalies = 15, 1 = 10, 2 = 5, 3+ = 0.
- Refactored the scoring branch into constants/formula without changing behavior.
- Added boundary coverage for 3+ anomalies so 0/15 is explicit and regression-tested.

## Validation
- pnpm --filter @mf-dashboard/db test -- src/queries/analytics.test.ts
- pnpm --filter @mf-dashboard/db typecheck
- pnpm exec oxfmt --check packages/db/src/queries/analytics.ts packages/db/src/queries/analytics.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Spending Stability” health-score calculation to apply a consistent penalty for each spending anomaly.
  * Health scores now decrease predictably as anomalies increase and reach zero when three or more anomalies are detected.
  * Updated scoring coverage to include higher anomaly counts, improving confidence in reported health scores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->