### PR TITLE
feat(analytics): add transaction search tool

### DIFF
--- a/packages/analytics/src/chat/tools.test.ts
+++ b/packages/analytics/src/chat/tools.test.ts
@@ -11,6 +11,7 @@ describe("createChatTools", () => {
     const analysisTools = createAnalysisTools(db, groupId);
 
     expect(Object.keys(createChatTools(db, groupId))).toEqual([
+      "searchTransactions",
       ...Object.keys(financialTools),
       ...Object.keys(analysisTools),
     ]);
@@ -21,6 +22,7 @@ describe("createChatTools", () => {
 
     expect(tools).toEqual(
       expect.objectContaining({
+        searchTransactions: expect.any(Object),
         getMonthlySummaryByMonth: expect.any(Object),
         getMonthlyCategoryTotals: expect.any(Object),
         getAssetBreakdownByCategory: expect.any(Object),

--- a/packages/analytics/src/chat/tools.ts
+++ b/packages/analytics/src/chat/tools.ts
@@ -1,11 +1,13 @@
 import type { Db } from "@mf-dashboard/db";
 import { createAnalysisTools } from "../insights/analysis-tools.js";
 import { createFinancialTools } from "../insights/tools.js";
+import { createTransactionSearchTool } from "./transaction-search-tool.js";
 
-export { createAnalysisTools, createFinancialTools };
+export { createAnalysisTools, createFinancialTools, createTransactionSearchTool };
 
 export function createChatTools(db: Db, groupId: string) {
   return {
+    searchTransactions: createTransactionSearchTool(db, groupId),
     ...createFinancialTools(db, groupId),
     ...createAnalysisTools(db, groupId),
   };

--- a/packages/analytics/src/chat/transaction-search-tool.test.ts
+++ b/packages/analytics/src/chat/transaction-search-tool.test.ts
@@ -6,7 +6,11 @@ const { searchTransactions } = vi.hoisted(() => ({
   searchTransactions: vi.fn<(options: unknown, db: Db) => never[]>(() => []),
 }));
 
-vi.mock("@mf-dashboard/db", () => ({ searchTransactions }));
+vi.mock("@mf-dashboard/db", () => ({
+  searchTransactions,
+  SEARCH_TRANSACTIONS_MAX_LIMIT: 100,
+  SEARCH_TRANSACTIONS_MAX_OFFSET: 10_000,
+}));
 
 const db = {} as Db;
 const execOptions = {
@@ -25,6 +29,8 @@ describe("createTransactionSearchTool", () => {
       minAmount: 10000,
       includeTransfers: false,
       includeExcluded: false,
+      limit: 25,
+      offset: 50,
     };
 
     await tool.execute?.(options, execOptions);

--- a/packages/analytics/src/chat/transaction-search-tool.test.ts
+++ b/packages/analytics/src/chat/transaction-search-tool.test.ts
@@ -1,0 +1,34 @@
+import type { Db } from "@mf-dashboard/db";
+import { describe, expect, it, vi } from "vitest";
+import { createTransactionSearchTool } from "./transaction-search-tool.js";
+
+const { searchTransactions } = vi.hoisted(() => ({
+  searchTransactions: vi.fn<(options: unknown, db: Db) => never[]>(() => []),
+}));
+
+vi.mock("@mf-dashboard/db", () => ({ searchTransactions }));
+
+const db = {} as Db;
+const execOptions = {
+  toolCallId: "test",
+  messages: [],
+  abortSignal: undefined as never,
+  context: {} as never,
+};
+
+describe("createTransactionSearchTool", () => {
+  it("groupIdを外部入力にせず検索条件へ必ず付与する", async () => {
+    const tool = createTransactionSearchTool(db, "group-a");
+    const options = {
+      month: "2025-06",
+      category: "食費",
+      minAmount: 10000,
+      includeTransfers: false,
+      includeExcluded: false,
+    };
+
+    await tool.execute?.(options, execOptions);
+
+    expect(searchTransactions).toHaveBeenCalledWith({ ...options, groupId: "group-a" }, db);
+  });
+});

--- a/packages/analytics/src/chat/transaction-search-tool.ts
+++ b/packages/analytics/src/chat/transaction-search-tool.ts
@@ -1,4 +1,9 @@
-import { searchTransactions, type Db } from "@mf-dashboard/db";
+import {
+  searchTransactions,
+  SEARCH_TRANSACTIONS_MAX_LIMIT,
+  SEARCH_TRANSACTIONS_MAX_OFFSET,
+  type Db,
+} from "@mf-dashboard/db";
 import { tool } from "ai";
 import { z } from "zod";
 
@@ -28,6 +33,20 @@ export function createTransactionSearchTool(db: Db, groupId: string) {
         .boolean()
         .optional()
         .describe("計算対象外の明細を含めるか。省略時は含める"),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(SEARCH_TRANSACTIONS_MAX_LIMIT)
+        .optional()
+        .describe("取得件数。省略時は50件、最大100件"),
+      offset: z
+        .number()
+        .int()
+        .nonnegative()
+        .max(SEARCH_TRANSACTIONS_MAX_OFFSET)
+        .optional()
+        .describe("取得開始位置。省略時は0、最大10000"),
     }),
     execute: async (options) => await searchTransactions({ ...options, groupId }, db),
   });

--- a/packages/analytics/src/chat/transaction-search-tool.ts
+++ b/packages/analytics/src/chat/transaction-search-tool.ts
@@ -1,0 +1,34 @@
+import { searchTransactions, type Db } from "@mf-dashboard/db";
+import { tool } from "ai";
+import { z } from "zod";
+
+const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+const monthSchema = z.string().regex(/^\d{4}-\d{2}$/);
+
+export function createTransactionSearchTool(db: Db, groupId: string) {
+  return tool({
+    description:
+      "家計の取引明細を日付・期間・月・カテゴリ・キーワード・金額・種別・振替/計算対象外の状態で検索する",
+    inputSchema: z.object({
+      date: dateSchema.optional().describe("対象日 (YYYY-MM-DD形式)"),
+      startDate: dateSchema.optional().describe("期間の開始日、境界を含む (YYYY-MM-DD形式)"),
+      endDate: dateSchema.optional().describe("期間の終了日、境界を含む (YYYY-MM-DD形式)"),
+      month: monthSchema.optional().describe("対象月 (YYYY-MM形式)"),
+      category: z.string().optional().describe("大カテゴリの完全一致"),
+      subCategory: z.string().optional().describe("中カテゴリの完全一致"),
+      keyword: z
+        .string()
+        .optional()
+        .describe("内容・大カテゴリ・中カテゴリを対象にした部分一致キーワード"),
+      minAmount: z.number().nonnegative().optional().describe("最小金額、境界を含む"),
+      maxAmount: z.number().nonnegative().optional().describe("最大金額、境界を含む"),
+      type: z.enum(["income", "expense", "transfer"]).optional().describe("取引種別"),
+      includeTransfers: z.boolean().optional().describe("振替を含めるか。省略時は含める"),
+      includeExcluded: z
+        .boolean()
+        .optional()
+        .describe("計算対象外の明細を含めるか。省略時は含める"),
+    }),
+    execute: async (options) => await searchTransactions({ ...options, groupId }, db),
+  });
+}

--- a/packages/db/src/queries/summary.ts
+++ b/packages/db/src/queries/summary.ts
@@ -223,6 +223,28 @@ export function buildExpenseSum(_accountIds: number[]) {
   end)`.as("total_expense");
 }
 
+export async function hasMatchingNormalTransaction(
+  db: Db,
+  accountId: number,
+  date: string,
+  amount: number,
+): Promise<boolean> {
+  const transaction = await db
+    .select({ id: schema.transactions.id })
+    .from(schema.transactions)
+    .where(
+      and(
+        eq(schema.transactions.accountId, accountId),
+        eq(schema.transactions.date, date),
+        eq(schema.transactions.amount, amount),
+        sql`${schema.transactions.type} IN ('income', 'expense')`,
+      ),
+    )
+    .get();
+
+  return transaction !== undefined;
+}
+
 /**
  * グループ外→グループ内への振替支出を計算（重複除外）
  * 同一日・同一金額・同一account・同一transfer_targetの振替は1件のみカウント
@@ -272,20 +294,9 @@ export async function getDeduplicatedTransferExpense(
 
     // 振替先アカウントで同一日・同一金額の通常トランザクションがある場合は除外
     // （既に通常支出としてカウントされているため）
-    const existingNormalTx = await db
-      .select({ id: schema.transactions.id })
-      .from(schema.transactions)
-      .where(
-        and(
-          eq(schema.transactions.accountId, t.transferTargetAccountId),
-          eq(schema.transactions.date, t.date),
-          eq(schema.transactions.amount, t.amount),
-          sql`${schema.transactions.type} IN ('income', 'expense')`,
-        ),
-      )
-      .get();
-
-    if (existingNormalTx) continue;
+    if (await hasMatchingNormalTransaction(db, t.transferTargetAccountId, t.date, t.amount)) {
+      continue;
+    }
 
     const key = `${t.date}-${t.amount}-${t.accountId}-${t.transferTargetAccountId}`;
     if (seen.has(key)) continue;

--- a/packages/db/src/queries/transaction.test.ts
+++ b/packages/db/src/queries/transaction.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { schema } from "../index";
 import { createTestDb, resetTestDb, closeTestDb } from "../test-helpers";
-import { getTransactions, getTransactionsByMonth, getTransactionsByAccountId } from "./transaction";
+import {
+  getTransactions,
+  getTransactionsByMonth,
+  getTransactionsByAccountId,
+  searchTransactions,
+} from "./transaction";
 
 type Db = Awaited<ReturnType<typeof createTestDb>>;
 let db: Db;
@@ -32,7 +37,7 @@ beforeEach(async () => {
     .run();
 });
 
-async function createTestAccount(name: string): Promise<number> {
+async function createTestAccount(name: string, groupId = TEST_GROUP_ID): Promise<number> {
   const now = new Date().toISOString();
   const account = await db
     .insert(schema.accounts)
@@ -49,7 +54,7 @@ async function createTestAccount(name: string): Promise<number> {
   await db
     .insert(schema.groupAccounts)
     .values({
-      groupId: TEST_GROUP_ID,
+      groupId,
       accountId: account.id,
       createdAt: now,
       updatedAt: now,
@@ -65,6 +70,9 @@ async function createTransaction(data: {
   amount: number;
   type: "income" | "expense" | "transfer";
   category?: string;
+  subCategory?: string;
+  description?: string;
+  isExcludedFromCalculation?: boolean;
   transferTargetAccountId?: number;
 }) {
   const now = new Date().toISOString();
@@ -75,18 +83,253 @@ async function createTransaction(data: {
       date: data.date,
       accountId: data.accountId,
       category: data.category ?? null,
-      subCategory: null,
-      description: "Test transaction",
+      subCategory: data.subCategory ?? null,
+      description: data.description ?? "Test transaction",
       amount: data.amount,
       type: data.type,
       isTransfer: data.type === "transfer",
-      isExcludedFromCalculation: data.type === "transfer",
+      isExcludedFromCalculation: data.isExcludedFromCalculation ?? data.type === "transfer",
       transferTargetAccountId: data.transferTargetAccountId ?? null,
       createdAt: now,
       updatedAt: now,
     })
     .run();
 }
+
+describe("searchTransactions", () => {
+  it("日付・期間・月を境界日を含めて検索する", async () => {
+    const accountId = await createTestAccount("Bank A");
+    await createTransaction({ accountId, date: "2025-05-31", amount: 1000, type: "expense" });
+    await createTransaction({ accountId, date: "2025-06-01", amount: 2000, type: "expense" });
+    await createTransaction({ accountId, date: "2025-06-10", amount: 3000, type: "expense" });
+    await createTransaction({ accountId, date: "2025-06-30", amount: 4000, type: "expense" });
+    await createTransaction({ accountId, date: "2025-07-01", amount: 5000, type: "expense" });
+
+    const byDate = await searchTransactions({ groupId: TEST_GROUP_ID, date: "2025-06-10" }, db);
+    const byPeriod = await searchTransactions(
+      { groupId: TEST_GROUP_ID, startDate: "2025-06-01", endDate: "2025-06-30" },
+      db,
+    );
+    const byMonth = await searchTransactions({ groupId: TEST_GROUP_ID, month: "2025-06" }, db);
+
+    expect(byDate.map((transaction) => transaction.date)).toEqual(["2025-06-10"]);
+    expect(byPeriod.map((transaction) => transaction.date)).toEqual([
+      "2025-06-30",
+      "2025-06-10",
+      "2025-06-01",
+    ]);
+    expect(byMonth.map((transaction) => transaction.date)).toEqual([
+      "2025-06-30",
+      "2025-06-10",
+      "2025-06-01",
+    ]);
+  });
+
+  it("カテゴリ・サブカテゴリ・キーワードで検索する", async () => {
+    const accountId = await createTestAccount("Card A");
+    await createTransaction({
+      accountId,
+      date: "2025-06-10",
+      amount: 3200,
+      type: "expense",
+      category: "食費",
+      subCategory: "食料品",
+      description: "Amazon Fresh",
+    });
+    await createTransaction({
+      accountId,
+      date: "2025-06-11",
+      amount: 800,
+      type: "expense",
+      category: "交通費",
+      subCategory: "電車",
+      description: "IC charge",
+    });
+
+    expect(await searchTransactions({ groupId: TEST_GROUP_ID, category: "食費" }, db)).toHaveLength(
+      1,
+    );
+    expect(
+      await searchTransactions({ groupId: TEST_GROUP_ID, subCategory: "電車" }, db),
+    ).toHaveLength(1);
+    expect(await searchTransactions({ groupId: TEST_GROUP_ID, keyword: "amazon" }, db)).toEqual([
+      expect.objectContaining({
+        date: "2025-06-10",
+        category: "食費",
+        subCategory: "食料品",
+        description: "Amazon Fresh",
+        amount: 3200,
+        type: "expense",
+        accountId,
+        accountName: "Card A",
+      }),
+    ]);
+    expect(await searchTransactions({ groupId: TEST_GROUP_ID, keyword: "食料" }, db)).toHaveLength(
+      1,
+    );
+  });
+
+  it("金額の最小値と最大値を包含境界として検索する", async () => {
+    const accountId = await createTestAccount("Card A");
+    await createTransaction({ accountId, date: "2025-06-01", amount: 9999, type: "expense" });
+    await createTransaction({ accountId, date: "2025-06-02", amount: 10000, type: "expense" });
+    await createTransaction({ accountId, date: "2025-06-03", amount: 20000, type: "expense" });
+    await createTransaction({ accountId, date: "2025-06-04", amount: 20001, type: "expense" });
+
+    const result = await searchTransactions(
+      { groupId: TEST_GROUP_ID, minAmount: 10000, maxAmount: 20000 },
+      db,
+    );
+
+    expect(result.map((transaction) => transaction.amount)).toEqual([20000, 10000]);
+  });
+
+  it("種別・振替・計算対象外を既存の振替変換後の状態で絞り込む", async () => {
+    const accountId = await createTestAccount("Bank A");
+    const internalAccountId = await createTestAccount("Bank B");
+    const now = new Date().toISOString();
+    const externalAccount = await db
+      .insert(schema.accounts)
+      .values({
+        mfId: "external_search",
+        name: "External Account",
+        type: "bank",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+      .get();
+
+    await createTransaction({ accountId, date: "2025-06-01", amount: 1000, type: "income" });
+    await createTransaction({ accountId, date: "2025-06-02", amount: 2000, type: "expense" });
+    await createTransaction({
+      accountId,
+      date: "2025-06-03",
+      amount: 3000,
+      type: "expense",
+      isExcludedFromCalculation: true,
+    });
+    await createTransaction({
+      accountId,
+      date: "2025-06-04",
+      amount: 4000,
+      type: "transfer",
+      transferTargetAccountId: internalAccountId,
+    });
+    await createTransaction({
+      accountId,
+      date: "2025-06-05",
+      amount: 5000,
+      type: "transfer",
+      transferTargetAccountId: externalAccount.id,
+    });
+
+    const incomes = await searchTransactions(
+      { groupId: TEST_GROUP_ID, type: "income", includeTransfers: false },
+      db,
+    );
+    const expenses = await searchTransactions(
+      { groupId: TEST_GROUP_ID, type: "expense", includeExcluded: false },
+      db,
+    );
+    const transfers = await searchTransactions(
+      { groupId: TEST_GROUP_ID, type: "transfer", includeExcluded: true },
+      db,
+    );
+    const transformedCategory = await searchTransactions(
+      { groupId: TEST_GROUP_ID, category: "収入" },
+      db,
+    );
+
+    expect(incomes.map((transaction) => transaction.amount)).toEqual([5000, 1000]);
+    expect(incomes[0]).toEqual(
+      expect.objectContaining({
+        category: "収入",
+        subCategory: "振替入金",
+        isTransfer: false,
+        isExcludedFromCalculation: false,
+      }),
+    );
+    expect(expenses.map((transaction) => transaction.amount)).toEqual([2000]);
+    expect(transfers.map((transaction) => transaction.amount)).toEqual([4000]);
+    expect(transformedCategory.map((transaction) => transaction.amount)).toEqual([5000]);
+    expect(
+      await searchTransactions({ groupId: TEST_GROUP_ID, includeTransfers: false }, db),
+    ).toHaveLength(4);
+  });
+
+  it("明示されたgroupIdのアカウントだけを検索する", async () => {
+    const now = new Date().toISOString();
+    const otherGroupId = "test_group_002";
+    await db
+      .insert(schema.groups)
+      .values({
+        id: otherGroupId,
+        name: "Test Group B",
+        isCurrent: false,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    const accountId = await createTestAccount("Bank A");
+    const otherAccountId = await createTestAccount("Bank B", otherGroupId);
+    await createTransaction({ accountId, date: "2025-06-10", amount: 1000, type: "expense" });
+    await createTransaction({
+      accountId: otherAccountId,
+      date: "2025-06-10",
+      amount: 2000,
+      type: "expense",
+    });
+
+    expect(
+      (await searchTransactions({ groupId: TEST_GROUP_ID }, db)).map(
+        (transaction) => transaction.amount,
+      ),
+    ).toEqual([1000]);
+    expect(
+      (await searchTransactions({ groupId: otherGroupId }, db)).map(
+        (transaction) => transaction.amount,
+      ),
+    ).toEqual([2000]);
+    expect(await searchTransactions({ groupId: "missing_group" }, db)).toEqual([]);
+  });
+
+  it("複数条件をANDで組み合わせる", async () => {
+    const accountId = await createTestAccount("Card A");
+    await createTransaction({
+      accountId,
+      date: "2025-06-10",
+      amount: 12000,
+      type: "expense",
+      category: "食費",
+      description: "Amazon Fresh",
+    });
+    await createTransaction({
+      accountId,
+      date: "2025-06-11",
+      amount: 8000,
+      type: "expense",
+      category: "食費",
+      description: "Amazon Fresh",
+    });
+
+    const result = await searchTransactions(
+      {
+        groupId: TEST_GROUP_ID,
+        month: "2025-06",
+        category: "食費",
+        keyword: "Amazon",
+        minAmount: 10000,
+        type: "expense",
+        includeTransfers: false,
+        includeExcluded: false,
+      },
+      db,
+    );
+
+    expect(result.map((transaction) => transaction.amount)).toEqual([12000]);
+  });
+});
 
 describe("getTransactions", () => {
   it("トランザクション一覧を返す", async () => {

--- a/packages/db/src/queries/transaction.test.ts
+++ b/packages/db/src/queries/transaction.test.ts
@@ -5,6 +5,8 @@ import {
   getTransactions,
   getTransactionsByMonth,
   getTransactionsByAccountId,
+  SEARCH_TRANSACTIONS_DEFAULT_LIMIT,
+  SEARCH_TRANSACTIONS_MAX_LIMIT,
   searchTransactions,
 } from "./transaction";
 
@@ -62,6 +64,14 @@ async function createTestAccount(name: string, groupId = TEST_GROUP_ID): Promise
     .run();
 
   return account.id;
+}
+
+async function addAccountToGroup(accountId: number, groupId: string) {
+  const now = new Date().toISOString();
+  await db
+    .insert(schema.groupAccounts)
+    .values({ groupId, accountId, createdAt: now, updatedAt: now })
+    .run();
 }
 
 async function createTransaction(data: {
@@ -256,6 +266,126 @@ describe("searchTransactions", () => {
     expect(
       await searchTransactions({ groupId: TEST_GROUP_ID, includeTransfers: false }, db),
     ).toHaveLength(4);
+  });
+
+  it("対象groupへの外部口座振替を支出として検索する", async () => {
+    const targetAccountId = await createTestAccount("Bank A");
+    const now = new Date().toISOString();
+    const sourceAccount = await db
+      .insert(schema.accounts)
+      .values({
+        mfId: "external_source",
+        name: "External Source",
+        type: "bank",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+      .get();
+
+    await createTransaction({
+      accountId: sourceAccount.id,
+      date: "2025-06-06",
+      amount: 6000,
+      type: "transfer",
+      transferTargetAccountId: targetAccountId,
+    });
+
+    const result = await searchTransactions(
+      { groupId: TEST_GROUP_ID, type: "expense", includeTransfers: false },
+      db,
+    );
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        amount: 6000,
+        type: "expense",
+        category: "支出",
+        subCategory: "振替出金",
+        isTransfer: false,
+        isExcludedFromCalculation: false,
+      }),
+    ]);
+  });
+
+  it("別の共通group内の振替を収入へ変換しない", async () => {
+    const sourceAccountId = await createTestAccount("Bank A");
+    const commonGroupId = "common_group";
+    const now = new Date().toISOString();
+    await db
+      .insert(schema.groups)
+      .values({
+        id: commonGroupId,
+        name: "Common Group",
+        isCurrent: false,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    const targetAccountId = await createTestAccount("Bank B", commonGroupId);
+    await addAccountToGroup(sourceAccountId, commonGroupId);
+    await createTransaction({
+      accountId: sourceAccountId,
+      date: "2025-06-07",
+      amount: 7000,
+      type: "transfer",
+      transferTargetAccountId: targetAccountId,
+    });
+
+    expect(await searchTransactions({ groupId: TEST_GROUP_ID, type: "income" }, db)).toEqual([]);
+    expect(await searchTransactions({ groupId: TEST_GROUP_ID, type: "transfer" }, db)).toEqual([
+      expect.objectContaining({ amount: 7000, type: "transfer", isTransfer: true }),
+    ]);
+  });
+
+  it("既定件数と最大件数で結果を制限しoffsetを適用する", async () => {
+    const accountId = await createTestAccount("Card A");
+    for (let day = 0; day <= SEARCH_TRANSACTIONS_MAX_LIMIT; day += 1) {
+      await createTransaction({
+        accountId,
+        date: `2025-06-${String((day % 28) + 1).padStart(2, "0")}`,
+        amount: day,
+        type: "expense",
+      });
+    }
+
+    const defaultResult = await searchTransactions({ groupId: TEST_GROUP_ID }, db);
+    const cappedResult = await searchTransactions(
+      { groupId: TEST_GROUP_ID, limit: SEARCH_TRANSACTIONS_MAX_LIMIT + 1 },
+      db,
+    );
+    const offsetResult = await searchTransactions(
+      { groupId: TEST_GROUP_ID, limit: 1, offset: 1 },
+      db,
+    );
+
+    expect(defaultResult).toHaveLength(SEARCH_TRANSACTIONS_DEFAULT_LIMIT);
+    expect(cappedResult).toHaveLength(SEARCH_TRANSACTIONS_MAX_LIMIT);
+    expect(offsetResult).toEqual([cappedResult[1]]);
+  });
+
+  it("取得batchより後の一致結果も検索する", async () => {
+    const accountId = await createTestAccount("Card A");
+    await createTransaction({
+      accountId,
+      date: "2025-05-01",
+      amount: 5000,
+      type: "expense",
+      category: "食費",
+    });
+    for (let day = 0; day < SEARCH_TRANSACTIONS_DEFAULT_LIMIT; day += 1) {
+      await createTransaction({
+        accountId,
+        date: `2025-06-${String((day % 28) + 1).padStart(2, "0")}`,
+        amount: day,
+        type: "expense",
+        category: "交通費",
+      });
+    }
+
+    expect(await searchTransactions({ groupId: TEST_GROUP_ID, category: "食費" }, db)).toEqual([
+      expect.objectContaining({ amount: 5000, category: "食費" }),
+    ]);
   });
 
   it("明示されたgroupIdのアカウントだけを検索する", async () => {

--- a/packages/db/src/queries/transaction.test.ts
+++ b/packages/db/src/queries/transaction.test.ts
@@ -66,6 +66,23 @@ async function createTestAccount(name: string, groupId = TEST_GROUP_ID): Promise
   return account.id;
 }
 
+async function createExternalAccount(name: string): Promise<number> {
+  const now = new Date().toISOString();
+  const account = await db
+    .insert(schema.accounts)
+    .values({
+      mfId: `mf_${name}`,
+      name,
+      type: "bank",
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning()
+    .get();
+
+  return account.id;
+}
+
 async function addAccountToGroup(accountId: number, groupId: string) {
   const now = new Date().toISOString();
   await db
@@ -305,6 +322,89 @@ describe("searchTransactions", () => {
         isTransfer: false,
         isExcludedFromCalculation: false,
       }),
+    ]);
+  });
+
+  it("通常明細と重複する対象groupへの振替支出を除外する", async () => {
+    const targetAccountId = await createTestAccount("Bank A");
+    const sourceAccountId = await createExternalAccount("External Bank");
+
+    await createTransaction({
+      accountId: sourceAccountId,
+      date: "2025-06-06",
+      amount: 6000,
+      type: "transfer",
+      transferTargetAccountId: targetAccountId,
+    });
+    await createTransaction({
+      accountId: targetAccountId,
+      date: "2025-06-06",
+      amount: 6000,
+      type: "expense",
+    });
+
+    const result = await searchTransactions(
+      { groupId: TEST_GROUP_ID, type: "expense", includeTransfers: false },
+      db,
+    );
+
+    expect(result).toEqual([
+      expect.objectContaining({ accountId: targetAccountId, amount: 6000, type: "expense" }),
+    ]);
+  });
+
+  it("重複する対象groupからの振替収入を1件だけ返す", async () => {
+    const sourceAccountId = await createTestAccount("Bank A");
+    const targetAccountId = await createExternalAccount("External Bank");
+
+    for (let index = 0; index < 2; index += 1) {
+      await createTransaction({
+        accountId: sourceAccountId,
+        date: "2025-06-06",
+        amount: 6000,
+        type: "transfer",
+        transferTargetAccountId: targetAccountId,
+      });
+    }
+
+    const result = await searchTransactions({ groupId: TEST_GROUP_ID, type: "income" }, db);
+
+    expect(result).toEqual([
+      expect.objectContaining({ accountId: sourceAccountId, amount: 6000, type: "income" }),
+    ]);
+  });
+
+  it("共通groupを持つ外部口座から対象groupへの振替を支出として検索する", async () => {
+    const targetAccountId = await createTestAccount("Bank A");
+    const commonGroupId = "common_group";
+    const now = new Date().toISOString();
+    await db
+      .insert(schema.groups)
+      .values({
+        id: commonGroupId,
+        name: "Common Group",
+        isCurrent: false,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    const sourceAccountId = await createTestAccount("External Bank", commonGroupId);
+    await addAccountToGroup(targetAccountId, commonGroupId);
+    await createTransaction({
+      accountId: sourceAccountId,
+      date: "2025-06-06",
+      amount: 6000,
+      type: "transfer",
+      transferTargetAccountId: targetAccountId,
+    });
+
+    const result = await searchTransactions(
+      { groupId: TEST_GROUP_ID, type: "expense", includeTransfers: false },
+      db,
+    );
+
+    expect(result).toEqual([
+      expect.objectContaining({ accountId: sourceAccountId, amount: 6000, type: "expense" }),
     ]);
   });
 

--- a/packages/db/src/queries/transaction.ts
+++ b/packages/db/src/queries/transaction.ts
@@ -1,7 +1,84 @@
-import { desc, eq, and, gte, sql, inArray } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, like, lte, sql, type SQL } from "drizzle-orm";
 import { getDb, type Db, schema } from "../index";
 import { resolveGroupId, getAccountIdsForGroup } from "../shared/group-filter";
 import { transformTransferToIncome } from "../shared/transfer";
+
+export interface SearchTransactionsOptions {
+  groupId: string;
+  date?: string;
+  startDate?: string;
+  endDate?: string;
+  month?: string;
+  category?: string;
+  subCategory?: string;
+  keyword?: string;
+  minAmount?: number;
+  maxAmount?: number;
+  type?: "income" | "expense" | "transfer";
+  includeTransfers?: boolean;
+  includeExcluded?: boolean;
+}
+
+export async function searchTransactions(options: SearchTransactionsOptions, db: Db = getDb()) {
+  const accountIds = await getAccountIdsForGroup(db, options.groupId);
+  if (accountIds.length === 0) return [];
+
+  const conditions: SQL[] = [inArray(schema.transactions.accountId, accountIds)];
+
+  if (options.date) conditions.push(eq(schema.transactions.date, options.date));
+  if (options.startDate) conditions.push(gte(schema.transactions.date, options.startDate));
+  if (options.endDate) conditions.push(lte(schema.transactions.date, options.endDate));
+  if (options.month) conditions.push(like(schema.transactions.date, `${options.month}-%`));
+  if (options.minAmount !== undefined) {
+    conditions.push(gte(schema.transactions.amount, options.minAmount));
+  }
+  if (options.maxAmount !== undefined) {
+    conditions.push(lte(schema.transactions.amount, options.maxAmount));
+  }
+
+  const results = await db
+    .select({
+      id: schema.transactions.id,
+      mfId: schema.transactions.mfId,
+      date: schema.transactions.date,
+      category: schema.transactions.category,
+      subCategory: schema.transactions.subCategory,
+      description: schema.transactions.description,
+      amount: schema.transactions.amount,
+      type: schema.transactions.type,
+      isTransfer: schema.transactions.isTransfer,
+      isExcludedFromCalculation: schema.transactions.isExcludedFromCalculation,
+      accountId: schema.transactions.accountId,
+      accountName: schema.accounts.name,
+      transferTarget: schema.transactions.transferTarget,
+      transferTargetAccountId: schema.transactions.transferTargetAccountId,
+    })
+    .from(schema.transactions)
+    .leftJoin(schema.accounts, eq(schema.accounts.id, schema.transactions.accountId))
+    .where(and(...conditions))
+    .orderBy(desc(schema.transactions.date), desc(schema.transactions.id))
+    .all();
+
+  const keyword = options.keyword?.toLocaleLowerCase();
+
+  return results
+    .map((transaction) => transformTransferToIncome(transaction, accountIds))
+    .filter((transaction) => {
+      if (options.category && transaction.category !== options.category) return false;
+      if (options.subCategory && transaction.subCategory !== options.subCategory) return false;
+      if (options.type && transaction.type !== options.type) return false;
+      if (options.includeTransfers === false && transaction.isTransfer) return false;
+      if (options.includeExcluded === false && transaction.isExcludedFromCalculation) return false;
+
+      if (keyword) {
+        return [transaction.description, transaction.category, transaction.subCategory].some(
+          (value) => value?.toLocaleLowerCase().includes(keyword),
+        );
+      }
+
+      return true;
+    });
+}
 
 export async function getTransactions(
   options?: { limit?: number; groupId?: string },

--- a/packages/db/src/queries/transaction.ts
+++ b/packages/db/src/queries/transaction.ts
@@ -2,7 +2,7 @@ import { and, desc, eq, gte, inArray, like, lte, or, sql, type SQL } from "drizz
 import { getDb, type Db, schema } from "../index";
 import { resolveGroupId, getAccountIdsForGroup } from "../shared/group-filter";
 import { transformTransferToIncome } from "../shared/transfer";
-import { classifyTransfer } from "./summary";
+import { classifyTransfer, hasMatchingNormalTransaction } from "./summary";
 
 export const SEARCH_TRANSACTIONS_DEFAULT_LIMIT = 50;
 export const SEARCH_TRANSACTIONS_MAX_LIMIT = 100;
@@ -96,17 +96,45 @@ export async function searchTransactions(options: SearchTransactionsOptions, db:
 
   const keyword = options.keyword?.toLocaleLowerCase();
   const accountIdSet = new Set(accountIds);
+  const seenTransfers = new Set<string>();
   type SearchTransaction = Awaited<ReturnType<typeof fetchBatch>>[number];
 
   const transformTransaction = async (
     transaction: SearchTransaction,
-  ): Promise<SearchTransaction> => {
+  ): Promise<SearchTransaction | null> => {
     if (
       transaction.type !== "transfer" ||
       transaction.accountId === null ||
       transaction.transferTargetAccountId === null
     ) {
       return transaction;
+    }
+
+    const sourceInGroup = accountIdSet.has(transaction.accountId);
+    const targetInGroup = accountIdSet.has(transaction.transferTargetAccountId);
+    const transferKey = `${transaction.date}-${transaction.amount}-${transaction.accountId}-${transaction.transferTargetAccountId}`;
+
+    if (!sourceInGroup && targetInGroup) {
+      if (
+        (await hasMatchingNormalTransaction(
+          db,
+          transaction.transferTargetAccountId,
+          transaction.date,
+          transaction.amount,
+        )) ||
+        seenTransfers.has(transferKey)
+      ) {
+        return null;
+      }
+      seenTransfers.add(transferKey);
+      return {
+        ...transaction,
+        type: "expense",
+        category: "支出",
+        subCategory: "振替出金",
+        isTransfer: false,
+        isExcludedFromCalculation: false,
+      };
     }
 
     const classification = await classifyTransfer(
@@ -116,17 +144,9 @@ export async function searchTransactions(options: SearchTransactionsOptions, db:
       transaction.transferTargetAccountId,
     );
     if (classification === "income") {
+      if (seenTransfers.has(transferKey)) return null;
+      seenTransfers.add(transferKey);
       return transformTransferToIncome(transaction, accountIds);
-    }
-    if (classification === "expense") {
-      return {
-        ...transaction,
-        type: "expense",
-        category: "支出",
-        subCategory: "振替出金",
-        isTransfer: false,
-        isExcludedFromCalculation: false,
-      };
     }
     return transaction;
   };
@@ -152,9 +172,10 @@ export async function searchTransactions(options: SearchTransactionsOptions, db:
 
   while (page.length < limit) {
     const batch = await fetchBatch(batchOffset);
-    const transformedBatch = await Promise.all(batch.map(transformTransaction));
 
-    for (const transaction of transformedBatch) {
+    for (const rawTransaction of batch) {
+      const transaction = await transformTransaction(rawTransaction);
+      if (!transaction) continue;
       if (!matchesOptions(transaction)) continue;
       if (remainingOffset > 0) {
         remainingOffset -= 1;

--- a/packages/db/src/queries/transaction.ts
+++ b/packages/db/src/queries/transaction.ts
@@ -1,7 +1,12 @@
-import { and, desc, eq, gte, inArray, like, lte, sql, type SQL } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, like, lte, or, sql, type SQL } from "drizzle-orm";
 import { getDb, type Db, schema } from "../index";
 import { resolveGroupId, getAccountIdsForGroup } from "../shared/group-filter";
 import { transformTransferToIncome } from "../shared/transfer";
+import { classifyTransfer } from "./summary";
+
+export const SEARCH_TRANSACTIONS_DEFAULT_LIMIT = 50;
+export const SEARCH_TRANSACTIONS_MAX_LIMIT = 100;
+export const SEARCH_TRANSACTIONS_MAX_OFFSET = 10_000;
 
 export interface SearchTransactionsOptions {
   groupId: string;
@@ -17,13 +22,33 @@ export interface SearchTransactionsOptions {
   type?: "income" | "expense" | "transfer";
   includeTransfers?: boolean;
   includeExcluded?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+function boundedInteger(
+  value: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+) {
+  const integer = value === undefined || !Number.isFinite(value) ? fallback : Math.trunc(value);
+  return Math.min(Math.max(integer, minimum), maximum);
 }
 
 export async function searchTransactions(options: SearchTransactionsOptions, db: Db = getDb()) {
   const accountIds = await getAccountIdsForGroup(db, options.groupId);
   if (accountIds.length === 0) return [];
 
-  const conditions: SQL[] = [inArray(schema.transactions.accountId, accountIds)];
+  const conditions: SQL[] = [
+    or(
+      inArray(schema.transactions.accountId, accountIds),
+      and(
+        eq(schema.transactions.type, "transfer"),
+        inArray(schema.transactions.transferTargetAccountId, accountIds),
+      ),
+    )!,
+  ];
 
   if (options.date) conditions.push(eq(schema.transactions.date, options.date));
   if (options.startDate) conditions.push(gte(schema.transactions.date, options.startDate));
@@ -36,48 +61,114 @@ export async function searchTransactions(options: SearchTransactionsOptions, db:
     conditions.push(lte(schema.transactions.amount, options.maxAmount));
   }
 
-  const results = await db
-    .select({
-      id: schema.transactions.id,
-      mfId: schema.transactions.mfId,
-      date: schema.transactions.date,
-      category: schema.transactions.category,
-      subCategory: schema.transactions.subCategory,
-      description: schema.transactions.description,
-      amount: schema.transactions.amount,
-      type: schema.transactions.type,
-      isTransfer: schema.transactions.isTransfer,
-      isExcludedFromCalculation: schema.transactions.isExcludedFromCalculation,
-      accountId: schema.transactions.accountId,
-      accountName: schema.accounts.name,
-      transferTarget: schema.transactions.transferTarget,
-      transferTargetAccountId: schema.transactions.transferTargetAccountId,
-    })
-    .from(schema.transactions)
-    .leftJoin(schema.accounts, eq(schema.accounts.id, schema.transactions.accountId))
-    .where(and(...conditions))
-    .orderBy(desc(schema.transactions.date), desc(schema.transactions.id))
-    .all();
+  const limit = boundedInteger(
+    options.limit,
+    SEARCH_TRANSACTIONS_DEFAULT_LIMIT,
+    1,
+    SEARCH_TRANSACTIONS_MAX_LIMIT,
+  );
+  const offset = boundedInteger(options.offset, 0, 0, SEARCH_TRANSACTIONS_MAX_OFFSET);
+  const fetchBatch = (batchOffset: number) =>
+    db
+      .select({
+        id: schema.transactions.id,
+        mfId: schema.transactions.mfId,
+        date: schema.transactions.date,
+        category: schema.transactions.category,
+        subCategory: schema.transactions.subCategory,
+        description: schema.transactions.description,
+        amount: schema.transactions.amount,
+        type: schema.transactions.type,
+        isTransfer: schema.transactions.isTransfer,
+        isExcludedFromCalculation: schema.transactions.isExcludedFromCalculation,
+        accountId: schema.transactions.accountId,
+        accountName: schema.accounts.name,
+        transferTarget: schema.transactions.transferTarget,
+        transferTargetAccountId: schema.transactions.transferTargetAccountId,
+      })
+      .from(schema.transactions)
+      .leftJoin(schema.accounts, eq(schema.accounts.id, schema.transactions.accountId))
+      .where(and(...conditions))
+      .orderBy(desc(schema.transactions.date), desc(schema.transactions.id))
+      .limit(SEARCH_TRANSACTIONS_MAX_LIMIT)
+      .offset(batchOffset)
+      .all();
 
   const keyword = options.keyword?.toLocaleLowerCase();
+  const accountIdSet = new Set(accountIds);
+  type SearchTransaction = Awaited<ReturnType<typeof fetchBatch>>[number];
 
-  return results
-    .map((transaction) => transformTransferToIncome(transaction, accountIds))
-    .filter((transaction) => {
-      if (options.category && transaction.category !== options.category) return false;
-      if (options.subCategory && transaction.subCategory !== options.subCategory) return false;
-      if (options.type && transaction.type !== options.type) return false;
-      if (options.includeTransfers === false && transaction.isTransfer) return false;
-      if (options.includeExcluded === false && transaction.isExcludedFromCalculation) return false;
+  const transformTransaction = async (
+    transaction: SearchTransaction,
+  ): Promise<SearchTransaction> => {
+    if (
+      transaction.type !== "transfer" ||
+      transaction.accountId === null ||
+      transaction.transferTargetAccountId === null
+    ) {
+      return transaction;
+    }
 
-      if (keyword) {
-        return [transaction.description, transaction.category, transaction.subCategory].some(
-          (value) => value?.toLocaleLowerCase().includes(keyword),
-        );
+    const classification = await classifyTransfer(
+      db,
+      accountIdSet,
+      transaction.accountId,
+      transaction.transferTargetAccountId,
+    );
+    if (classification === "income") {
+      return transformTransferToIncome(transaction, accountIds);
+    }
+    if (classification === "expense") {
+      return {
+        ...transaction,
+        type: "expense",
+        category: "支出",
+        subCategory: "振替出金",
+        isTransfer: false,
+        isExcludedFromCalculation: false,
+      };
+    }
+    return transaction;
+  };
+
+  const matchesOptions = (transaction: SearchTransaction) => {
+    if (options.category && transaction.category !== options.category) return false;
+    if (options.subCategory && transaction.subCategory !== options.subCategory) return false;
+    if (options.type && transaction.type !== options.type) return false;
+    if (options.includeTransfers === false && transaction.isTransfer) return false;
+    if (options.includeExcluded === false && transaction.isExcludedFromCalculation) return false;
+
+    if (keyword) {
+      return [transaction.description, transaction.category, transaction.subCategory].some(
+        (value) => value?.toLocaleLowerCase().includes(keyword),
+      );
+    }
+    return true;
+  };
+
+  const page: SearchTransaction[] = [];
+  let batchOffset = 0;
+  let remainingOffset = offset;
+
+  while (page.length < limit) {
+    const batch = await fetchBatch(batchOffset);
+    const transformedBatch = await Promise.all(batch.map(transformTransaction));
+
+    for (const transaction of transformedBatch) {
+      if (!matchesOptions(transaction)) continue;
+      if (remainingOffset > 0) {
+        remainingOffset -= 1;
+        continue;
       }
+      page.push(transaction);
+      if (page.length === limit) break;
+    }
 
-      return true;
-    });
+    if (batch.length < SEARCH_TRANSACTIONS_MAX_LIMIT) break;
+    batchOffset += batch.length;
+  }
+
+  return page;
 }
 
 export async function getTransactions(


### PR DESCRIPTION
# Summary

- 家計AIチャット向けの `searchTransactions` DB queryを追加
- 日付・期間・月・カテゴリ・サブカテゴリ・キーワード・金額・種別・振替/計算対象外を組み合わせて検索可能にした
- 明示的な `groupId` スコープ、件数制限、既存summaryと一致する振替変換・重複排除を適用したchat tool wrapperを追加
- HIR-102: https://linear.app/hiroppy/issue/HIR-102/家計aiチャット用transaction-search-toolを実装する

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| 機能適合性 | 複数の検索条件と包含境界が仕様どおりに作用する必要がある | 各単独条件と複合条件が期待する明細のみを返す |
| セキュリティ | 別家計グループの明細混入と無制限取得を防ぐ必要がある | 明示したgroupIdだけを検索し、limit/offsetを上限内に制限する |
| 互換性 | 既存summaryの振替・除外・重複排除がchat検索でも維持される必要がある | 変換後のtype/category/stateとsummary対象明細が一致する |
| 性能効率性 | 全明細の一括取得を避ける必要がある | DB側filterとbounded paginationを適用する |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| 等価分割 | 各filterの一致・不一致クラスを確認する | date/category/subCategory/keyword/type/state |
| 境界値分析 | 期間端点・金額上下限・pagination上限が重要 | start/end date、月末、min/maxAmount、limit/offset |
| デシジョンテーブル | 条件の組み合わせによる漏れを防ぐ | month/category/keyword/amount/type/stateのAND検索 |
| エラー推測 | group漏洩と振替変換順序が高リスク | 別group、内部/外部振替、通常明細との重複、振替同士の重複 |

### Primary Test Conditions

- 日付完全一致、開始/終了日を含む期間、月初/月末を含む月検索
- カテゴリ・サブカテゴリ完全一致とdescription/category/subCategoryのキーワード部分一致
- minAmount/maxAmountの直前・境界・直後
- income/expense/transferとincludeTransfers/includeExcludedの組み合わせ
- group内外の振替変換、共通group、通常明細と振替明細の重複、振替同士の重複
- 異なるgroupId間の分離、複合AND検索、既定/最大limitとoffset

### Out-of-Scope Risks

- 大規模実データでの負荷試験は未実施。個人DBを使用せず、unit test用インメモリDBで検証した。
- UI変更がないためStorybook/E2E/runtime media検証は対象外。

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [ ] Storybook tests
- [ ] E2E tests
- [ ] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/db test — 21 files passed、291 tests passed、17 skipped（1 file skipped）
pnpm --filter @mf-dashboard/analytics test — 10 files passed、132 tests passed
pnpm turbo typecheck — 8 packages passed
pnpm lint — passed
pnpm format:check — passed（499 files）
pnpm knip — passed
git diff --check — passed
```

### Checks Not Run

- Storybook / E2E / manual runtime — UI・app behaviorを変更していないため対象外
