### PR TITLE
fix(web): calculate sankey percentages from total flow

### DIFF
--- a/apps/web/src/components/info/sankey-diagram-utils.test.ts
+++ b/apps/web/src/components/info/sankey-diagram-utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { calculateFlowPercentage } from "./sankey-diagram-utils";
+
+describe("calculateFlowPercentage", () => {
+  it("赤字時は収入と赤字を総支出に対する割合として計算する", () => {
+    const totalIncome = 52785;
+    const totalExpense = 119305;
+    const deficit = totalExpense - totalIncome;
+
+    expect(calculateFlowPercentage(totalIncome, totalExpense)).toBe("44");
+    expect(calculateFlowPercentage(deficit, totalExpense)).toBe("56");
+  });
+
+  it("黒字時は支出と黒字を総収入に対する割合として計算する", () => {
+    const totalIncome = 300000;
+    const totalExpense = 200000;
+    const balance = totalIncome - totalExpense;
+
+    expect(calculateFlowPercentage(totalIncome, totalIncome)).toBe("100");
+    expect(calculateFlowPercentage(totalExpense, totalIncome)).toBe("67");
+    expect(calculateFlowPercentage(balance, totalIncome)).toBe("33");
+  });
+
+  it("総フローがゼロの場合は0を返す", () => {
+    expect(calculateFlowPercentage(0, 0)).toBe("0");
+  });
+});

--- a/apps/web/src/components/info/sankey-diagram-utils.ts
+++ b/apps/web/src/components/info/sankey-diagram-utils.ts
@@ -1,0 +1,5 @@
+export function calculateFlowPercentage(value: number, totalFlow: number): string {
+  if (totalFlow === 0) return "0";
+
+  return ((value / totalFlow) * 100).toFixed(0);
+}

--- a/apps/web/src/components/info/sankey-diagram.client.tsx
+++ b/apps/web/src/components/info/sankey-diagram.client.tsx
@@ -8,6 +8,7 @@ import { ChartTooltipContent } from "../charts/chart-tooltip";
 import { AmountDisplay } from "../ui/amount-display";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { EmptyState } from "../ui/empty-state";
+import { calculateFlowPercentage } from "./sankey-diagram-utils";
 
 interface SankeyDiagramClientProps {
   income: Array<{ category: string; amount: number }>;
@@ -124,22 +125,6 @@ export function SankeyDiagramClient({ income, expense, height = 600 }: SankeyDia
     return sankeyData.labelMap.get(id) || id;
   };
 
-  // Calculate percentage for each node
-  const getPercentage = (id: string, value: number): string => {
-    if (id.startsWith("n-in-")) {
-      return totalIncome > 0 ? ((value / totalIncome) * 100).toFixed(0) : "0";
-    } else if (id.startsWith("n-out-")) {
-      return totalExpense > 0 ? ((value / totalExpense) * 100).toFixed(0) : "0";
-    } else if (id === "n-central") {
-      return "100";
-    } else if (id === "n-balance") {
-      return totalFlow > 0 ? ((balance / totalFlow) * 100).toFixed(0) : "0";
-    } else if (id === "n-deficit") {
-      return totalFlow > 0 ? ((Math.abs(balance) / totalFlow) * 100).toFixed(0) : "0";
-    }
-    return "100";
-  };
-
   return (
     <Card>
       <CardHeader>
@@ -230,7 +215,7 @@ export function SankeyDiagramClient({ income, expense, height = 600 }: SankeyDia
                 const id = node.id as string;
                 const label = getLabel(id);
                 const value = node.value || 0;
-                const pct = getPercentage(id, value);
+                const pct = calculateFlowPercentage(value, totalFlow);
 
                 return `${label} ${pct}%`;
               }}


### PR DESCRIPTION
# Summary

- Calculate every Sankey node percentage against the shared total flow (`max(income, expense)`).
- Fix deficit cases so income and deficit contributions add up to 100% instead of showing income as 100% by itself.
- Add focused regression coverage for deficit, surplus, and zero-flow cases.
- Linear: https://linear.app/hiroppy/issue/HIR-97/収入が100percentになる計算を確認する

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | The chart percentage must represent each node contribution to the same cash flow. | ¥52,785 income and ¥66,520 deficit are shown as 44% and 56% of ¥119,305 total flow. |
| Reliability | Zero flow and both surplus/deficit states must avoid invalid or inconsistent percentages. | Zero flow returns 0%; surplus and deficit components use the same denominator. |
| Interaction capability | Labels must be understandable alongside the visual flow and summary amounts. | The monthly cash-flow screen shows percentages that add up consistently along each side of the Sankey. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Equivalence partitioning | Surplus, deficit, and no-flow states use different flow compositions. | One representative from each state class. |
| Boundary value analysis | A zero denominator is the critical numeric boundary. | No division-by-zero result when total flow is zero. |
| Error guessing | The reported symptom came from mixing per-category and total-flow denominators. | The exact reported amounts reproduce 100% before the fix and 44% after it. |

### Primary Test Conditions

- Deficit: income ¥52,785, expense ¥119,305, deficit ¥66,520 → income 44%, deficit 56%.
- Surplus: income ¥300,000, expense ¥200,000, balance ¥100,000 → expense 67%, balance 33%.
- Zero flow → 0%.
- Demo runtime deficit month: income ¥279,421, expense ¥296,593 → income 94%, deficit 6%.

### Out-of-Scope Risks

- Historical category aggregation is unchanged; this PR only changes label denominators.
- Existing Nivo responsive-size warnings in Storybook are unrelated to the percentage calculation.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [x] Storybook tests
- [ ] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/web test:unit — 23 files / 375 tests passed
pnpm turbo typecheck — 9 tasks passed
pnpm lint — passed
pnpm format:check — passed
pnpm --filter @mf-dashboard/web test:storybook — 74 files / 330 tests passed
DB_PATH=../../data/demo.db DEMO_MODE=true pnpm --filter @mf-dashboard/web exec next dev -p 3100 — /cf and /cf/2026-05 returned 200; deficit flow labels verified
```

### Checks Not Run

- Automated E2E tests — no dedicated Sankey percentage assertion exists; focused unit coverage and browser walkthrough directly cover the change.