### PR TITLE
feat(chat): add structured finance cards

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@base-ui/react": "1.5.0",
+    "@mf-dashboard/analytics": "workspace:*",
     "@mf-dashboard/date-utils": "workspace:*",
     "@mf-dashboard/db": "workspace:*",
     "@mf-dashboard/meta": "workspace:*",

--- a/apps/web/src/components/chat/cards/finance-chat-card.stories.tsx
+++ b/apps/web/src/components/chat/cards/finance-chat-card.stories.tsx
@@ -1,0 +1,112 @@
+import type { FinanceChatCard as FinanceChatCardData } from "@mf-dashboard/analytics/chat/cards";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { FinanceChatCard } from "./finance-chat-card";
+
+const meta = {
+  title: "Chat/FinanceChatCard",
+  component: FinanceChatCard,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-full max-w-lg p-4">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof FinanceChatCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const summary = {
+  type: "summary",
+  title: "2026年7月の収支",
+  description: "確定済みの取引を集計しています",
+  href: "/cf/2026-07",
+  metrics: [
+    { label: "収入", amount: 350000, amountType: "income" },
+    { label: "支出", amount: -218000, amountType: "expense" },
+    { label: "収支", amount: 132000, amountType: "balance" },
+  ],
+} satisfies FinanceChatCardData;
+
+export const Summary: Story = { args: { card: summary } };
+
+export const TransactionList: Story = {
+  args: {
+    card: {
+      type: "transactionList",
+      title: "最近の支出",
+      href: "/cf/2026-07",
+      transactions: [
+        {
+          id: "transaction-a",
+          date: "2026-07-17",
+          description: "店舗 A",
+          category: "食費",
+          amount: -3200,
+          amountType: "expense",
+        },
+        {
+          id: "transaction-b",
+          date: "2026-07-16",
+          description: "交通機関 A",
+          category: "交通費",
+          amount: -860,
+          amountType: "expense",
+        },
+      ],
+    },
+  },
+};
+
+export const CategoryBreakdown: Story = {
+  args: {
+    card: {
+      type: "categoryBreakdown",
+      title: "カテゴリ別支出",
+      categories: [
+        { name: "住居費", amount: -82000, amountType: "expense", percentage: 52.4 },
+        { name: "食費", amount: -42000, amountType: "expense", percentage: 26.8 },
+        { name: "交通費", amount: -14000, amountType: "expense", percentage: 8.9 },
+      ],
+    },
+  },
+};
+
+export const Insight: Story = {
+  args: {
+    card: {
+      type: "insight",
+      title: "支出が減少しました",
+      description: "前月と比べて食費が12,000円減っています。",
+      amount: 12000,
+      amountType: "balance",
+      action: { label: "内訳を見る", href: "/cf/2026-07" },
+    },
+  },
+};
+
+export const Action: Story = {
+  args: {
+    card: {
+      type: "action",
+      title: "資産配分を確認しましょう",
+      description: "現在の口座残高と資産カテゴリを確認できます。",
+      action: { label: "資産を見る", href: "/bs" },
+    },
+  },
+};
+
+export const AllCards: Story = {
+  args: { card: summary },
+  render: () => (
+    <div className="space-y-4">
+      <FinanceChatCard card={summary} />
+      <FinanceChatCard {...TransactionList.args} />
+      <FinanceChatCard {...CategoryBreakdown.args} />
+      <FinanceChatCard {...Insight.args} />
+      <FinanceChatCard {...Action.args} />
+    </div>
+  ),
+};

--- a/apps/web/src/components/chat/cards/finance-chat-card.test.tsx
+++ b/apps/web/src/components/chat/cards/finance-chat-card.test.tsx
@@ -1,0 +1,78 @@
+import type { FinanceChatCard as FinanceChatCardData } from "@mf-dashboard/analytics/chat/cards";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FinanceChatCard } from "./finance-chat-card";
+
+describe("FinanceChatCard", () => {
+  it.each<FinanceChatCardData>([
+    {
+      type: "summary",
+      title: "収支サマリー",
+      href: "/cf/2026-07",
+      metrics: [{ label: "収支", amount: 1000, amountType: "balance" }],
+    },
+    {
+      type: "transactionList",
+      title: "取引一覧",
+      transactions: [
+        {
+          id: "transaction-a",
+          date: "2026-07-01",
+          description: "店舗 A",
+          amount: -1000,
+          amountType: "expense",
+        },
+      ],
+    },
+    {
+      type: "categoryBreakdown",
+      title: "カテゴリ内訳",
+      categories: [{ name: "食費", amount: -1000, amountType: "expense", percentage: 50 }],
+    },
+    { type: "insight", title: "インサイト", description: "前月より改善しました" },
+    {
+      type: "action",
+      title: "アクション",
+      description: "詳細を確認できます",
+      action: { label: "確認する", href: "/insights" },
+    },
+  ])("renders the $type card", (card) => {
+    render(<FinanceChatCard card={card} />);
+    expect(screen.getByText(card.title)).not.toBeNull();
+  });
+
+  it("uses semantic monetary colors and an allowed internal link", () => {
+    render(
+      <FinanceChatCard
+        card={{
+          type: "summary",
+          title: "収支",
+          href: "/group-a/cf/2026-07",
+          metrics: [
+            { label: "収入", amount: 2000, amountType: "income" },
+            { label: "支出", amount: -1500, amountType: "expense" },
+            { label: "差額", amount: 500, amountType: "balance" },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("2,000円").classList.contains("text-income")).toBe(true);
+    expect(screen.getByText("-1,500円").classList.contains("text-expense")).toBe(true);
+    expect(screen.getByText("500円").classList.contains("text-balance-positive")).toBe(true);
+    expect(screen.getByRole("link").getAttribute("href")).toBe("/group-a/cf/2026-07");
+  });
+
+  it("does not create a link for an unsafe runtime action", () => {
+    const card = {
+      type: "action",
+      title: "不正なアクション",
+      description: "外部 URL は開きません",
+      action: { label: "開く", href: "https://example.com" },
+    } as FinanceChatCardData;
+
+    render(<FinanceChatCard card={card} />);
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText("開く")).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/chat/cards/finance-chat-card.tsx
+++ b/apps/web/src/components/chat/cards/finance-chat-card.tsx
@@ -1,0 +1,196 @@
+import {
+  isFinanceChatHrefSafe,
+  type ActionCard as ActionCardData,
+  type CategoryBreakdownCard as CategoryBreakdownCardData,
+  type FinanceChatCard as FinanceChatCardData,
+  type InsightCard as InsightCardData,
+  type SummaryCard as SummaryCardData,
+  type TransactionListCard as TransactionListCardData,
+} from "@mf-dashboard/analytics/chat/cards";
+import { ArrowRight, ChartPie, Lightbulb, ReceiptText, WalletCards } from "lucide-react";
+import type { Route } from "next";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { cn } from "../../../lib/utils";
+import { AmountDisplay } from "../../ui/amount-display";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../../ui/card";
+
+interface FinanceChatCardProps {
+  card: FinanceChatCardData;
+}
+
+interface CardShellProps {
+  children: ReactNode;
+  href?: string;
+}
+
+function SafeLink({ href, className, children }: CardShellProps & { className?: string }) {
+  if (!href || !isFinanceChatHrefSafe(href)) return children;
+
+  return (
+    <Link href={href as Route} className={className}>
+      {children}
+    </Link>
+  );
+}
+
+function CardShell({ href, children }: CardShellProps) {
+  const isLinkable = href ? isFinanceChatHrefSafe(href) : false;
+
+  return (
+    <SafeLink
+      href={href}
+      className="block rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <Card className={cn("overflow-hidden", isLinkable && "transition-colors hover:bg-muted/50")}>
+        {children}
+      </Card>
+    </SafeLink>
+  );
+}
+
+function CardAction({ action }: { action: { label: string; href: string } }) {
+  const content = (
+    <span className="inline-flex h-9 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground">
+      {action.label}
+      <ArrowRight aria-hidden="true" className="size-4" />
+    </span>
+  );
+
+  return (
+    <SafeLink
+      href={action.href}
+      className="inline-flex rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      {content}
+    </SafeLink>
+  );
+}
+
+function SummaryCard({ card }: { card: SummaryCardData }) {
+  return (
+    <CardShell href={card.href}>
+      <CardHeader>
+        <CardTitle icon={WalletCards}>{card.title}</CardTitle>
+        {card.description && <CardDescription>{card.description}</CardDescription>}
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {card.metrics.map((metric) => (
+          <div key={metric.label} className="flex items-center justify-between gap-4">
+            <span className="text-sm text-muted-foreground">{metric.label}</span>
+            <AmountDisplay amount={metric.amount} type={metric.amountType} weight="semibold" />
+          </div>
+        ))}
+      </CardContent>
+    </CardShell>
+  );
+}
+
+function TransactionListCard({ card }: { card: TransactionListCardData }) {
+  return (
+    <CardShell href={card.href}>
+      <CardHeader>
+        <CardTitle icon={ReceiptText}>{card.title}</CardTitle>
+      </CardHeader>
+      <CardContent className="divide-y">
+        {card.transactions.map((transaction) => (
+          <div
+            key={transaction.id}
+            className="flex items-center justify-between gap-4 py-3 first:pt-0 last:pb-0"
+          >
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium">{transaction.description}</p>
+              <p className="text-xs text-muted-foreground">
+                <time dateTime={transaction.date}>{transaction.date}</time>
+                {transaction.category && ` · ${transaction.category}`}
+              </p>
+            </div>
+            <AmountDisplay
+              amount={transaction.amount}
+              type={transaction.amountType}
+              size="sm"
+              className="shrink-0"
+            />
+          </div>
+        ))}
+      </CardContent>
+    </CardShell>
+  );
+}
+
+function CategoryBreakdownCard({ card }: { card: CategoryBreakdownCardData }) {
+  return (
+    <CardShell href={card.href}>
+      <CardHeader>
+        <CardTitle icon={ChartPie}>{card.title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {card.categories.map((category) => (
+          <div key={category.name} className="space-y-1.5">
+            <div className="flex items-center justify-between gap-4 text-sm">
+              <span>{category.name}</span>
+              <div className="flex items-center gap-2">
+                <AmountDisplay amount={category.amount} type={category.amountType} size="sm" />
+                <span className="w-12 text-right text-xs tabular-nums text-muted-foreground">
+                  {category.percentage.toFixed(1)}%
+                </span>
+              </div>
+            </div>
+            <div className="h-2 overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full rounded-full bg-primary"
+                style={{ width: `${category.percentage}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </CardShell>
+  );
+}
+
+function InsightCard({ card }: { card: InsightCardData }) {
+  return (
+    <CardShell>
+      <CardHeader>
+        <CardTitle icon={Lightbulb}>{card.title}</CardTitle>
+        <CardDescription>{card.description}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {card.amount !== undefined && card.amountType && (
+          <AmountDisplay amount={card.amount} type={card.amountType} size="xl" weight="bold" />
+        )}
+        {card.action && <CardAction action={card.action} />}
+      </CardContent>
+    </CardShell>
+  );
+}
+
+function ActionCard({ card }: { card: ActionCardData }) {
+  return (
+    <CardShell>
+      <CardHeader>
+        <CardTitle icon={ArrowRight}>{card.title}</CardTitle>
+        <CardDescription>{card.description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <CardAction action={card.action} />
+      </CardContent>
+    </CardShell>
+  );
+}
+
+export function FinanceChatCard({ card }: FinanceChatCardProps) {
+  switch (card.type) {
+    case "summary":
+      return <SummaryCard card={card} />;
+    case "transactionList":
+      return <TransactionListCard card={card} />;
+    case "categoryBreakdown":
+      return <CategoryBreakdownCard card={card} />;
+    case "insight":
+      return <InsightCard card={card} />;
+    case "action":
+      return <ActionCard card={card} />;
+  }
+}

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./chat/cards": "./src/chat/cards.ts",
     "./chat/tools": "./src/chat/tools.ts",
     "./categorization": "./src/categorization.ts",
     "./tools/analysis": "./src/insights/analysis-tools.ts",

--- a/packages/analytics/src/chat/cards.test.ts
+++ b/packages/analytics/src/chat/cards.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { buildFinanceChatHref, financeChatCardSchema, financeChatHrefSchema } from "./cards.js";
+
+describe("financeChatHrefSchema", () => {
+  it.each(["/", "/cf", "/cf/2026-07", "/group-a/accounts/account-1", "/group-a/insights"])(
+    "accepts supported internal route %s",
+    (href) => expect(financeChatHrefSchema.safeParse(href).success).toBe(true),
+  );
+
+  it.each([
+    "https://example.com",
+    "//example.com",
+    "/cf/2026-13",
+    "/unknown/detail",
+    "/group-a/unknown",
+    "/group-a/cf/2026-07/extra",
+    "/accounts/%2e%2e",
+    "/cf?month=2026-07",
+  ])("rejects unsupported or unsafe route %s", (href) => {
+    expect(financeChatHrefSchema.safeParse(href).success).toBe(false);
+  });
+});
+
+describe("buildFinanceChatHref", () => {
+  it("builds routes from trusted page and parameter values", () => {
+    expect(buildFinanceChatHref({ page: "dashboard", groupId: "group-a" })).toBe("/group-a");
+    expect(buildFinanceChatHref({ page: "cashFlow", groupId: "group-a", month: "2026-07" })).toBe(
+      "/group-a/cf/2026-07",
+    );
+    expect(buildFinanceChatHref({ page: "accounts", accountId: "account 1" })).toBe(
+      "/accounts/account%201",
+    );
+  });
+
+  it("rejects traversal and invalid month parameters", () => {
+    expect(() => buildFinanceChatHref({ page: "dashboard", groupId: ".." })).toThrow(
+      "Invalid route segment",
+    );
+    expect(() => buildFinanceChatHref({ page: "cashFlow", month: "2026-13" })).toThrow(
+      "Invalid string",
+    );
+    expect(() => buildFinanceChatHref({ page: "accounts", accountId: "" })).toThrow("Too small");
+  });
+});
+
+describe("financeChatCardSchema", () => {
+  it("parses each supported card type", () => {
+    const cards = [
+      {
+        type: "summary",
+        title: "今月の収支",
+        metrics: [{ label: "収支", amount: 12000, amountType: "balance" }],
+      },
+      {
+        type: "transactionList",
+        title: "最近の支出",
+        transactions: [
+          {
+            id: "transaction-1",
+            date: "2026-07-01",
+            description: "店舗 A",
+            amount: -1200,
+            amountType: "expense",
+          },
+        ],
+      },
+      {
+        type: "categoryBreakdown",
+        title: "カテゴリ別支出",
+        categories: [{ name: "食費", amount: -1200, amountType: "expense", percentage: 50 }],
+      },
+      { type: "insight", title: "支出傾向", description: "前月より減少しています" },
+      {
+        type: "action",
+        title: "詳細を確認",
+        description: "収支ページで確認できます",
+        action: { label: "収支を見る", href: "/cf/2026-07" },
+      },
+    ];
+
+    for (const card of cards) expect(financeChatCardSchema.safeParse(card).success).toBe(true);
+  });
+
+  it("rejects an unsafe action and invalid numeric boundaries", () => {
+    expect(
+      financeChatCardSchema.safeParse({
+        type: "action",
+        title: "外部へ移動",
+        description: "不正な URL",
+        action: { label: "開く", href: "javascript:alert(1)" },
+      }).success,
+    ).toBe(false);
+    expect(
+      financeChatCardSchema.safeParse({
+        type: "categoryBreakdown",
+        title: "支出",
+        categories: [{ name: "食費", amount: 100, amountType: "expense", percentage: 101 }],
+      }).success,
+    ).toBe(false);
+    expect(
+      financeChatCardSchema.safeParse({
+        type: "transactionList",
+        title: "取引",
+        transactions: [
+          {
+            id: "transaction-1",
+            date: "2026-02-30",
+            description: "店舗 A",
+            amount: -100,
+            amountType: "expense",
+          },
+        ],
+      }).success,
+    ).toBe(false);
+    expect(
+      financeChatCardSchema.safeParse({
+        type: "insight",
+        title: "支出傾向",
+        description: "支出が減少しました",
+        amount: 1000,
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/analytics/src/chat/cards.ts
+++ b/packages/analytics/src/chat/cards.ts
@@ -1,0 +1,181 @@
+import { z } from "zod";
+
+const routeSegmentSchema = z
+  .string()
+  .min(1)
+  .refine((segment) => {
+    try {
+      const decoded = decodeURIComponent(segment);
+      return decoded !== "." && decoded !== ".." && !/[/?#\\\\]/.test(decoded);
+    } catch {
+      return false;
+    }
+  }, "Invalid route segment");
+
+const yearMonthSchema = z.string().regex(/^\d{4}-(0[1-9]|1[0-2])$/);
+const topLevelPages = new Set(["accounts", "bs", "cf", "insights", "simulator"]);
+
+export function isFinanceChatHrefSafe(href: string): boolean {
+  if (!href.startsWith("/") || href.startsWith("//") || href.includes("?") || href.includes("#")) {
+    return false;
+  }
+
+  const segments = href.split("/").slice(1);
+  if (segments.at(-1) === "") segments.pop();
+  if (!segments.every((segment) => routeSegmentSchema.safeParse(segment).success)) return false;
+
+  if (segments.length <= 1) return true;
+
+  const pageIndex = topLevelPages.has(segments[0]) ? 0 : 1;
+  const page = segments[pageIndex];
+  const detail = segments[pageIndex + 1];
+
+  if (!page || !topLevelPages.has(page)) return false;
+  if (!detail) return segments.length === pageIndex + 1;
+  if (segments.length !== pageIndex + 2) return false;
+
+  if (page === "cf") return yearMonthSchema.safeParse(detail).success;
+  return page === "accounts";
+}
+
+export const financeChatHrefSchema = z
+  .string()
+  .refine(isFinanceChatHrefSafe, "Only supported internal dashboard routes are allowed");
+
+const amountTypeSchema = z.enum(["income", "expense", "balance"]);
+const finiteAmountSchema = z.number().finite();
+const actionSchema = z.object({
+  label: z.string().min(1),
+  href: financeChatHrefSchema,
+});
+const linkableCardSchema = z.object({
+  href: financeChatHrefSchema.optional(),
+});
+
+export const summaryCardSchema = z
+  .object({
+    type: z.literal("summary"),
+    title: z.string().min(1),
+    description: z.string().min(1).optional(),
+    metrics: z
+      .array(
+        z.object({
+          label: z.string().min(1),
+          amount: finiteAmountSchema,
+          amountType: amountTypeSchema,
+        }),
+      )
+      .min(1),
+  })
+  .extend(linkableCardSchema.shape);
+
+export const transactionListCardSchema = z
+  .object({
+    type: z.literal("transactionList"),
+    title: z.string().min(1),
+    transactions: z
+      .array(
+        z.object({
+          id: z.string().min(1),
+          date: z.iso.date(),
+          description: z.string().min(1),
+          category: z.string().min(1).optional(),
+          amount: finiteAmountSchema,
+          amountType: z.enum(["income", "expense"]),
+        }),
+      )
+      .min(1),
+  })
+  .extend(linkableCardSchema.shape);
+
+export const categoryBreakdownCardSchema = z
+  .object({
+    type: z.literal("categoryBreakdown"),
+    title: z.string().min(1),
+    categories: z
+      .array(
+        z.object({
+          name: z.string().min(1),
+          amount: finiteAmountSchema,
+          amountType: z.enum(["income", "expense"]),
+          percentage: z.number().min(0).max(100),
+        }),
+      )
+      .min(1),
+  })
+  .extend(linkableCardSchema.shape);
+
+export const insightCardSchema = z
+  .object({
+    type: z.literal("insight"),
+    title: z.string().min(1),
+    description: z.string().min(1),
+    amount: finiteAmountSchema.optional(),
+    amountType: amountTypeSchema.optional(),
+    action: actionSchema.optional(),
+  })
+  .refine((card) => (card.amount === undefined) === (card.amountType === undefined), {
+    message: "Insight amount and amountType must be provided together",
+  });
+
+export const actionCardSchema = z.object({
+  type: z.literal("action"),
+  title: z.string().min(1),
+  description: z.string().min(1),
+  action: actionSchema,
+});
+
+export const financeChatCardSchema = z.discriminatedUnion("type", [
+  summaryCardSchema,
+  transactionListCardSchema,
+  categoryBreakdownCardSchema,
+  insightCardSchema,
+  actionCardSchema,
+]);
+
+export type FinanceChatCard = z.infer<typeof financeChatCardSchema>;
+export type SummaryCard = z.infer<typeof summaryCardSchema>;
+export type TransactionListCard = z.infer<typeof transactionListCardSchema>;
+export type CategoryBreakdownCard = z.infer<typeof categoryBreakdownCardSchema>;
+export type InsightCard = z.infer<typeof insightCardSchema>;
+export type ActionCard = z.infer<typeof actionCardSchema>;
+
+type FinanceChatRoute =
+  | { page: "dashboard"; groupId?: string }
+  | { page: "cashFlow"; groupId?: string; month?: string }
+  | { page: "balanceSheet"; groupId?: string }
+  | { page: "accounts"; groupId?: string; accountId?: string }
+  | { page: "insights"; groupId?: string }
+  | { page: "simulator"; groupId?: string };
+
+function encodeRouteSegment(segment: string): string {
+  return encodeURIComponent(routeSegmentSchema.parse(segment));
+}
+
+export function buildFinanceChatHref(route: FinanceChatRoute): string {
+  const segments = route.groupId === undefined ? [] : [encodeRouteSegment(route.groupId)];
+
+  switch (route.page) {
+    case "dashboard":
+      break;
+    case "cashFlow":
+      segments.push("cf");
+      if (route.month !== undefined) segments.push(yearMonthSchema.parse(route.month));
+      break;
+    case "balanceSheet":
+      segments.push("bs");
+      break;
+    case "accounts":
+      segments.push("accounts");
+      if (route.accountId !== undefined) segments.push(encodeRouteSegment(route.accountId));
+      break;
+    case "insights":
+      segments.push("insights");
+      break;
+    case "simulator":
+      segments.push("simulator");
+      break;
+  }
+
+  return financeChatHrefSchema.parse(`/${segments.join("/")}`);
+}

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -1,3 +1,22 @@
 export { analyzeFinancialData } from "./analyzer.js";
 export type { AnalyticsInsights, AnalyticsReport } from "./types.js";
 export { createAnalysisTools, createChatTools, createFinancialTools } from "./chat/tools.js";
+export {
+  actionCardSchema,
+  buildFinanceChatHref,
+  categoryBreakdownCardSchema,
+  financeChatCardSchema,
+  financeChatHrefSchema,
+  insightCardSchema,
+  isFinanceChatHrefSafe,
+  summaryCardSchema,
+  transactionListCardSchema,
+} from "./chat/cards.js";
+export type {
+  ActionCard,
+  CategoryBreakdownCard,
+  FinanceChatCard,
+  InsightCard,
+  SummaryCard,
+  TransactionListCard,
+} from "./chat/cards.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       '@base-ui/react':
         specifier: 1.5.0
         version: 1.5.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mf-dashboard/analytics':
+        specifier: workspace:*
+        version: link:../../packages/analytics
       '@mf-dashboard/date-utils':
         specifier: workspace:*
         version: link:../../packages/date-utils


### PR DESCRIPTION
# Summary

- Define a Zod-backed `FinanceChatCard` discriminated union for Summary, TransactionList, CategoryBreakdown, Insight, and Action cards.
- Add a deterministic route builder and runtime validation that only permit supported internal dashboard routes.
- Render all five card types with semantic monetary colors, Storybook coverage, and focused unit tests.

Closes HIR-101

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | All MVP tool-result card variants must retain their structured data and render deterministically. | All five variants parse and render with the expected values. |
| Security | LLM-provided href/action values must not enable external or unsafe navigation. | Schemas and the renderer reject external URLs, traversal, malformed route details, and invalid parameters. |
| Usability / accessibility | Cards must remain readable and operable in the chat surface. | Storybook browser tests pass; links expose focus styles and monetary values use existing semantic classes. |
| Maintainability | Type/schema drift would break downstream tool result rendering. | TypeScript types are inferred from the Zod schemas and renderer dispatch is based on the discriminant. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Equivalence partitioning and boundary value analysis | Route, date, percentage, and optional-pair inputs have clear valid/invalid partitions and boundaries. | Supported paths and values are accepted; external URLs, traversal, invalid dates/months, empty route parameters, and percentages above 100 are rejected. |
| Decision table and branch testing | Each card discriminant and safe/unsafe link state selects a distinct render branch. | Five render branches, semantic amount variants, allowed links, and unsafe-link fallback are exercised. |
| Exploratory / checklist-based testing | Visual composition and navigation affordances are best assessed in a browser. | AllCards Storybook view shows all variants, semantic colors, readable layout, and expected internal href values. |

### Primary Test Conditions

- Parse every supported card variant from the shared schema.
- Build global and group-scoped cash-flow/account routes.
- Reject external URLs, protocol-relative URLs, traversal, malformed dates/months, and incomplete insight amounts.
- Render all five variants and verify income, expense, and balance semantic classes.
- Render an unsafe runtime action without creating a link.
- Launch the AllCards story in Chromium and inspect all card headings and generated href values.

### Out-of-Scope Risks

- End-to-end LLM/tool-result integration is part of the parent chat flow; this branch supplies the shared contract and pure renderer.
- ChartCard and AccountListCard are explicitly post-MVP.
- Existing unrelated Storybook chart-size console warnings remain unchanged.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [x] Storybook tests
- [ ] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/analytics test — 9 files / 131 tests passed
pnpm --filter @mf-dashboard/web test:unit — 24 files / 383 tests passed
pnpm --filter @mf-dashboard/web test:storybook — 75 files / 336 tests passed
pnpm turbo typecheck — 8 packages passed
pnpm lint — passed
pnpm format:check — passed
pnpm knip — passed
Storybook AllCards in Chromium — five card headings rendered; implementation hrefs limited to /cf/2026-07 and /bs
```

### Checks Not Run

- Web E2E — no application route or complete chat container exists on the epic branch; the pure card renderer is covered by unit, Storybook browser, and manual Storybook runtime verification.
