### PR TITLE
fix(web): keep mobile menu responsive during pie rendering

### DIFF
--- a/apps/web/src/components/info/asset-breakdown-chart.client.test.tsx
+++ b/apps/web/src/components/info/asset-breakdown-chart.client.test.tsx
@@ -1,0 +1,35 @@
+import { render } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { AssetBreakdownChartClient } from "./asset-breakdown-chart.client";
+
+const { pieMock } = vi.hoisted(() => ({
+  pieMock: vi.fn<(props: Record<string, unknown>) => void>(),
+}));
+
+vi.mock("recharts", () => ({
+  Cell: () => null,
+  Pie: ({ children, ...props }: PropsWithChildren<Record<string, unknown>>) => {
+    pieMock(props);
+    return <div>{children}</div>;
+  },
+  PieChart: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  ResponsiveContainer: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  Tooltip: () => null,
+}));
+
+describe("AssetBreakdownChartClient", () => {
+  it("disables pie animation to keep the mobile navigation responsive", () => {
+    render(
+      <AssetBreakdownChartClient
+        data={[{ category: "現金", amount: 1000 }]}
+        dailyChanges={null}
+        weeklyChanges={null}
+        monthlyChanges={null}
+        netAssets={1000}
+      />,
+    );
+
+    expect(pieMock).toHaveBeenCalledWith(expect.objectContaining({ isAnimationActive: false }));
+  });
+});

--- a/apps/web/src/components/info/asset-breakdown-chart.client.tsx
+++ b/apps/web/src/components/info/asset-breakdown-chart.client.tsx
@@ -95,6 +95,7 @@ export function AssetBreakdownChartClient({
                   outerRadius={60}
                   dataKey="value"
                   strokeWidth={0}
+                  isAnimationActive={false}
                 >
                   {chartData.map((entry, index) => (
                     <Cell key={`cell-${index}`} fill={entry.color} />


### PR DESCRIPTION
# Summary

- disable the Recharts pie animation on the dashboard asset breakdown
- add a regression test that verifies the animation remains disabled
- keep chart data, colors, layout, and desktop rendering unchanged

Resolves HIR-98.

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Performance efficiency | The issue is an input-response delay while chart work occupies the mobile main thread. | The menu opens before the pie chart's former 1,500ms animation window completes. |
| Functional suitability | The navigation and chart must both continue to work. | The mobile menu opens/closes and the asset breakdown still renders the same data. |
| Compatibility | The regression is device-width and resource-sensitive. | The dashboard flow passes with the Pixel 7 Playwright profile and under CPU throttling. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Comparative testing | Compare identical click timing with the Recharts animation enabled and disabled. | Detect the animation's contribution to input delay. |
| State transition testing | Exercise closed menu → open menu → page navigation. | Verify the mobile sidebar interaction remains usable. |
| Regression testing | Assert the `Pie` contract and run the existing web suite. | Prevent animation from being re-enabled and catch adjacent regressions. |

### Primary Test Conditions

- Open the dashboard at mobile width and invoke the menu while the asset pie chart is rendering.
- Confirm the menu opens and primary navigation remains usable.
- Confirm asset chart data, colors, and layout are unchanged.
- Under 6× CPU throttling at 600ms after DOMContentLoaded, compare menu response: 1,163ms before and 604ms after.

### Out-of-Scope Risks

- Other dashboard chart animations remain unchanged because HIR-98 specifically targets the asset pie chart.
- Physical low-end device coverage is represented by Chromium CPU throttling and the Pixel 7 profile.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [ ] Storybook tests
- [x] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/web test:unit — 24 files / 376 tests passed
pnpm turbo typecheck — 9 packages passed
pnpm lint — passed without warnings or errors
pnpm format:check — passed
pnpm --filter @mf-dashboard/web test:e2e --project=mobile-chrome -g "navigates between primary pages from the sidebar" — 1 passed
Playwright Pixel 7-equivalent performance probe with 6× CPU throttling — menu response improved from 1,163ms to 604ms at the 600ms sampling point
```

### Checks Not Run

- Storybook tests — no Storybook story or shared visual styling changed; unit, mobile E2E, and runtime verification directly cover this behavior.
