### PR TITLE
fix: make stale lock cleanup race-safe

### DIFF
--- a/apps/crawler/src/crawler-run-lock.test.ts
+++ b/apps/crawler/src/crawler-run-lock.test.ts
@@ -42,26 +42,33 @@ describe("crawler run lock", () => {
     });
   });
 
-  test("does not block acquisition during an idle status check", async () => {
-    let markStatusCheckingQuarantine: () => void;
-    const statusCheckingQuarantine = new Promise<void>((resolve) => {
-      markStatusCheckingQuarantine = resolve;
+  test("allows acquisition to wait for an idle status check", async () => {
+    let markStatusGuardAcquired: () => void;
+    const statusGuardAcquired = new Promise<void>((resolve) => {
+      markStatusGuardAcquired = resolve;
     });
     let finishStatusCheck!: () => void;
     const statusMayFinish = new Promise<void>((resolve) => {
       finishStatusCheck = resolve;
     });
     const statePromise = getCrawlerRunState({
-      beforeQuarantinedLockCheck: async () => {
-        markStatusCheckingQuarantine();
+      afterLockMutationGuardAcquired: async () => {
+        markStatusGuardAcquired();
         await statusMayFinish;
       },
       lockPath,
     });
-    await statusCheckingQuarantine;
+    await statusGuardAcquired;
 
-    const lock = await acquireCrawlerRunLock("manual", { lockPath });
-    await lock.release();
+    let markAcquisitionBlocked: () => void;
+    const acquisitionBlocked = new Promise<void>((resolve) => {
+      markAcquisitionBlocked = resolve;
+    });
+    const lockPromise = acquireCrawlerRunLock("manual", {
+      afterLockMutationGuardBlocked: async () => markAcquisitionBlocked(),
+      lockPath,
+    });
+    await acquisitionBlocked;
     finishStatusCheck();
 
     await expect(statePromise).resolves.toEqual({
@@ -70,7 +77,9 @@ describe("crawler run lock", () => {
       source: null,
       startedAt: null,
     });
+    const lock = await lockPromise;
     expect(lock.record.source).toBe("manual");
+    await lock.release();
   });
 
   test("acquires when a mutation guard was left without a lock", async () => {
@@ -332,12 +341,22 @@ describe("crawler run lock", () => {
       source: "scheduled",
       startedAt: new Date().toISOString(),
     };
+    let intrusion!: ReturnType<typeof acquireCrawlerRunLock>;
+    let intrusionSettled = false;
 
     const state = await getCrawlerRunState({
       afterStaleLockQuarantine: async () => {
-        await expect(acquireCrawlerRunLock("intruder", { lockPath })).rejects.toBeInstanceOf(
-          CrawlerAlreadyRunningError,
+        intrusion = acquireCrawlerRunLock("intruder", { lockPath });
+        void intrusion.then(
+          () => {
+            intrusionSettled = true;
+          },
+          () => {
+            intrusionSettled = true;
+          },
         );
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(intrusionSettled).toBe(false);
       },
       beforeStaleLockRemoval: async () => {
         await rm(lockPath);
@@ -346,6 +365,7 @@ describe("crawler run lock", () => {
       lockPath,
       pidExists: (pid) => pid === process.pid,
     });
+    await expect(intrusion).rejects.toBeInstanceOf(CrawlerAlreadyRunningError);
 
     expect(state).toEqual({
       running: true,
@@ -400,6 +420,86 @@ describe("crawler run lock", () => {
       CrawlerAlreadyRunningError,
     );
     await expect(readFile(lockPath, "utf8")).resolves.toBe(JSON.stringify(replacement));
+  });
+
+  test("clears a stale lock left quarantined by interrupted cleanup", async () => {
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        id: "stale-lock",
+        pid: 999_999,
+        source: "scheduled",
+        startedAt: new Date().toISOString(),
+      }),
+    );
+
+    await expect(
+      getCrawlerRunState({
+        afterStaleLockQuarantine: async () => {
+          throw new Error("interrupted cleanup");
+        },
+        lockPath,
+        pidExists: () => false,
+      }),
+    ).rejects.toThrow("interrupted cleanup");
+
+    await expect(getCrawlerRunState({ lockPath, pidExists: () => false })).resolves.toEqual({
+      running: false,
+      pid: null,
+      source: null,
+      startedAt: null,
+    });
+  });
+
+  test("allows acquisition to wait for status to remove a stale lock", async () => {
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        id: "stale-lock",
+        pid: 999_999,
+        source: "scheduled",
+        startedAt: new Date().toISOString(),
+      }),
+    );
+    let markCleanupGuardAcquired: () => void;
+    const cleanupGuardAcquired = new Promise<void>((resolve) => {
+      markCleanupGuardAcquired = resolve;
+    });
+    let finishCleanup!: () => void;
+    const cleanupMayFinish = new Promise<void>((resolve) => {
+      finishCleanup = resolve;
+    });
+    const statePromise = getCrawlerRunState({
+      afterLockMutationGuardAcquired: async () => {
+        markCleanupGuardAcquired();
+        await cleanupMayFinish;
+      },
+      lockPath,
+      pidExists: () => false,
+    });
+    await cleanupGuardAcquired;
+
+    let markAcquisitionBlocked: () => void;
+    const acquisitionBlocked = new Promise<void>((resolve) => {
+      markAcquisitionBlocked = resolve;
+    });
+    const lockPromise = acquireCrawlerRunLock("manual", {
+      afterLockMutationGuardBlocked: async () => markAcquisitionBlocked(),
+      lockPath,
+      pidExists: () => false,
+    });
+    await acquisitionBlocked;
+    finishCleanup();
+
+    await expect(statePromise).resolves.toEqual({
+      running: false,
+      pid: null,
+      source: null,
+      startedAt: null,
+    });
+    const lock = await lockPromise;
+    expect(lock.record.source).toBe("manual");
+    await lock.release();
   });
 
   test("treats a fresh invalid lock as running", async () => {

--- a/apps/crawler/src/crawler-run-lock.test.ts
+++ b/apps/crawler/src/crawler-run-lock.test.ts
@@ -31,6 +31,48 @@ describe("crawler run lock", () => {
     });
   });
 
+  test("returns idle state when the lock directory does not exist", async () => {
+    const missingDirectoryLockPath = path.join(tempDir, "missing", "crawler-run.lock");
+
+    await expect(getCrawlerRunState({ lockPath: missingDirectoryLockPath })).resolves.toEqual({
+      running: false,
+      pid: null,
+      source: null,
+      startedAt: null,
+    });
+  });
+
+  test("does not block acquisition during an idle status check", async () => {
+    let markStatusCheckingQuarantine: () => void;
+    const statusCheckingQuarantine = new Promise<void>((resolve) => {
+      markStatusCheckingQuarantine = resolve;
+    });
+    let finishStatusCheck!: () => void;
+    const statusMayFinish = new Promise<void>((resolve) => {
+      finishStatusCheck = resolve;
+    });
+    const statePromise = getCrawlerRunState({
+      beforeQuarantinedLockCheck: async () => {
+        markStatusCheckingQuarantine();
+        await statusMayFinish;
+      },
+      lockPath,
+    });
+    await statusCheckingQuarantine;
+
+    const lock = await acquireCrawlerRunLock("manual", { lockPath });
+    await lock.release();
+    finishStatusCheck();
+
+    await expect(statePromise).resolves.toEqual({
+      running: false,
+      pid: null,
+      source: null,
+      startedAt: null,
+    });
+    expect(lock.record.source).toBe("manual");
+  });
+
   test("acquires when a mutation guard was left without a lock", async () => {
     await writeFile(`${lockPath}.mutation`, "");
     await writeFile(

--- a/apps/crawler/src/crawler-run-lock.test.ts
+++ b/apps/crawler/src/crawler-run-lock.test.ts
@@ -31,6 +31,22 @@ describe("crawler run lock", () => {
     });
   });
 
+  test("acquires when a mutation guard was left without a lock", async () => {
+    await writeFile(`${lockPath}.mutation`, "");
+    await writeFile(
+      `${lockPath}.mutation-active-stale-owner`,
+      JSON.stringify({ pid: 999_999, pidStartedAt: null }),
+    );
+
+    const lock = await acquireCrawlerRunLock("manual", {
+      lockPath,
+      pidExists: (pid) => pid === process.pid,
+    });
+
+    expect(lock.record.source).toBe("manual");
+    await lock.release();
+  });
+
   test("reports running state while a lock is held and idle after release", async () => {
     const lock = await acquireCrawlerRunLock("manual", { lockPath });
 

--- a/apps/crawler/src/crawler-run-lock.test.ts
+++ b/apps/crawler/src/crawler-run-lock.test.ts
@@ -37,6 +37,14 @@ describe("crawler run lock", () => {
       `${lockPath}.mutation-active-stale-owner`,
       JSON.stringify({ pid: 999_999, pidStartedAt: null }),
     );
+    await writeFile(
+      `${lockPath}.mutation-owner-reused-pid`,
+      JSON.stringify({
+        createdAt: new Date(Date.now() - 120_000).toISOString(),
+        pid: process.pid,
+        pidStartedAt: null,
+      }),
+    );
 
     const lock = await acquireCrawlerRunLock("manual", {
       lockPath,
@@ -303,6 +311,44 @@ describe("crawler run lock", () => {
       source: "scheduled",
       startedAt: replacement.startedAt,
     });
+    await expect(readFile(lockPath, "utf8")).resolves.toBe(JSON.stringify(replacement));
+  });
+
+  test("recovers a replacement left quarantined by interrupted cleanup", async () => {
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        id: "stale-lock",
+        pid: 123,
+        source: "manual",
+        startedAt: new Date(Date.now() - 120_000).toISOString(),
+      }),
+    );
+
+    const replacement = {
+      id: "replacement-lock",
+      pid: process.pid,
+      source: "scheduled",
+      startedAt: new Date().toISOString(),
+    };
+
+    await expect(
+      getCrawlerRunState({
+        afterStaleLockQuarantine: async () => {
+          throw new Error("interrupted cleanup");
+        },
+        beforeStaleLockRemoval: async () => {
+          await rm(lockPath);
+          await writeFile(lockPath, JSON.stringify(replacement));
+        },
+        lockPath,
+        pidExists: (pid) => pid === process.pid,
+      }),
+    ).rejects.toThrow("interrupted cleanup");
+
+    await expect(acquireCrawlerRunLock("manual", { lockPath })).rejects.toBeInstanceOf(
+      CrawlerAlreadyRunningError,
+    );
     await expect(readFile(lockPath, "utf8")).resolves.toBe(JSON.stringify(replacement));
   });
 

--- a/apps/crawler/src/crawler-run-lock.test.ts
+++ b/apps/crawler/src/crawler-run-lock.test.ts
@@ -376,6 +376,49 @@ describe("crawler run lock", () => {
     await expect(readFile(lockPath, "utf8")).resolves.toBe(JSON.stringify(replacement));
   });
 
+  test("releases a replacement that finishes while quarantined", async () => {
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        id: "stale-lock",
+        pid: 999_999,
+        source: "scheduled",
+        startedAt: new Date().toISOString(),
+      }),
+    );
+    let replacementLock!: Awaited<ReturnType<typeof acquireCrawlerRunLock>>;
+    let releasePromise!: Promise<void>;
+    let releaseSettled = false;
+
+    await getCrawlerRunState({
+      afterStaleLockQuarantine: async () => {
+        releasePromise = replacementLock.release();
+        void releasePromise.then(
+          () => {
+            releaseSettled = true;
+          },
+          () => undefined,
+        );
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(releaseSettled).toBe(false);
+      },
+      beforeStaleLockCleanup: async () => {
+        await rm(lockPath);
+        replacementLock = await acquireCrawlerRunLock("replacement", { lockPath });
+      },
+      lockPath,
+      pidExists: (pid) => pid === process.pid,
+    });
+    await releasePromise;
+
+    await expect(getCrawlerRunState({ lockPath })).resolves.toEqual({
+      running: false,
+      pid: null,
+      source: null,
+      startedAt: null,
+    });
+  });
+
   test("recovers a replacement left quarantined by interrupted cleanup", async () => {
     await writeFile(
       lockPath,

--- a/apps/crawler/src/crawler-run-lock.test.ts
+++ b/apps/crawler/src/crawler-run-lock.test.ts
@@ -219,6 +219,47 @@ describe("crawler run lock", () => {
     );
   });
 
+  test("rejects acquisition while a raced replacement is quarantined", async () => {
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        id: "stale-lock",
+        pid: 123,
+        source: "manual",
+        startedAt: new Date(Date.now() - 120_000).toISOString(),
+      }),
+    );
+
+    const replacement = {
+      id: "replacement-lock",
+      pid: process.pid,
+      source: "scheduled",
+      startedAt: new Date().toISOString(),
+    };
+
+    const state = await getCrawlerRunState({
+      afterStaleLockQuarantine: async () => {
+        await expect(acquireCrawlerRunLock("intruder", { lockPath })).rejects.toBeInstanceOf(
+          CrawlerAlreadyRunningError,
+        );
+      },
+      beforeStaleLockRemoval: async () => {
+        await rm(lockPath);
+        await writeFile(lockPath, JSON.stringify(replacement));
+      },
+      lockPath,
+      pidExists: (pid) => pid === process.pid,
+    });
+
+    expect(state).toEqual({
+      running: true,
+      pid: process.pid,
+      source: "scheduled",
+      startedAt: replacement.startedAt,
+    });
+    await expect(readFile(lockPath, "utf8")).resolves.toBe(JSON.stringify(replacement));
+  });
+
   test("treats a fresh invalid lock as running", async () => {
     await writeFile(lockPath, "");
 

--- a/apps/crawler/src/crawler-run-lock.test.ts
+++ b/apps/crawler/src/crawler-run-lock.test.ts
@@ -76,6 +76,36 @@ describe("crawler run lock", () => {
     await lock.release();
   });
 
+  test("allows exactly one of two simultaneous acquisitions", async () => {
+    let publishedCount = 0;
+    let releasePublished: () => void;
+    const bothPublished = new Promise<void>((resolve) => {
+      releasePublished = resolve;
+    });
+    const options = {
+      afterLockMutationIntentPublished: async () => {
+        publishedCount += 1;
+        if (publishedCount === 2) {
+          releasePublished();
+        }
+        await bothPublished;
+      },
+      lockPath,
+    };
+    const results = await Promise.allSettled([
+      acquireCrawlerRunLock("manual", options),
+      acquireCrawlerRunLock("scheduled", options),
+    ]);
+    const acquired = results.filter((result) => result.status === "fulfilled");
+    const rejected = results.filter((result) => result.status === "rejected");
+
+    expect(acquired).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(rejected[0]?.reason).toBeInstanceOf(CrawlerAlreadyRunningError);
+
+    await acquired[0]?.value.release();
+  });
+
   test("clears a stale lock when its process is gone", async () => {
     await writeFile(
       lockPath,

--- a/apps/crawler/src/crawler-run-lock.test.ts
+++ b/apps/crawler/src/crawler-run-lock.test.ts
@@ -346,6 +346,14 @@ describe("crawler run lock", () => {
       }),
     ).rejects.toThrow("interrupted cleanup");
 
+    await expect(
+      getCrawlerRunState({ lockPath, pidExists: (pid) => pid === process.pid }),
+    ).resolves.toEqual({
+      running: true,
+      pid: process.pid,
+      source: "scheduled",
+      startedAt: replacement.startedAt,
+    });
     await expect(acquireCrawlerRunLock("manual", { lockPath })).rejects.toBeInstanceOf(
       CrawlerAlreadyRunningError,
     );

--- a/apps/crawler/src/crawler-run-lock.test.ts
+++ b/apps/crawler/src/crawler-run-lock.test.ts
@@ -1,5 +1,5 @@
 import { writeFileSync } from "node:fs";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
@@ -178,6 +178,45 @@ describe("crawler run lock", () => {
       source: "scheduled",
       startedAt: replacement.startedAt,
     });
+  });
+
+  test("preserves a replacement installed after the final stale check", async () => {
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        id: "stale-lock",
+        pid: 123,
+        source: "manual",
+        startedAt: new Date(Date.now() - 120_000).toISOString(),
+      }),
+    );
+
+    const replacement = {
+      id: "replacement-lock",
+      pid: process.pid,
+      source: "scheduled",
+      startedAt: new Date().toISOString(),
+    };
+
+    const state = await getCrawlerRunState({
+      beforeStaleLockRemoval: async () => {
+        await rm(lockPath);
+        await writeFile(lockPath, JSON.stringify(replacement));
+      },
+      lockPath,
+      pidExists: (pid) => pid === process.pid,
+    });
+
+    expect(state).toEqual({
+      running: true,
+      pid: process.pid,
+      source: "scheduled",
+      startedAt: replacement.startedAt,
+    });
+    await expect(readFile(lockPath, "utf8")).resolves.toBe(JSON.stringify(replacement));
+    await expect(acquireCrawlerRunLock("manual", { lockPath })).rejects.toBeInstanceOf(
+      CrawlerAlreadyRunningError,
+    );
   });
 
   test("treats a fresh invalid lock as running", async () => {

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { link, mkdir, open, rename, rm } from "node:fs/promises";
+import { link, mkdir, open, readdir, rename, rm } from "node:fs/promises";
 import path from "node:path";
 
 const DEFAULT_LOCK_PATH = path.resolve(import.meta.dirname, "../../../data/crawler-run.lock");
@@ -53,6 +53,11 @@ interface LockFileSnapshot {
 
 interface LockMutationGuard {
   release: () => Promise<void>;
+}
+
+interface LockMutationIntentRecord {
+  pid: number;
+  pidStartedAt: string | null;
 }
 
 type StaleLockRemovalResult = "busy" | "changed" | "removed";
@@ -174,30 +179,6 @@ async function readLockRecord(lockPath: string): Promise<CrawlerRunLockRecord | 
   return (await readLockSnapshot(lockPath))?.record ?? null;
 }
 
-async function tryAcquireLockMutationGuard(lockPath: string): Promise<LockMutationGuard | null> {
-  const guardPath = `${lockPath}.mutation`;
-  let file: Awaited<ReturnType<typeof open>>;
-
-  try {
-    file = await open(guardPath, "wx");
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
-      return null;
-    }
-    throw err;
-  }
-
-  return {
-    release: async () => {
-      try {
-        await file.close();
-      } finally {
-        await rm(guardPath, { force: true });
-      }
-    },
-  };
-}
-
 function isStaleLock(
   record: CrawlerRunLockRecord,
   options: ReturnType<typeof getOptions>,
@@ -216,24 +197,113 @@ function isStaleLock(
   return isExpired(record.startedAt, options.staleMs);
 }
 
+function parseLockMutationIntent(contents: string): LockMutationIntentRecord | null {
+  try {
+    const parsed = JSON.parse(contents) as Partial<LockMutationIntentRecord>;
+    if (
+      typeof parsed.pid !== "number" ||
+      (parsed.pidStartedAt !== null && typeof parsed.pidStartedAt !== "string")
+    ) {
+      return null;
+    }
+    return { pid: parsed.pid, pidStartedAt: parsed.pidStartedAt };
+  } catch {
+    return null;
+  }
+}
+
+function isLockMutationIntentActive(
+  record: LockMutationIntentRecord | null,
+  options: ReturnType<typeof getOptions>,
+): boolean {
+  if (!record || !options.pidExists(record.pid)) {
+    return false;
+  }
+
+  if (!record.pidStartedAt) {
+    return true;
+  }
+
+  const currentPidStartedAt = options.getPidStartedAt(record.pid);
+  return !currentPidStartedAt || currentPidStartedAt === record.pidStartedAt;
+}
+
+async function tryAcquireLockMutationGuard(
+  options: ReturnType<typeof getOptions>,
+): Promise<LockMutationGuard | null> {
+  const directory = path.dirname(options.lockPath);
+  const basename = path.basename(options.lockPath);
+  const id = randomUUID();
+  // Active intent paths are unique and never reused, so dead owners can be removed by exact path.
+  const pendingPath = path.join(directory, `${basename}.mutation-pending-${id}`);
+  const intentPath = path.join(directory, `${basename}.mutation-active-${id}`);
+  const intentPrefix = `${basename}.mutation-active-`;
+  const record: LockMutationIntentRecord = {
+    pid: process.pid,
+    pidStartedAt: options.getPidStartedAt(process.pid),
+  };
+  let file: Awaited<ReturnType<typeof open>> | null = null;
+
+  try {
+    try {
+      file = await open(pendingPath, "wx");
+      await file.writeFile(JSON.stringify(record));
+    } finally {
+      await file?.close();
+    }
+    await rename(pendingPath, intentPath);
+  } catch (err) {
+    await rm(pendingPath, { force: true });
+    throw err;
+  }
+
+  try {
+    let hasOtherActiveIntent = false;
+    for (const name of await readdir(directory)) {
+      if (!name.startsWith(intentPrefix)) {
+        continue;
+      }
+
+      const candidatePath = path.join(directory, name);
+      const snapshot = await readLockSnapshot(candidatePath);
+      const candidate = snapshot ? parseLockMutationIntent(snapshot.contents) : null;
+      if (isLockMutationIntentActive(candidate, options)) {
+        hasOtherActiveIntent ||= candidatePath !== intentPath;
+      } else {
+        await rm(candidatePath, { force: true });
+      }
+    }
+
+    if (hasOtherActiveIntent) {
+      await rm(intentPath, { force: true });
+      return null;
+    }
+
+    return {
+      release: () => rm(intentPath, { force: true }),
+    };
+  } catch (err) {
+    await rm(intentPath, { force: true });
+    throw err;
+  }
+}
+
 async function removeStaleLockIfCurrent(
-  lockPath: string,
   expected: LockFileSnapshot,
-  beforeRemoval?: () => Promise<void>,
-  afterQuarantine?: () => Promise<void>,
+  options: ReturnType<typeof getOptions>,
 ): Promise<StaleLockRemovalResult> {
-  const mutationGuard = await tryAcquireLockMutationGuard(lockPath);
+  const mutationGuard = await tryAcquireLockMutationGuard(options);
   if (!mutationGuard) {
     return "busy";
   }
 
-  const quarantinePath = `${lockPath}.stale-${randomUUID()}`;
+  const quarantinePath = `${options.lockPath}.stale-${randomUUID()}`;
 
   try {
     try {
-      await beforeRemoval?.();
-      await rename(lockPath, quarantinePath);
-      await afterQuarantine?.();
+      await options.beforeStaleLockRemoval?.();
+      await rename(options.lockPath, quarantinePath);
+      await options.afterStaleLockQuarantine?.();
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
         return "changed";
@@ -253,7 +323,7 @@ async function removeStaleLockIfCurrent(
     }
 
     try {
-      await link(quarantinePath, lockPath);
+      await link(quarantinePath, options.lockPath);
       await rm(quarantinePath, { force: true });
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
@@ -294,12 +364,7 @@ export async function getCrawlerRunState(
     return snapshotState;
   }
 
-  const removal = await removeStaleLockIfCurrent(
-    resolved.lockPath,
-    snapshot,
-    resolved.beforeStaleLockRemoval,
-    resolved.afterStaleLockQuarantine,
-  );
+  const removal = await removeStaleLockIfCurrent(snapshot, resolved);
   if (removal === "removed") {
     return { running: false, pid: null, source: null, startedAt: null };
   }
@@ -317,7 +382,7 @@ export async function acquireCrawlerRunLock(
   const resolved = getOptions(options);
   await mkdir(path.dirname(resolved.lockPath), { recursive: true });
 
-  const mutationGuard = await tryAcquireLockMutationGuard(resolved.lockPath);
+  const mutationGuard = await tryAcquireLockMutationGuard(resolved);
   if (!mutationGuard) {
     throw new CrawlerAlreadyRunningError({
       running: true,

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -24,9 +24,10 @@ interface CrawlerRunLockRecord {
 }
 
 interface CrawlerRunLockOptions {
+  afterLockMutationGuardAcquired?: () => Promise<void>;
+  afterLockMutationGuardBlocked?: () => Promise<void>;
   afterLockMutationIntentPublished?: () => Promise<void>;
   afterStaleLockQuarantine?: () => Promise<void>;
-  beforeQuarantinedLockCheck?: () => Promise<void>;
   beforeStaleLockRemoval?: () => Promise<void>;
   lockPath?: string;
   getPidStartedAt?: (pid: number) => string | null;
@@ -100,9 +101,10 @@ function getLinuxPidStartedAt(pid: number): string | null {
 
 function getOptions(options: CrawlerRunLockOptions = {}) {
   return {
+    afterLockMutationGuardAcquired: options.afterLockMutationGuardAcquired,
+    afterLockMutationGuardBlocked: options.afterLockMutationGuardBlocked,
     afterLockMutationIntentPublished: options.afterLockMutationIntentPublished,
     afterStaleLockQuarantine: options.afterStaleLockQuarantine,
-    beforeQuarantinedLockCheck: options.beforeQuarantinedLockCheck,
     beforeStaleLockRemoval: options.beforeStaleLockRemoval,
     getPidStartedAt: options.getPidStartedAt ?? getLinuxPidStartedAt,
     lockPath: options.lockPath ?? DEFAULT_LOCK_PATH,
@@ -207,6 +209,15 @@ function isStaleLock(
   return isExpired(record.startedAt, options.staleMs);
 }
 
+function isStaleSnapshot(
+  snapshot: LockFileSnapshot,
+  options: ReturnType<typeof getOptions>,
+): boolean {
+  return snapshot.record
+    ? isStaleLock(snapshot.record, options)
+    : Date.now() - snapshot.mtimeMs > options.staleMs;
+}
+
 function parseLockMutationIntent(contents: string): LockMutationIntentRecord | null {
   try {
     const parsed = JSON.parse(contents) as Partial<LockMutationIntentRecord>;
@@ -303,6 +314,7 @@ async function tryAcquireLockMutationGuard(
   try {
     while (true) {
       if ((await getActiveLockMutationIntents(directory, ownerPrefixes)).length > 0) {
+        await options.afterLockMutationGuardBlocked?.();
         await rm(candidatePath, { force: true });
         return null;
       }
@@ -319,11 +331,13 @@ async function tryAcquireLockMutationGuard(
 
       // Another candidate may have become owner since the initial owner check.
       if ((await getActiveLockMutationIntents(directory, ownerPrefixes)).length > 0) {
+        await options.afterLockMutationGuardBlocked?.();
         await rm(candidatePath, { force: true });
         return null;
       }
 
       await rename(candidatePath, ownerPath);
+      await options.afterLockMutationGuardAcquired?.();
       return {
         release: () => rm(ownerPath, { force: true }),
       };
@@ -439,24 +453,21 @@ export async function getCrawlerRunState(
   options: CrawlerRunLockOptions = {},
 ): Promise<CrawlerRunState> {
   const resolved = getOptions(options);
+  await mkdir(path.dirname(resolved.lockPath), { recursive: true });
   let snapshot = await readLockSnapshot(resolved.lockPath);
-  let isQuarantined = false;
 
   if (!snapshot) {
-    await resolved.beforeQuarantinedLockCheck?.();
-    for (const quarantinePath of await getQuarantinePaths(resolved.lockPath)) {
-      snapshot = await readLockSnapshot(quarantinePath);
-      if (snapshot) {
-        isQuarantined = true;
-        break;
-      }
+    const mutationGuard = await tryAcquireLockMutationGuard(resolved);
+    if (!mutationGuard) {
+      return toUnknownRunningState();
+    }
+    try {
+      await recoverQuarantinedLock(resolved.lockPath);
+    } finally {
+      await mutationGuard.release();
     }
 
-    const current = await readLockSnapshot(resolved.lockPath);
-    if (current) {
-      snapshot = current;
-      isQuarantined = false;
-    }
+    snapshot = await readLockSnapshot(resolved.lockPath);
     if (!snapshot) {
       return { running: false, pid: null, source: null, startedAt: null };
     }
@@ -472,15 +483,7 @@ export async function getCrawlerRunState(
         startedAt: new Date(snapshot.mtimeMs).toISOString(),
       };
 
-  if (isQuarantined) {
-    return snapshotState;
-  }
-
-  const isStale = record
-    ? isStaleLock(record, resolved)
-    : Date.now() - snapshot.mtimeMs > resolved.staleMs;
-
-  if (!isStale) {
+  if (!isStaleSnapshot(snapshot, resolved)) {
     return snapshotState;
   }
 
@@ -502,9 +505,15 @@ export async function acquireCrawlerRunLock(
   const resolved = getOptions(options);
   await mkdir(path.dirname(resolved.lockPath), { recursive: true });
 
-  const mutationGuard = await tryAcquireLockMutationGuard(resolved);
-  if (!mutationGuard) {
-    throw new CrawlerAlreadyRunningError(toUnknownRunningState());
+  let mutationGuard = await tryAcquireLockMutationGuard(resolved);
+  while (!mutationGuard) {
+    const snapshot = await readLockSnapshot(resolved.lockPath);
+    if (snapshot && !isStaleSnapshot(snapshot, resolved)) {
+      throw new CrawlerAlreadyRunningError(toUnknownRunningState());
+    }
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    mutationGuard = await tryAcquireLockMutationGuard(resolved);
   }
 
   const record: CrawlerRunLockRecord = {

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { mkdir, open, readFile, rm, stat } from "node:fs/promises";
+import { link, mkdir, open, rename, rm } from "node:fs/promises";
 import path from "node:path";
 
 const DEFAULT_LOCK_PATH = path.resolve(import.meta.dirname, "../../../data/crawler-run.lock");
@@ -23,6 +23,7 @@ interface CrawlerRunLockRecord {
 }
 
 interface CrawlerRunLockOptions {
+  beforeStaleLockRemoval?: () => Promise<void>;
   lockPath?: string;
   getPidStartedAt?: (pid: number) => string | null;
   pidExists?: (pid: number) => boolean;
@@ -39,6 +40,14 @@ export class CrawlerAlreadyRunningError extends Error {
 interface CrawlerRunLock {
   record: CrawlerRunLockRecord;
   release: () => Promise<void>;
+}
+
+interface LockFileSnapshot {
+  contents: string;
+  device: number;
+  inode: number;
+  mtimeMs: number;
+  record: CrawlerRunLockRecord | null;
 }
 
 function defaultPidExists(pid: number): boolean {
@@ -75,6 +84,7 @@ function getLinuxPidStartedAt(pid: number): string | null {
 
 function getOptions(options: CrawlerRunLockOptions = {}) {
   return {
+    beforeStaleLockRemoval: options.beforeStaleLockRemoval,
     getPidStartedAt: options.getPidStartedAt ?? getLinuxPidStartedAt,
     lockPath: options.lockPath ?? DEFAULT_LOCK_PATH,
     pidExists: options.pidExists ?? defaultPidExists,
@@ -96,44 +106,64 @@ function isExpired(startedAt: string, staleMs: number): boolean {
   return Number.isNaN(startedAtMs) || Date.now() - startedAtMs > staleMs;
 }
 
-async function readLockRecord(lockPath: string): Promise<CrawlerRunLockRecord | null> {
+function parseLockRecord(contents: string): CrawlerRunLockRecord | null {
+  let parsed: Partial<CrawlerRunLockRecord>;
   try {
-    const raw = await readFile(lockPath, "utf8");
-    let parsed: Partial<CrawlerRunLockRecord>;
-    try {
-      parsed = JSON.parse(raw) as Partial<CrawlerRunLockRecord>;
-    } catch {
-      return null;
-    }
+    parsed = JSON.parse(contents) as Partial<CrawlerRunLockRecord>;
+  } catch {
+    return null;
+  }
 
-    const pidStartedAt =
-      parsed.pidStartedAt === undefined || parsed.pidStartedAt === null
-        ? null
-        : parsed.pidStartedAt;
+  const pidStartedAt =
+    parsed.pidStartedAt === undefined || parsed.pidStartedAt === null ? null : parsed.pidStartedAt;
 
-    if (
-      typeof parsed.id !== "string" ||
-      typeof parsed.pid !== "number" ||
-      (pidStartedAt !== null && typeof pidStartedAt !== "string") ||
-      typeof parsed.source !== "string" ||
-      typeof parsed.startedAt !== "string"
-    ) {
-      return null;
-    }
+  if (
+    typeof parsed.id !== "string" ||
+    typeof parsed.pid !== "number" ||
+    (pidStartedAt !== null && typeof pidStartedAt !== "string") ||
+    typeof parsed.source !== "string" ||
+    typeof parsed.startedAt !== "string"
+  ) {
+    return null;
+  }
 
-    return {
-      id: parsed.id,
-      pid: parsed.pid,
-      pidStartedAt,
-      source: parsed.source,
-      startedAt: parsed.startedAt,
-    };
+  return {
+    id: parsed.id,
+    pid: parsed.pid,
+    pidStartedAt,
+    source: parsed.source,
+    startedAt: parsed.startedAt,
+  };
+}
+
+async function readLockSnapshot(lockPath: string): Promise<LockFileSnapshot | null> {
+  let file: Awaited<ReturnType<typeof open>>;
+  try {
+    file = await open(lockPath, "r");
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return null;
     }
     throw err;
   }
+
+  try {
+    const contents = await file.readFile("utf8");
+    const stats = await file.stat();
+    return {
+      contents,
+      device: stats.dev,
+      inode: stats.ino,
+      mtimeMs: stats.mtimeMs,
+      record: parseLockRecord(contents),
+    };
+  } finally {
+    await file.close();
+  }
+}
+
+async function readLockRecord(lockPath: string): Promise<CrawlerRunLockRecord | null> {
+  return (await readLockSnapshot(lockPath))?.record ?? null;
 }
 
 function isStaleLock(
@@ -156,71 +186,78 @@ function isStaleLock(
 
 async function removeStaleLockIfCurrent(
   lockPath: string,
-  record: CrawlerRunLockRecord | null,
-  staleMtimeMs?: number,
+  expected: LockFileSnapshot,
+  beforeRemoval?: () => Promise<void>,
 ): Promise<boolean> {
+  const quarantinePath = `${lockPath}.stale-${randomUUID()}`;
+
   try {
-    const current = await readLockRecord(lockPath);
-
-    if (record) {
-      if (current?.id !== record.id) {
-        return false;
-      }
-    } else {
-      if (current) {
-        return false;
-      }
-
-      if (staleMtimeMs !== undefined) {
-        const stats = await stat(lockPath);
-        if (stats.mtimeMs !== staleMtimeMs) {
-          return false;
-        }
-      }
-    }
-
-    await rm(lockPath, { force: true });
-    return true;
+    await beforeRemoval?.();
+    await rename(lockPath, quarantinePath);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return false;
     }
     throw err;
   }
+
+  const current = await readLockSnapshot(quarantinePath);
+  if (
+    current &&
+    current.device === expected.device &&
+    current.inode === expected.inode &&
+    current.contents === expected.contents
+  ) {
+    await rm(quarantinePath, { force: true });
+    return true;
+  }
+
+  try {
+    await link(quarantinePath, lockPath);
+    await rm(quarantinePath, { force: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw err;
+    }
+  }
+
+  return false;
 }
 
 export async function getCrawlerRunState(
   options: CrawlerRunLockOptions = {},
 ): Promise<CrawlerRunState> {
   const resolved = getOptions(options);
-  const record = await readLockRecord(resolved.lockPath);
+  const snapshot = await readLockSnapshot(resolved.lockPath);
+
+  if (!snapshot) {
+    return { running: false, pid: null, source: null, startedAt: null };
+  }
+
+  const { record } = snapshot;
 
   if (!record) {
-    try {
-      const stats = await stat(resolved.lockPath);
-      if (Date.now() - stats.mtimeMs > resolved.staleMs) {
-        if (await removeStaleLockIfCurrent(resolved.lockPath, record, stats.mtimeMs)) {
-          return { running: false, pid: null, source: null, startedAt: null };
-        }
-        return getCrawlerRunState(options);
+    if (Date.now() - snapshot.mtimeMs > resolved.staleMs) {
+      if (
+        await removeStaleLockIfCurrent(resolved.lockPath, snapshot, resolved.beforeStaleLockRemoval)
+      ) {
+        return { running: false, pid: null, source: null, startedAt: null };
       }
-
-      return {
-        running: true,
-        pid: null,
-        source: null,
-        startedAt: new Date(stats.mtimeMs).toISOString(),
-      };
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        throw err;
-      }
-      return { running: false, pid: null, source: null, startedAt: null };
+      return getCrawlerRunState(options);
     }
+
+    return {
+      running: true,
+      pid: null,
+      source: null,
+      startedAt: new Date(snapshot.mtimeMs).toISOString(),
+    };
   }
 
   if (isStaleLock(record, resolved)) {
-    if (await removeStaleLockIfCurrent(resolved.lockPath, record)) {
+    if (
+      await removeStaleLockIfCurrent(resolved.lockPath, snapshot, resolved.beforeStaleLockRemoval)
+    ) {
       return { running: false, pid: null, source: null, startedAt: null };
     }
     return getCrawlerRunState(options);

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -23,6 +23,7 @@ interface CrawlerRunLockRecord {
 }
 
 interface CrawlerRunLockOptions {
+  afterStaleLockQuarantine?: () => Promise<void>;
   beforeStaleLockRemoval?: () => Promise<void>;
   lockPath?: string;
   getPidStartedAt?: (pid: number) => string | null;
@@ -49,6 +50,12 @@ interface LockFileSnapshot {
   mtimeMs: number;
   record: CrawlerRunLockRecord | null;
 }
+
+interface LockMutationGuard {
+  release: () => Promise<void>;
+}
+
+type StaleLockRemovalResult = "busy" | "changed" | "removed";
 
 function defaultPidExists(pid: number): boolean {
   try {
@@ -84,6 +91,7 @@ function getLinuxPidStartedAt(pid: number): string | null {
 
 function getOptions(options: CrawlerRunLockOptions = {}) {
   return {
+    afterStaleLockQuarantine: options.afterStaleLockQuarantine,
     beforeStaleLockRemoval: options.beforeStaleLockRemoval,
     getPidStartedAt: options.getPidStartedAt ?? getLinuxPidStartedAt,
     lockPath: options.lockPath ?? DEFAULT_LOCK_PATH,
@@ -166,6 +174,30 @@ async function readLockRecord(lockPath: string): Promise<CrawlerRunLockRecord | 
   return (await readLockSnapshot(lockPath))?.record ?? null;
 }
 
+async function tryAcquireLockMutationGuard(lockPath: string): Promise<LockMutationGuard | null> {
+  const guardPath = `${lockPath}.mutation`;
+  let file: Awaited<ReturnType<typeof open>>;
+
+  try {
+    file = await open(guardPath, "wx");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+      return null;
+    }
+    throw err;
+  }
+
+  return {
+    release: async () => {
+      try {
+        await file.close();
+      } finally {
+        await rm(guardPath, { force: true });
+      }
+    },
+  };
+}
+
 function isStaleLock(
   record: CrawlerRunLockRecord,
   options: ReturnType<typeof getOptions>,
@@ -188,40 +220,51 @@ async function removeStaleLockIfCurrent(
   lockPath: string,
   expected: LockFileSnapshot,
   beforeRemoval?: () => Promise<void>,
-): Promise<boolean> {
+  afterQuarantine?: () => Promise<void>,
+): Promise<StaleLockRemovalResult> {
+  const mutationGuard = await tryAcquireLockMutationGuard(lockPath);
+  if (!mutationGuard) {
+    return "busy";
+  }
+
   const quarantinePath = `${lockPath}.stale-${randomUUID()}`;
 
   try {
-    await beforeRemoval?.();
-    await rename(lockPath, quarantinePath);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      return false;
-    }
-    throw err;
-  }
-
-  const current = await readLockSnapshot(quarantinePath);
-  if (
-    current &&
-    current.device === expected.device &&
-    current.inode === expected.inode &&
-    current.contents === expected.contents
-  ) {
-    await rm(quarantinePath, { force: true });
-    return true;
-  }
-
-  try {
-    await link(quarantinePath, lockPath);
-    await rm(quarantinePath, { force: true });
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+    try {
+      await beforeRemoval?.();
+      await rename(lockPath, quarantinePath);
+      await afterQuarantine?.();
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return "changed";
+      }
       throw err;
     }
-  }
 
-  return false;
+    const current = await readLockSnapshot(quarantinePath);
+    if (
+      current &&
+      current.device === expected.device &&
+      current.inode === expected.inode &&
+      current.contents === expected.contents
+    ) {
+      await rm(quarantinePath, { force: true });
+      return "removed";
+    }
+
+    try {
+      await link(quarantinePath, lockPath);
+      await rm(quarantinePath, { force: true });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw err;
+      }
+    }
+
+    return "changed";
+  } finally {
+    await mutationGuard.release();
+  }
 }
 
 export async function getCrawlerRunState(
@@ -235,35 +278,36 @@ export async function getCrawlerRunState(
   }
 
   const { record } = snapshot;
+  const snapshotState = record
+    ? toRunState(record)
+    : {
+        running: true as const,
+        pid: null,
+        source: null,
+        startedAt: new Date(snapshot.mtimeMs).toISOString(),
+      };
+  const isStale = record
+    ? isStaleLock(record, resolved)
+    : Date.now() - snapshot.mtimeMs > resolved.staleMs;
 
-  if (!record) {
-    if (Date.now() - snapshot.mtimeMs > resolved.staleMs) {
-      if (
-        await removeStaleLockIfCurrent(resolved.lockPath, snapshot, resolved.beforeStaleLockRemoval)
-      ) {
-        return { running: false, pid: null, source: null, startedAt: null };
-      }
-      return getCrawlerRunState(options);
-    }
-
-    return {
-      running: true,
-      pid: null,
-      source: null,
-      startedAt: new Date(snapshot.mtimeMs).toISOString(),
-    };
+  if (!isStale) {
+    return snapshotState;
   }
 
-  if (isStaleLock(record, resolved)) {
-    if (
-      await removeStaleLockIfCurrent(resolved.lockPath, snapshot, resolved.beforeStaleLockRemoval)
-    ) {
-      return { running: false, pid: null, source: null, startedAt: null };
-    }
+  const removal = await removeStaleLockIfCurrent(
+    resolved.lockPath,
+    snapshot,
+    resolved.beforeStaleLockRemoval,
+    resolved.afterStaleLockQuarantine,
+  );
+  if (removal === "removed") {
+    return { running: false, pid: null, source: null, startedAt: null };
+  }
+  if (removal === "changed") {
     return getCrawlerRunState(options);
   }
 
-  return toRunState(record);
+  return snapshotState;
 }
 
 export async function acquireCrawlerRunLock(
@@ -272,6 +316,16 @@ export async function acquireCrawlerRunLock(
 ): Promise<CrawlerRunLock> {
   const resolved = getOptions(options);
   await mkdir(path.dirname(resolved.lockPath), { recursive: true });
+
+  const mutationGuard = await tryAcquireLockMutationGuard(resolved.lockPath);
+  if (!mutationGuard) {
+    throw new CrawlerAlreadyRunningError({
+      running: true,
+      pid: null,
+      source: null,
+      startedAt: null,
+    });
+  }
 
   const record: CrawlerRunLockRecord = {
     id: randomUUID(),
@@ -282,6 +336,7 @@ export async function acquireCrawlerRunLock(
   };
 
   let file: Awaited<ReturnType<typeof open>> | null = null;
+  let lockExists = false;
   try {
     file = await open(resolved.lockPath, "wx");
     await file.writeFile(JSON.stringify(record));
@@ -289,14 +344,21 @@ export async function acquireCrawlerRunLock(
     if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
       throw err;
     }
+    lockExists = true;
+  } finally {
+    try {
+      await file?.close();
+    } finally {
+      await mutationGuard.release();
+    }
+  }
 
+  if (lockExists) {
     const state = await getCrawlerRunState(options);
     if (!state.running) {
       return acquireCrawlerRunLock(source, options);
     }
     throw new CrawlerAlreadyRunningError(state);
-  } finally {
-    await file?.close();
   }
 
   return {

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 const DEFAULT_LOCK_PATH = path.resolve(import.meta.dirname, "../../../data/crawler-run.lock");
 const DEFAULT_MAX_WAIT_MINUTES = 20;
 const LOCK_STALE_BUFFER_MINUTES = 100;
+const LOCK_MUTATION_INTENT_STALE_MS = 60_000;
 
 export interface CrawlerRunState {
   running: boolean;
@@ -57,6 +58,7 @@ interface LockMutationGuard {
 }
 
 interface LockMutationIntentRecord {
+  createdAt: string;
   pid: number;
   pidStartedAt: string | null;
 }
@@ -203,19 +205,28 @@ function parseLockMutationIntent(contents: string): LockMutationIntentRecord | n
   try {
     const parsed = JSON.parse(contents) as Partial<LockMutationIntentRecord>;
     if (
+      typeof parsed.createdAt !== "string" ||
       typeof parsed.pid !== "number" ||
       (parsed.pidStartedAt !== null && typeof parsed.pidStartedAt !== "string")
     ) {
       return null;
     }
-    return { pid: parsed.pid, pidStartedAt: parsed.pidStartedAt };
+    return {
+      createdAt: parsed.createdAt,
+      pid: parsed.pid,
+      pidStartedAt: parsed.pidStartedAt,
+    };
   } catch {
     return null;
   }
 }
 
 function isLockMutationIntentActive(record: LockMutationIntentRecord | null): boolean {
-  if (!record || !defaultPidExists(record.pid)) {
+  if (
+    !record ||
+    isExpired(record.createdAt, LOCK_MUTATION_INTENT_STALE_MS) ||
+    !defaultPidExists(record.pid)
+  ) {
     return false;
   }
 
@@ -262,6 +273,7 @@ async function tryAcquireLockMutationGuard(
   const candidatePrefix = `${basename}.mutation-candidate-`;
   const ownerPrefixes = [`${basename}.mutation-owner-`, `${basename}.mutation-active-`];
   const record: LockMutationIntentRecord = {
+    createdAt: new Date().toISOString(),
     pid: process.pid,
     pidStartedAt: getLinuxPidStartedAt(process.pid),
   };
@@ -314,6 +326,46 @@ async function tryAcquireLockMutationGuard(
     await rm(candidatePath, { force: true });
     await rm(ownerPath, { force: true });
     throw err;
+  }
+}
+
+async function recoverQuarantinedLock(lockPath: string): Promise<void> {
+  const directory = path.dirname(lockPath);
+  const quarantinePrefix = `${path.basename(lockPath)}.stale-`;
+
+  for (const name of (await readdir(directory)).sort()) {
+    if (!name.startsWith(quarantinePrefix)) {
+      continue;
+    }
+
+    const quarantinePath = path.join(directory, name);
+    try {
+      await link(quarantinePath, lockPath);
+      await rm(quarantinePath, { force: true });
+      return;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") {
+        continue;
+      }
+      if (code !== "EEXIST") {
+        throw err;
+      }
+
+      const [quarantined, current] = await Promise.all([
+        readLockSnapshot(quarantinePath),
+        readLockSnapshot(lockPath),
+      ]);
+      if (
+        quarantined &&
+        current &&
+        quarantined.device === current.device &&
+        quarantined.inode === current.inode
+      ) {
+        await rm(quarantinePath, { force: true });
+      }
+      return;
+    }
   }
 }
 
@@ -432,6 +484,7 @@ export async function acquireCrawlerRunLock(
   let file: Awaited<ReturnType<typeof open>> | null = null;
   let lockExists = false;
   try {
+    await recoverQuarantinedLock(resolved.lockPath);
     file = await open(resolved.lockPath, "wx");
     await file.writeFile(JSON.stringify(record));
   } catch (err) {

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -118,6 +118,10 @@ function toRunState(record: CrawlerRunLockRecord): CrawlerRunState {
   };
 }
 
+function toUnknownRunningState(): CrawlerRunState {
+  return { running: true, pid: null, source: null, startedAt: null };
+}
+
 function isExpired(startedAt: string, staleMs: number): boolean {
   const startedAtMs = Date.parse(startedAt);
   return Number.isNaN(startedAtMs) || Date.now() - startedAtMs > staleMs;
@@ -422,10 +426,23 @@ export async function getCrawlerRunState(
   options: CrawlerRunLockOptions = {},
 ): Promise<CrawlerRunState> {
   const resolved = getOptions(options);
-  const snapshot = await readLockSnapshot(resolved.lockPath);
+  let snapshot = await readLockSnapshot(resolved.lockPath);
 
   if (!snapshot) {
-    return { running: false, pid: null, source: null, startedAt: null };
+    const mutationGuard = await tryAcquireLockMutationGuard(resolved);
+    if (!mutationGuard) {
+      return toUnknownRunningState();
+    }
+    try {
+      await recoverQuarantinedLock(resolved.lockPath);
+    } finally {
+      await mutationGuard.release();
+    }
+
+    snapshot = await readLockSnapshot(resolved.lockPath);
+    if (!snapshot) {
+      return { running: false, pid: null, source: null, startedAt: null };
+    }
   }
 
   const { record } = snapshot;
@@ -465,12 +482,7 @@ export async function acquireCrawlerRunLock(
 
   const mutationGuard = await tryAcquireLockMutationGuard(resolved);
   if (!mutationGuard) {
-    throw new CrawlerAlreadyRunningError({
-      running: true,
-      pid: null,
-      source: null,
-      startedAt: null,
-    });
+    throw new CrawlerAlreadyRunningError(toUnknownRunningState());
   }
 
   const record: CrawlerRunLockRecord = {

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -26,6 +26,7 @@ interface CrawlerRunLockRecord {
 interface CrawlerRunLockOptions {
   afterLockMutationIntentPublished?: () => Promise<void>;
   afterStaleLockQuarantine?: () => Promise<void>;
+  beforeQuarantinedLockCheck?: () => Promise<void>;
   beforeStaleLockRemoval?: () => Promise<void>;
   lockPath?: string;
   getPidStartedAt?: (pid: number) => string | null;
@@ -101,6 +102,7 @@ function getOptions(options: CrawlerRunLockOptions = {}) {
   return {
     afterLockMutationIntentPublished: options.afterLockMutationIntentPublished,
     afterStaleLockQuarantine: options.afterStaleLockQuarantine,
+    beforeQuarantinedLockCheck: options.beforeQuarantinedLockCheck,
     beforeStaleLockRemoval: options.beforeStaleLockRemoval,
     getPidStartedAt: options.getPidStartedAt ?? getLinuxPidStartedAt,
     lockPath: options.lockPath ?? DEFAULT_LOCK_PATH,
@@ -333,16 +335,27 @@ async function tryAcquireLockMutationGuard(
   }
 }
 
-async function recoverQuarantinedLock(lockPath: string): Promise<void> {
+async function getQuarantinePaths(lockPath: string): Promise<string[]> {
   const directory = path.dirname(lockPath);
   const quarantinePrefix = `${path.basename(lockPath)}.stale-`;
-
-  for (const name of (await readdir(directory)).sort()) {
-    if (!name.startsWith(quarantinePrefix)) {
-      continue;
+  let names: string[];
+  try {
+    names = await readdir(directory);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
     }
+    throw err;
+  }
 
-    const quarantinePath = path.join(directory, name);
+  return names
+    .filter((name) => name.startsWith(quarantinePrefix))
+    .sort()
+    .map((name) => path.join(directory, name));
+}
+
+async function recoverQuarantinedLock(lockPath: string): Promise<void> {
+  for (const quarantinePath of await getQuarantinePaths(lockPath)) {
     try {
       await link(quarantinePath, lockPath);
       await rm(quarantinePath, { force: true });
@@ -427,19 +440,23 @@ export async function getCrawlerRunState(
 ): Promise<CrawlerRunState> {
   const resolved = getOptions(options);
   let snapshot = await readLockSnapshot(resolved.lockPath);
+  let isQuarantined = false;
 
   if (!snapshot) {
-    const mutationGuard = await tryAcquireLockMutationGuard(resolved);
-    if (!mutationGuard) {
-      return toUnknownRunningState();
-    }
-    try {
-      await recoverQuarantinedLock(resolved.lockPath);
-    } finally {
-      await mutationGuard.release();
+    await resolved.beforeQuarantinedLockCheck?.();
+    for (const quarantinePath of await getQuarantinePaths(resolved.lockPath)) {
+      snapshot = await readLockSnapshot(quarantinePath);
+      if (snapshot) {
+        isQuarantined = true;
+        break;
+      }
     }
 
-    snapshot = await readLockSnapshot(resolved.lockPath);
+    const current = await readLockSnapshot(resolved.lockPath);
+    if (current) {
+      snapshot = current;
+      isQuarantined = false;
+    }
     if (!snapshot) {
       return { running: false, pid: null, source: null, startedAt: null };
     }
@@ -454,6 +471,11 @@ export async function getCrawlerRunState(
         source: null,
         startedAt: new Date(snapshot.mtimeMs).toISOString(),
       };
+
+  if (isQuarantined) {
+    return snapshotState;
+  }
+
   const isStale = record
     ? isStaleLock(record, resolved)
     : Date.now() - snapshot.mtimeMs > resolved.staleMs;

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -23,6 +23,7 @@ interface CrawlerRunLockRecord {
 }
 
 interface CrawlerRunLockOptions {
+  afterLockMutationIntentPublished?: () => Promise<void>;
   afterStaleLockQuarantine?: () => Promise<void>;
   beforeStaleLockRemoval?: () => Promise<void>;
   lockPath?: string;
@@ -96,6 +97,7 @@ function getLinuxPidStartedAt(pid: number): string | null {
 
 function getOptions(options: CrawlerRunLockOptions = {}) {
   return {
+    afterLockMutationIntentPublished: options.afterLockMutationIntentPublished,
     afterStaleLockQuarantine: options.afterStaleLockQuarantine,
     beforeStaleLockRemoval: options.beforeStaleLockRemoval,
     getPidStartedAt: options.getPidStartedAt ?? getLinuxPidStartedAt,
@@ -212,11 +214,8 @@ function parseLockMutationIntent(contents: string): LockMutationIntentRecord | n
   }
 }
 
-function isLockMutationIntentActive(
-  record: LockMutationIntentRecord | null,
-  options: ReturnType<typeof getOptions>,
-): boolean {
-  if (!record || !options.pidExists(record.pid)) {
+function isLockMutationIntentActive(record: LockMutationIntentRecord | null): boolean {
+  if (!record || !defaultPidExists(record.pid)) {
     return false;
   }
 
@@ -224,8 +223,30 @@ function isLockMutationIntentActive(
     return true;
   }
 
-  const currentPidStartedAt = options.getPidStartedAt(record.pid);
+  const currentPidStartedAt = getLinuxPidStartedAt(record.pid);
   return !currentPidStartedAt || currentPidStartedAt === record.pidStartedAt;
+}
+
+async function getActiveLockMutationIntents(
+  directory: string,
+  prefixes: string[],
+): Promise<string[]> {
+  const activeIntents: string[] = [];
+  for (const name of await readdir(directory)) {
+    if (!prefixes.some((prefix) => name.startsWith(prefix))) {
+      continue;
+    }
+
+    const intentPath = path.join(directory, name);
+    const snapshot = await readLockSnapshot(intentPath);
+    const record = snapshot ? parseLockMutationIntent(snapshot.contents) : null;
+    if (isLockMutationIntentActive(record)) {
+      activeIntents.push(intentPath);
+    } else {
+      await rm(intentPath, { force: true });
+    }
+  }
+  return activeIntents.sort();
 }
 
 async function tryAcquireLockMutationGuard(
@@ -236,11 +257,13 @@ async function tryAcquireLockMutationGuard(
   const id = randomUUID();
   // Active intent paths are unique and never reused, so dead owners can be removed by exact path.
   const pendingPath = path.join(directory, `${basename}.mutation-pending-${id}`);
-  const intentPath = path.join(directory, `${basename}.mutation-active-${id}`);
-  const intentPrefix = `${basename}.mutation-active-`;
+  const candidatePath = path.join(directory, `${basename}.mutation-candidate-${id}`);
+  const ownerPath = path.join(directory, `${basename}.mutation-owner-${id}`);
+  const candidatePrefix = `${basename}.mutation-candidate-`;
+  const ownerPrefixes = [`${basename}.mutation-owner-`, `${basename}.mutation-active-`];
   const record: LockMutationIntentRecord = {
     pid: process.pid,
-    pidStartedAt: options.getPidStartedAt(process.pid),
+    pidStartedAt: getLinuxPidStartedAt(process.pid),
   };
   let file: Awaited<ReturnType<typeof open>> | null = null;
 
@@ -251,39 +274,45 @@ async function tryAcquireLockMutationGuard(
     } finally {
       await file?.close();
     }
-    await rename(pendingPath, intentPath);
+    await rename(pendingPath, candidatePath);
+    await options.afterLockMutationIntentPublished?.();
   } catch (err) {
     await rm(pendingPath, { force: true });
+    await rm(candidatePath, { force: true });
     throw err;
   }
 
   try {
-    let hasOtherActiveIntent = false;
-    for (const name of await readdir(directory)) {
-      if (!name.startsWith(intentPrefix)) {
+    while (true) {
+      if ((await getActiveLockMutationIntents(directory, ownerPrefixes)).length > 0) {
+        await rm(candidatePath, { force: true });
+        return null;
+      }
+
+      const candidates = await getActiveLockMutationIntents(directory, [candidatePrefix]);
+      if (candidates[0] !== candidatePath) {
+        await rm(candidatePath, { force: true });
+        return null;
+      }
+      if (candidates.length > 1) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
         continue;
       }
 
-      const candidatePath = path.join(directory, name);
-      const snapshot = await readLockSnapshot(candidatePath);
-      const candidate = snapshot ? parseLockMutationIntent(snapshot.contents) : null;
-      if (isLockMutationIntentActive(candidate, options)) {
-        hasOtherActiveIntent ||= candidatePath !== intentPath;
-      } else {
+      // Another candidate may have become owner since the initial owner check.
+      if ((await getActiveLockMutationIntents(directory, ownerPrefixes)).length > 0) {
         await rm(candidatePath, { force: true });
+        return null;
       }
-    }
 
-    if (hasOtherActiveIntent) {
-      await rm(intentPath, { force: true });
-      return null;
+      await rename(candidatePath, ownerPath);
+      return {
+        release: () => rm(ownerPath, { force: true }),
+      };
     }
-
-    return {
-      release: () => rm(intentPath, { force: true }),
-    };
   } catch (err) {
-    await rm(intentPath, { force: true });
+    await rm(candidatePath, { force: true });
+    await rm(ownerPath, { force: true });
     throw err;
   }
 }

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -28,6 +28,7 @@ interface CrawlerRunLockOptions {
   afterLockMutationGuardBlocked?: () => Promise<void>;
   afterLockMutationIntentPublished?: () => Promise<void>;
   afterStaleLockQuarantine?: () => Promise<void>;
+  beforeStaleLockCleanup?: () => Promise<void>;
   beforeStaleLockRemoval?: () => Promise<void>;
   lockPath?: string;
   getPidStartedAt?: (pid: number) => string | null;
@@ -105,6 +106,7 @@ function getOptions(options: CrawlerRunLockOptions = {}) {
     afterLockMutationGuardBlocked: options.afterLockMutationGuardBlocked,
     afterLockMutationIntentPublished: options.afterLockMutationIntentPublished,
     afterStaleLockQuarantine: options.afterStaleLockQuarantine,
+    beforeStaleLockCleanup: options.beforeStaleLockCleanup,
     beforeStaleLockRemoval: options.beforeStaleLockRemoval,
     getPidStartedAt: options.getPidStartedAt ?? getLinuxPidStartedAt,
     lockPath: options.lockPath ?? DEFAULT_LOCK_PATH,
@@ -349,6 +351,18 @@ async function tryAcquireLockMutationGuard(
   }
 }
 
+async function waitForLockMutationGuard(
+  options: ReturnType<typeof getOptions>,
+): Promise<LockMutationGuard> {
+  while (true) {
+    const mutationGuard = await tryAcquireLockMutationGuard(options);
+    if (mutationGuard) {
+      return mutationGuard;
+    }
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+}
+
 async function getQuarantinePaths(lockPath: string): Promise<string[]> {
   const directory = path.dirname(lockPath);
   const quarantinePrefix = `${path.basename(lockPath)}.stale-`;
@@ -487,6 +501,7 @@ export async function getCrawlerRunState(
     return snapshotState;
   }
 
+  await resolved.beforeStaleLockCleanup?.();
   const removal = await removeStaleLockIfCurrent(snapshot, resolved);
   if (removal === "removed") {
     return { running: false, pid: null, source: null, startedAt: null };
@@ -554,9 +569,14 @@ export async function acquireCrawlerRunLock(
   return {
     record,
     release: async () => {
-      const current = await readLockRecord(resolved.lockPath);
-      if (current?.id === record.id) {
-        await rm(resolved.lockPath, { force: true });
+      const mutationGuard = await waitForLockMutationGuard(resolved);
+      try {
+        const current = await readLockRecord(resolved.lockPath);
+        if (current?.id === record.id) {
+          await rm(resolved.lockPath, { force: true });
+        }
+      } finally {
+        await mutationGuard.release();
       }
     },
   };


### PR DESCRIPTION
## Summary

- quarantine stale lock candidates before deletion
- verify file identity and contents after the atomic rename
- restore replacement locks without overwriting and cover the final-check race

## Testing

- pnpm --filter @mf-dashboard/crawler test -- crawler-run-lock.test.ts
- pnpm turbo typecheck
- pnpm lint
- pnpm format:check

Linear: HIR-95