### PR TITLE
HIR-91: Fix Vercel web output directory

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -2,5 +2,5 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "buildCommand": "cd ../.. && pnpm turbo build:demo --filter=@mf-dashboard/web...",
-  "outputDirectory": "out"
+  "outputDirectory": ".next"
 }


### PR DESCRIPTION
## Summary
- Point the web Vercel output directory at Next.js' default distDir, `.next`, instead of the static export `out` directory.
- Keep the existing demo build command and Turborepo outputs unchanged because `.next/**` is already included.

## Validation
- `pnpm turbo typecheck --filter=@mf-dashboard/web`
- `pnpm turbo build:demo --filter=@mf-dashboard/web...`
- Confirmed `apps/web/.next/routes-manifest.json` exists and `apps/web/out/routes-manifest.json` does not after the demo build.

Linear: HIR-91
