### PR TITLE
feat(chat): implement finance MVP responses

### DIFF
--- a/apps/web/src/app/api/chat/route.test.ts
+++ b/apps/web/src/app/api/chat/route.test.ts
@@ -384,6 +384,75 @@ describe("POST /api/chat", () => {
     );
   });
 
+  it("does not preserve cards from multiple presentation calls in follow-up context", async () => {
+    await POST(request({ groupId: "group-b", messages }));
+    const streamOptions = mocks.streamText.mock.calls[0]![0];
+    streamOptions.onChunk({ chunk: { type: "text-delta", text: "確認しました。" } });
+    const cards = [
+      {
+        type: "action" as const,
+        title: "詳細を確認",
+        description: "収支ページで確認できます",
+        action: { label: "収支を見る", href: "/group-b/cf/2026-07" },
+      },
+    ];
+    const emptyCards = [
+      {
+        type: "empty" as const,
+        title: "支出がありません",
+        description: "条件を変えて確認してください",
+        prompts: ["今月の支出は？"],
+      },
+    ];
+    streamOptions.onChunk({
+      chunk: { type: "tool-result", toolName: "presentFinanceCards", output: cards },
+    });
+    streamOptions.onChunk({
+      chunk: { type: "tool-result", toolName: "presentFinanceCards", output: emptyCards },
+    });
+    const responseOptions = mocks.toUIMessageStreamResponse.mock.calls[0]![0];
+    const metadata = responseOptions.messageMetadata({ part: { type: "finish" } });
+    const signedAssistantMessage: UIMessage = {
+      id: "message-assistant",
+      role: "assistant",
+      metadata,
+      parts: [
+        { type: "text", text: "確認しました。" },
+        {
+          type: "tool-presentFinanceCards",
+          toolCallId: "tool-call-a",
+          state: "output-available",
+          input: { cards },
+          output: cards,
+        },
+        {
+          type: "tool-presentFinanceCards",
+          toolCallId: "tool-call-b",
+          state: "output-available",
+          input: { cards: emptyCards },
+          output: emptyCards,
+        },
+      ],
+    };
+    const followUpMessages = [
+      messages[0],
+      signedAssistantMessage,
+      { id: "message-b", role: "user", parts: [{ type: "text", text: "続けて" }] },
+    ] satisfies UIMessage[];
+    mocks.safeValidateUIMessages.mockResolvedValue({ success: true, data: followUpMessages });
+
+    await POST(request({ groupId: "group-b", messages: followUpMessages }));
+
+    expect(mocks.convertToModelMessages).toHaveBeenLastCalledWith(
+      [
+        messages[0],
+        { ...signedAssistantMessage, parts: [{ type: "text", text: "確認しました。" }] },
+        followUpMessages[2],
+      ],
+      { tools },
+    );
+  });
+
   it("returns unavailable when the LLM environment is incomplete", async () => {
     mocks.isLLMEnabled.mockReturnValue(false);
 

--- a/apps/web/src/app/api/chat/route.test.ts
+++ b/apps/web/src/app/api/chat/route.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   getCurrentGroup: vi.fn<AnyMock>(),
   getDb: vi.fn<AnyMock>(),
   getModel: vi.fn<AnyMock>(),
+  getToolName: vi.fn<AnyMock>(),
   isToolUIPart: vi.fn<AnyMock>(),
   isDatabaseAvailable: vi.fn<AnyMock>(),
   isLLMEnabled: vi.fn<AnyMock>(),
@@ -39,6 +40,7 @@ vi.mock("@mf-dashboard/db", () => ({
 vi.mock("ai", () => ({
   consumeStream: mocks.consumeStream,
   convertToModelMessages: mocks.convertToModelMessages,
+  getToolName: mocks.getToolName,
   isToolUIPart: mocks.isToolUIPart,
   safeValidateUIMessages: mocks.safeValidateUIMessages,
   stepCountIs: mocks.stepCountIs,
@@ -79,6 +81,7 @@ describe("POST /api/chat", () => {
     mocks.isToolUIPart.mockImplementation(
       (part) => part.type === "dynamic-tool" || part.type.startsWith("tool-"),
     );
+    mocks.getToolName.mockImplementation((part) => part.type.replace(/^tool-/, ""));
     mocks.createFinanceChatTools.mockReturnValue(tools);
     mocks.convertToModelMessages.mockResolvedValue(modelMessages);
     mocks.stepCountIs.mockReturnValue("finite-stop-condition");
@@ -294,10 +297,21 @@ describe("POST /api/chat", () => {
     );
   });
 
-  it("keeps signed assistant text in model history without tool outputs", async () => {
+  it("keeps signed assistant text and presentation context without raw data tool outputs", async () => {
     await POST(request({ groupId: "group-b", messages }));
     const streamOptions = mocks.streamText.mock.calls[0]![0];
     streamOptions.onChunk({ chunk: { type: "text-delta", text: "支出を見直しましょう。" } });
+    const cards = [
+      {
+        type: "action" as const,
+        title: "詳細を確認",
+        description: "収支ページで確認できます",
+        action: { label: "収支を見る", href: "/group-b/cf/2026-07" },
+      },
+    ];
+    streamOptions.onChunk({
+      chunk: { type: "tool-result", toolName: "presentFinanceCards", output: cards },
+    });
     const responseOptions = mocks.toUIMessageStreamResponse.mock.calls[0]![0];
     const metadata = responseOptions.messageMetadata({ part: { type: "finish" } });
     const signedAssistantMessage: UIMessage = {
@@ -312,6 +326,13 @@ describe("POST /api/chat", () => {
           state: "output-available",
           input: { query: "食費" },
           output: { transactions: [{ amount: 1_000 }] },
+        },
+        {
+          type: "tool-presentFinanceCards",
+          toolCallId: "tool-call-b",
+          state: "output-available",
+          input: { cards },
+          output: cards,
         },
       ],
     };
@@ -330,10 +351,35 @@ describe("POST /api/chat", () => {
         messages[0],
         {
           ...signedAssistantMessage,
-          parts: [{ type: "text", text: "支出を見直しましょう。" }],
+          parts: [
+            { type: "text", text: "支出を見直しましょう。" },
+            {
+              type: "text",
+              text: `\n\n直前の回答で表示したカード: ${JSON.stringify(cards)}`,
+            },
+          ],
         },
         followUpMessages[2],
       ],
+      { tools },
+    );
+
+    const tamperedMessages = structuredClone(followUpMessages);
+    const presentationPart = tamperedMessages[1]!.parts[2];
+    if (presentationPart?.type === "tool-presentFinanceCards") {
+      presentationPart.output = [
+        {
+          ...cards[0],
+          action: { ...cards[0]!.action, href: "/group-a/cf/2026-07" },
+        },
+      ];
+    }
+    mocks.safeValidateUIMessages.mockResolvedValue({ success: true, data: tamperedMessages });
+
+    await POST(request({ groupId: "group-b", messages: tamperedMessages }));
+
+    expect(mocks.convertToModelMessages).toHaveBeenLastCalledWith(
+      [tamperedMessages[0], tamperedMessages[2]],
       { tools },
     );
   });

--- a/apps/web/src/app/api/chat/route.test.ts
+++ b/apps/web/src/app/api/chat/route.test.ts
@@ -125,6 +125,22 @@ describe("POST /api/chat", () => {
     await expect(response.text()).resolves.toContain("tool-output-available");
   });
 
+  it("defines the MVP card recipes and household improvement criteria", async () => {
+    await POST(request({ messages }));
+
+    const systemPrompt = mocks.streamText.mock.calls[0]![0].system as string;
+    expect(systemPrompt).toContain(
+      "日付別支出には、expenseを検索し、summary、transactionList、action",
+    );
+    expect(systemPrompt).toContain("月次状況には、対象月の収支を取得し、summaryとinsight");
+    expect(systemPrompt).toContain("summary、categoryBreakdown、transactionList");
+    expect(systemPrompt).toContain("手残りと貯蓄率がどれだけ改善するか");
+    expect(systemPrompt).toContain("最新の総資産を取得し、summary");
+    expect(systemPrompt).toContain("emptyだけを提示");
+    expect(systemPrompt).toContain("手残り、貯蓄率、予備資金、負債、資産の集中度");
+    expect(systemPrompt).toMatch(/現在日付は\d{4}-\d{2}-\d{2}（Asia\/Tokyo）/);
+  });
+
   it("rejects malformed JSON", async () => {
     const response = await POST(
       new Request("http://localhost/api/chat", { method: "POST", body: "{" }),

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -23,7 +23,23 @@ const SYSTEM_PROMPT = `あなたは家計改善を支援するAIアシスタン�
 - ページへ誘導するときは、ツール結果とアプリのroute builderから提供された内部リンクだけを使用してください。URLを自作しないでください。
 - 個人情報や家計データを必要以上に繰り返さず、外部共有を促さないでください。
 - 断定できない場合は不足している根拠を明示し、追加確認を促してください。
-- 回答は簡潔な日本語で、実行可能な家計改善策を優先してください。`;
+- 回答は簡潔な日本語で、実行可能な家計改善策を優先してください。
+- データ取得後は必ずpresentFinanceCardsを1回呼び、本文の要点をstructured cardsでも提示してください。
+- 「6/10の支出を見たい」など日付別支出には、expenseを検索し、summary、transactionList、actionの順で提示してください。
+- 「今月どう？」など月次状況には、対象月の収支を取得し、summaryとinsightを提示してください。
+- 「今月の食費は？」などカテゴリ支出には、対象月・カテゴリの取引とカテゴリ合計を取得し、summary、categoryBreakdown、transactionListを提示してください。
+- 「削れそうな支出ある？」には、固定費・変動費と過去比較を取得し、変動費の候補を中心に、固定費を別枠のinsightで提示してください。手残りと貯蓄率がどれだけ改善するかを主な判断基準にしてください。
+- 「総資産は？」には最新の総資産を取得し、summaryを提示してください。
+- 該当データがない場合、金額を推測せずemptyだけを提示し、期間や条件を変える代替promptを1〜3件含めてください。
+- empty以外ではgetFinanceDashboardRouteを呼び、その結果だけをhrefまたはactionに使って、詳細ページへ遷移できるCTAを少なくとも1件含めてください。
+- 投資余力を扱う場合は、手残り、貯蓄率、予備資金、負債、資産の集中度をすべて確認し、不足する観点があれば結論を保留してください。`;
+
+function getSystemPrompt(): string {
+  const currentDate = new Intl.DateTimeFormat("sv-SE", { timeZone: "Asia/Tokyo" }).format(
+    new Date(),
+  );
+  return `${SYSTEM_PROMPT}\n- 現在日付は${currentDate}（Asia/Tokyo）です。年のない日付はこの日付を基準に解釈してください。`;
+}
 
 function errorResponse(status: number, code: string, message: string): Response {
   return Response.json({ error: { code, message } }, { status });
@@ -149,7 +165,7 @@ export async function POST(request: Request): Promise<Response> {
   const result = streamText({
     abortSignal: request.signal,
     model,
-    system: SYSTEM_PROMPT,
+    system: getSystemPrompt(),
     messages: await convertToModelMessages(modelInputMessages, { tools }),
     onChunk: ({ chunk }) => {
       if (chunk.type === "text-delta") assistantText += chunk.text;

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -1,10 +1,12 @@
 import { createHmac } from "node:crypto";
+import { financeChatCardsSchema, type FinanceChatCard } from "@mf-dashboard/analytics/chat/cards";
 import { createFinanceChatTools } from "@mf-dashboard/analytics/chat/tools";
 import { getModel, isLLMEnabled } from "@mf-dashboard/analytics/config";
 import { getAllGroups, getCurrentGroup, getDb, isDatabaseAvailable } from "@mf-dashboard/db";
 import {
   consumeStream,
   convertToModelMessages,
+  getToolName,
   isToolUIPart,
   safeValidateUIMessages,
   stepCountIs,
@@ -60,8 +62,25 @@ function getMessageText(message: UIMessage): string {
     .join("");
 }
 
-function signAssistantMessage(groupId: string, text: string): string {
-  return createHmac("sha256", process.env.AI_API_KEY!).update(`${groupId}\0${text}`).digest("hex");
+function getPresentationCards(message: UIMessage): FinanceChatCard[] {
+  return message.parts.flatMap((part) => {
+    if (
+      !isToolUIPart(part) ||
+      getToolName(part) !== "presentFinanceCards" ||
+      part.state !== "output-available"
+    ) {
+      return [];
+    }
+
+    const result = financeChatCardsSchema.safeParse(part.output);
+    return result.success ? result.data : [];
+  });
+}
+
+function signAssistantMessage(groupId: string, text: string, cards: FinanceChatCard[]): string {
+  return createHmac("sha256", process.env.AI_API_KEY!)
+    .update(`${groupId}\0${text}\0${JSON.stringify(cards)}`)
+    .digest("hex");
 }
 
 function hasValidAssistantSignature(message: UIMessage, groupId: string): boolean {
@@ -71,7 +90,8 @@ function hasValidAssistantSignature(message: UIMessage, groupId: string): boolea
     typeof metadata === "object" &&
     metadata !== null &&
     SIGNATURE_METADATA_KEY in metadata &&
-    metadata[SIGNATURE_METADATA_KEY] === signAssistantMessage(groupId, getMessageText(message))
+    metadata[SIGNATURE_METADATA_KEY] ===
+      signAssistantMessage(groupId, getMessageText(message), getPresentationCards(message))
   );
 }
 
@@ -82,12 +102,23 @@ function getTrustedModelMessages(messages: UIMessage[], groupId: string): UIMess
         message.role === "user" ||
         (message.role === "assistant" && hasValidAssistantSignature(message, groupId)),
     )
-    .map((message) => ({
-      ...message,
-      parts: message.parts.filter((part) =>
-        message.role === "assistant" ? part.type === "text" : !isToolUIPart(part),
-      ),
-    }))
+    .map((message) => {
+      if (message.role !== "assistant") {
+        return { ...message, parts: message.parts.filter((part) => !isToolUIPart(part)) };
+      }
+
+      const cards = getPresentationCards(message);
+      const parts = message.parts.filter((part) => part.type === "text");
+
+      if (cards.length > 0) {
+        parts.push({
+          type: "text",
+          text: `\n\n直前の回答で表示したカード: ${JSON.stringify(cards)}`,
+        });
+      }
+
+      return { ...message, parts };
+    })
     .filter((message) => message.parts.length > 0);
 }
 
@@ -162,6 +193,7 @@ export async function POST(request: Request): Promise<Response> {
   const tools = createFinanceChatTools(db, group.id);
   const modelInputMessages = getTrustedModelMessages(validation.data, group.id);
   let assistantText = "";
+  let assistantCards: FinanceChatCard[] = [];
   const result = streamText({
     abortSignal: request.signal,
     model,
@@ -169,6 +201,10 @@ export async function POST(request: Request): Promise<Response> {
     messages: await convertToModelMessages(modelInputMessages, { tools }),
     onChunk: ({ chunk }) => {
       if (chunk.type === "text-delta") assistantText += chunk.text;
+      if (chunk.type === "tool-result" && chunk.toolName === "presentFinanceCards") {
+        const parsedCards = financeChatCardsSchema.safeParse(chunk.output);
+        if (parsedCards.success) assistantCards.push(...parsedCards.data);
+      }
     },
     tools,
     stopWhen: stepCountIs(MAX_TOOL_STEPS),
@@ -178,7 +214,9 @@ export async function POST(request: Request): Promise<Response> {
     consumeSseStream: consumeStream,
     messageMetadata: ({ part }) =>
       part.type === "finish"
-        ? { [SIGNATURE_METADATA_KEY]: signAssistantMessage(group.id, assistantText) }
+        ? {
+            [SIGNATURE_METADATA_KEY]: signAssistantMessage(group.id, assistantText, assistantCards),
+          }
         : undefined,
     originalMessages: validation.data,
     onError: () => "回答の生成中にエラーが発生しました。",

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -63,18 +63,28 @@ function getMessageText(message: UIMessage): string {
 }
 
 function getPresentationCards(message: UIMessage): FinanceChatCard[] {
-  return message.parts.flatMap((part) => {
+  const outputs: unknown[] = [];
+
+  for (const part of message.parts) {
     if (
       !isToolUIPart(part) ||
       getToolName(part) !== "presentFinanceCards" ||
       part.state !== "output-available"
     ) {
-      return [];
+      continue;
     }
 
-    const result = financeChatCardsSchema.safeParse(part.output);
-    return result.success ? result.data : [];
-  });
+    outputs.push(part.output);
+  }
+
+  return getSinglePresentationCards(outputs);
+}
+
+function getSinglePresentationCards(outputs: unknown[]): FinanceChatCard[] {
+  if (outputs.length !== 1) return [];
+
+  const result = financeChatCardsSchema.safeParse(outputs[0]);
+  return result.success ? result.data : [];
 }
 
 function signAssistantMessage(groupId: string, text: string, cards: FinanceChatCard[]): string {
@@ -193,7 +203,7 @@ export async function POST(request: Request): Promise<Response> {
   const tools = createFinanceChatTools(db, group.id);
   const modelInputMessages = getTrustedModelMessages(validation.data, group.id);
   let assistantText = "";
-  let assistantCards: FinanceChatCard[] = [];
+  const presentationOutputs: unknown[] = [];
   const result = streamText({
     abortSignal: request.signal,
     model,
@@ -202,8 +212,7 @@ export async function POST(request: Request): Promise<Response> {
     onChunk: ({ chunk }) => {
       if (chunk.type === "text-delta") assistantText += chunk.text;
       if (chunk.type === "tool-result" && chunk.toolName === "presentFinanceCards") {
-        const parsedCards = financeChatCardsSchema.safeParse(chunk.output);
-        if (parsedCards.success) assistantCards.push(...parsedCards.data);
+        presentationOutputs.push(chunk.output);
       }
     },
     tools,
@@ -215,7 +224,11 @@ export async function POST(request: Request): Promise<Response> {
     messageMetadata: ({ part }) =>
       part.type === "finish"
         ? {
-            [SIGNATURE_METADATA_KEY]: signAssistantMessage(group.id, assistantText, assistantCards),
+            [SIGNATURE_METADATA_KEY]: signAssistantMessage(
+              group.id,
+              assistantText,
+              getSinglePresentationCards(presentationOutputs),
+            ),
           }
         : undefined,
     originalMessages: validation.data,

--- a/apps/web/src/components/chat/cards/finance-chat-card.stories.tsx
+++ b/apps/web/src/components/chat/cards/finance-chat-card.stories.tsx
@@ -98,6 +98,17 @@ export const Action: Story = {
   },
 };
 
+export const Empty: Story = {
+  args: {
+    card: {
+      type: "empty",
+      title: "支出が見つかりません",
+      description: "期間や条件を変えて、もう一度お試しください。",
+      prompts: ["今月の支出を見たい", "先月の支出を見たい"],
+    },
+  },
+};
+
 export const AllCards: Story = {
   args: { card: summary },
   render: () => (
@@ -107,6 +118,7 @@ export const AllCards: Story = {
       <FinanceChatCard {...CategoryBreakdown.args} />
       <FinanceChatCard {...Insight.args} />
       <FinanceChatCard {...Action.args} />
+      <FinanceChatCard {...Empty.args} />
     </div>
   ),
 };

--- a/apps/web/src/components/chat/cards/finance-chat-card.test.tsx
+++ b/apps/web/src/components/chat/cards/finance-chat-card.test.tsx
@@ -1,6 +1,6 @@
 import type { FinanceChatCard as FinanceChatCardData } from "@mf-dashboard/analytics/chat/cards";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { FinanceChatCard } from "./finance-chat-card";
 
 describe("FinanceChatCard", () => {
@@ -36,9 +36,33 @@ describe("FinanceChatCard", () => {
       description: "詳細を確認できます",
       action: { label: "確認する", href: "/insights" },
     },
+    {
+      type: "empty",
+      title: "支出が見つかりません",
+      description: "期間を変えて確認してください",
+      prompts: ["今月の支出を見たい"],
+    },
   ])("renders the $type card", (card) => {
     render(<FinanceChatCard card={card} />);
     expect(screen.getByText(card.title)).not.toBeNull();
+  });
+
+  it("submits an alternative prompt from the empty state", () => {
+    const onPromptSelect = vi.fn<(prompt: string) => void>();
+    render(
+      <FinanceChatCard
+        card={{
+          type: "empty",
+          title: "見つかりません",
+          description: "別の条件をお試しください",
+          prompts: ["先月の支出を見たい"],
+        }}
+        onPromptSelect={onPromptSelect}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "先月の支出を見たい" }));
+    expect(onPromptSelect).toHaveBeenCalledWith("先月の支出を見たい");
   });
 
   it("uses semantic monetary colors and an allowed internal link", () => {

--- a/apps/web/src/components/chat/cards/finance-chat-card.tsx
+++ b/apps/web/src/components/chat/cards/finance-chat-card.tsx
@@ -2,12 +2,13 @@ import {
   isFinanceChatHrefSafe,
   type ActionCard as ActionCardData,
   type CategoryBreakdownCard as CategoryBreakdownCardData,
+  type EmptyCard as EmptyCardData,
   type FinanceChatCard as FinanceChatCardData,
   type InsightCard as InsightCardData,
   type SummaryCard as SummaryCardData,
   type TransactionListCard as TransactionListCardData,
 } from "@mf-dashboard/analytics/chat/cards";
-import { ArrowRight, ChartPie, Lightbulb, ReceiptText, WalletCards } from "lucide-react";
+import { ArrowRight, ChartPie, Inbox, Lightbulb, ReceiptText, WalletCards } from "lucide-react";
 import type { Route } from "next";
 import Link from "next/link";
 import type { ReactNode } from "react";
@@ -17,6 +18,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../..
 
 interface FinanceChatCardProps {
   card: FinanceChatCardData;
+  onPromptSelect?: (prompt: string) => void;
 }
 
 interface CardShellProps {
@@ -180,7 +182,36 @@ function ActionCard({ card }: { card: ActionCardData }) {
   );
 }
 
-export function FinanceChatCard({ card }: FinanceChatCardProps) {
+function EmptyCard({
+  card,
+  onPromptSelect,
+}: {
+  card: EmptyCardData;
+  onPromptSelect?: (prompt: string) => void;
+}) {
+  return (
+    <CardShell>
+      <CardHeader>
+        <CardTitle icon={Inbox}>{card.title}</CardTitle>
+        <CardDescription>{card.description}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {card.prompts.map((prompt) => (
+          <button
+            key={prompt}
+            type="button"
+            className="block w-full rounded-md border px-3 py-2 text-left text-sm transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={() => onPromptSelect?.(prompt)}
+          >
+            {prompt}
+          </button>
+        ))}
+      </CardContent>
+    </CardShell>
+  );
+}
+
+export function FinanceChatCard({ card, onPromptSelect }: FinanceChatCardProps) {
   switch (card.type) {
     case "summary":
       return <SummaryCard card={card} />;
@@ -192,5 +223,7 @@ export function FinanceChatCard({ card }: FinanceChatCardProps) {
       return <InsightCard card={card} />;
     case "action":
       return <ActionCard card={card} />;
+    case "empty":
+      return <EmptyCard card={card} onPromptSelect={onPromptSelect} />;
   }
 }

--- a/apps/web/src/components/chat/chat-shell.stories.tsx
+++ b/apps/web/src/components/chat/chat-shell.stories.tsx
@@ -13,6 +13,69 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const structuredResponse = {
+  id: "assistant-structured",
+  role: "assistant" as const,
+  parts: [
+    { type: "text" as const, text: "6月10日の支出は合計3,200円でした。" },
+    {
+      type: "tool-presentFinanceCards" as const,
+      toolCallId: "present-structured",
+      state: "output-available" as const,
+      input: { cards: [] },
+      output: [
+        {
+          type: "summary" as const,
+          title: "6月10日の支出",
+          metrics: [{ label: "支出合計", amount: -3_200, amountType: "expense" as const }],
+        },
+        {
+          type: "transactionList" as const,
+          title: "支出明細",
+          transactions: [
+            {
+              id: "transaction-a",
+              date: "2026-06-10",
+              description: "店舗 A",
+              category: "食費",
+              amount: -3_200,
+              amountType: "expense" as const,
+            },
+          ],
+        },
+        {
+          type: "action" as const,
+          title: "6月の詳細",
+          description: "月全体の収支と明細を確認できます。",
+          action: { label: "収支ページを見る", href: "/cf/2026-06" },
+        },
+      ],
+    },
+  ],
+};
+
+const emptyResponse = {
+  id: "assistant-empty",
+  role: "assistant" as const,
+  parts: [
+    { type: "text" as const, text: "指定された条件の支出は見つかりませんでした。" },
+    {
+      type: "tool-presentFinanceCards" as const,
+      toolCallId: "present-empty",
+      state: "output-available" as const,
+      input: { cards: [] },
+      output: [
+        {
+          type: "empty" as const,
+          title: "支出が見つかりません",
+          description: "期間や条件を変えて、もう一度お試しください。",
+          prompts: ["今月の支出を見たい", "先月の支出を見たい"],
+        },
+      ],
+    },
+  ],
+};
+
 export const Closed: Story = {
   render: () => (
     <ChatProvider>
@@ -24,6 +87,22 @@ export const Closed: Story = {
 export const Open: Story = {
   render: () => (
     <ChatProvider initialOpen>
+      <ChatShell />
+    </ChatProvider>
+  ),
+};
+
+export const StructuredResponse: Story = {
+  render: () => (
+    <ChatProvider initialMessages={[structuredResponse]} initialOpen>
+      <ChatShell />
+    </ChatProvider>
+  ),
+};
+
+export const EmptyResponse: Story = {
+  render: () => (
+    <ChatProvider initialMessages={[emptyResponse]} initialOpen>
       <ChatShell />
     </ChatProvider>
   ),

--- a/apps/web/src/components/chat/chat-shell.test.tsx
+++ b/apps/web/src/components/chat/chat-shell.test.tsx
@@ -3,6 +3,47 @@ import { describe, expect, it, vi } from "vitest";
 import { ChatProvider } from "./chat-provider";
 import { ChatShell } from "./chat-shell";
 
+const structuredMessage = {
+  id: "assistant-structured",
+  role: "assistant" as const,
+  parts: [
+    { type: "text" as const, text: "6月10日の支出です。" },
+    {
+      type: "tool-presentFinanceCards" as const,
+      toolCallId: "present-a",
+      state: "output-available" as const,
+      input: { cards: [] },
+      output: [
+        {
+          type: "summary" as const,
+          title: "6月10日の支出",
+          metrics: [{ label: "支出合計", amount: -3_200, amountType: "expense" as const }],
+        },
+        {
+          type: "transactionList" as const,
+          title: "支出明細",
+          transactions: [
+            {
+              id: "transaction-a",
+              date: "2026-06-10",
+              description: "店舗 A",
+              category: "食費",
+              amount: -3_200,
+              amountType: "expense" as const,
+            },
+          ],
+        },
+        {
+          type: "action" as const,
+          title: "月の詳細",
+          description: "6月の収支ページを確認できます",
+          action: { label: "詳細を見る", href: "/cf/2026-06" },
+        },
+      ],
+    },
+  ],
+};
+
 describe("ChatShell", () => {
   it("opens, focuses the input, and restores focus after Escape", async () => {
     render(
@@ -67,5 +108,48 @@ describe("ChatShell", () => {
 
     expect(localStorageSpy).not.toHaveBeenCalled();
     localStorageSpy.mockRestore();
+  });
+
+  it("renders validated structured cards and their CTA", () => {
+    render(
+      <ChatProvider initialMessages={[structuredMessage]} initialOpen>
+        <ChatShell />
+      </ChatProvider>,
+    );
+
+    expect(screen.getByText("6月10日の支出です。")).toBeTruthy();
+    expect(screen.getByText("6月10日の支出")).toBeTruthy();
+    expect(screen.getByText("支出明細")).toBeTruthy();
+    expect(screen.getByText("店舗 A")).toBeTruthy();
+    expect(screen.getByRole("link", { name: /詳細を見る/ }).getAttribute("href")).toBe(
+      "/cf/2026-06",
+    );
+  });
+
+  it("ignores unvalidated or unrelated tool output", () => {
+    render(
+      <ChatProvider
+        initialMessages={[
+          {
+            id: "assistant-raw-tool",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-searchTransactions",
+                toolCallId: "search-a",
+                state: "output-available",
+                input: {},
+                output: { transactions: [{ description: "表示しない明細" }] },
+              },
+            ],
+          },
+        ]}
+        initialOpen
+      >
+        <ChatShell />
+      </ChatProvider>,
+    );
+
+    expect(screen.queryByText("表示しない明細")).toBeNull();
   });
 });

--- a/apps/web/src/components/chat/chat-shell.test.tsx
+++ b/apps/web/src/components/chat/chat-shell.test.tsx
@@ -126,6 +126,42 @@ describe("ChatShell", () => {
     );
   });
 
+  it("rejects multiple presentation outputs in one response", () => {
+    render(
+      <ChatProvider
+        initialMessages={[
+          {
+            ...structuredMessage,
+            parts: [
+              ...structuredMessage.parts,
+              {
+                type: "tool-presentFinanceCards" as const,
+                toolCallId: "present-b",
+                state: "output-available" as const,
+                input: { cards: [] },
+                output: [
+                  {
+                    type: "empty" as const,
+                    title: "該当する支出はありません",
+                    description: "別の日付で確認できます",
+                    prompts: ["今月の支出を見たい"],
+                  },
+                ],
+              },
+            ],
+          },
+        ]}
+        initialOpen
+      >
+        <ChatShell />
+      </ChatProvider>,
+    );
+
+    expect(screen.getByText("6月10日の支出です。")).toBeTruthy();
+    expect(screen.queryByText("6月10日の支出")).toBeNull();
+    expect(screen.queryByText("該当する支出はありません")).toBeNull();
+  });
+
   it("ignores unvalidated or unrelated tool output", () => {
     render(
       <ChatProvider

--- a/apps/web/src/components/chat/chat-shell.tsx
+++ b/apps/web/src/components/chat/chat-shell.tsx
@@ -17,18 +17,22 @@ const PANEL_ID = "finance-ai-chat-panel";
 function getFinanceCards(message: UIMessage): FinanceChatCardData[] {
   if (message.role !== "assistant") return [];
 
-  return message.parts.flatMap((part) => {
-    if (
-      !isToolUIPart(part) ||
-      getToolName(part) !== "presentFinanceCards" ||
-      part.state !== "output-available"
-    ) {
-      return [];
-    }
+  const presentationOutputs: unknown[] = [];
 
-    const result = financeChatCardsSchema.safeParse(part.output);
-    return result.success ? result.data : [];
-  });
+  for (const part of message.parts) {
+    if (
+      isToolUIPart(part) &&
+      getToolName(part) === "presentFinanceCards" &&
+      part.state === "output-available"
+    ) {
+      presentationOutputs.push(part.output);
+    }
+  }
+
+  if (presentationOutputs.length !== 1) return [];
+
+  const result = financeChatCardsSchema.safeParse(presentationOutputs[0]);
+  return result.success ? result.data : [];
 }
 
 export function ChatShell() {

--- a/apps/web/src/components/chat/chat-shell.tsx
+++ b/apps/web/src/components/chat/chat-shell.tsx
@@ -1,12 +1,35 @@
 "use client";
 
+import {
+  financeChatCardsSchema,
+  type FinanceChatCard as FinanceChatCardData,
+} from "@mf-dashboard/analytics/chat/cards";
+import { getToolName, isToolUIPart, type UIMessage } from "ai";
 import { Bot, Send, Sparkles, X } from "lucide-react";
 import { useCallback, useEffect, useRef, type FormEvent } from "react";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
+import { FinanceChatCard } from "./cards/finance-chat-card";
 import { useFinanceChat } from "./chat-provider";
 
 const PANEL_ID = "finance-ai-chat-panel";
+
+function getFinanceCards(message: UIMessage): FinanceChatCardData[] {
+  if (message.role !== "assistant") return [];
+
+  return message.parts.flatMap((part) => {
+    if (
+      !isToolUIPart(part) ||
+      getToolName(part) !== "presentFinanceCards" ||
+      part.state !== "output-available"
+    ) {
+      return [];
+    }
+
+    const result = financeChatCardsSchema.safeParse(part.output);
+    return result.success ? result.data : [];
+  });
+}
 
 export function ChatShell() {
   const { addUserMessage, close, draft, isOpen, messages, open, setDraft } = useFinanceChat();
@@ -110,8 +133,9 @@ export function ChatShell() {
                     .filter((part) => part.type === "text")
                     .map((part) => part.text)
                     .join("");
+                  const cards = getFinanceCards(message);
 
-                  if (!text) return null;
+                  if (!text && cards.length === 0) return null;
 
                   return (
                     <div
@@ -121,16 +145,27 @@ export function ChatShell() {
                         message.role === "user" ? "justify-end" : "justify-start",
                       )}
                     >
-                      <p
-                        className={cn(
-                          "max-w-[85%] whitespace-pre-wrap rounded-2xl px-4 py-2 text-sm",
-                          message.role === "user"
-                            ? "rounded-br-sm bg-primary text-primary-foreground"
-                            : "rounded-bl-sm bg-muted text-foreground",
+                      <div className="max-w-[85%] space-y-3">
+                        {text && (
+                          <p
+                            className={cn(
+                              "whitespace-pre-wrap rounded-2xl px-4 py-2 text-sm",
+                              message.role === "user"
+                                ? "rounded-br-sm bg-primary text-primary-foreground"
+                                : "rounded-bl-sm bg-muted text-foreground",
+                            )}
+                          >
+                            {text}
+                          </p>
                         )}
-                      >
-                        {text}
-                      </p>
+                        {cards.map((card, index) => (
+                          <FinanceChatCard
+                            key={`${card.type}-${card.title}-${index}`}
+                            card={card}
+                            onPromptSelect={addUserMessage}
+                          />
+                        ))}
+                      </div>
                     </div>
                   );
                 })

--- a/packages/analytics/src/chat/cards.test.ts
+++ b/packages/analytics/src/chat/cards.test.ts
@@ -76,6 +76,12 @@ describe("financeChatCardSchema", () => {
         description: "収支ページで確認できます",
         action: { label: "収支を見る", href: "/cf/2026-07" },
       },
+      {
+        type: "empty",
+        title: "支出が見つかりません",
+        description: "期間を変えて確認してください",
+        prompts: ["今月の支出を見たい"],
+      },
     ];
 
     for (const card of cards) expect(financeChatCardSchema.safeParse(card).success).toBe(true);

--- a/packages/analytics/src/chat/cards.ts
+++ b/packages/analytics/src/chat/cards.ts
@@ -125,13 +125,23 @@ export const actionCardSchema = z.object({
   action: actionSchema,
 });
 
+export const emptyCardSchema = z.object({
+  type: z.literal("empty"),
+  title: z.string().min(1),
+  description: z.string().min(1),
+  prompts: z.array(z.string().min(1)).min(1).max(3),
+});
+
 export const financeChatCardSchema = z.discriminatedUnion("type", [
   summaryCardSchema,
   transactionListCardSchema,
   categoryBreakdownCardSchema,
   insightCardSchema,
   actionCardSchema,
+  emptyCardSchema,
 ]);
+
+export const financeChatCardsSchema = z.array(financeChatCardSchema).min(1).max(6);
 
 export type FinanceChatCard = z.infer<typeof financeChatCardSchema>;
 export type SummaryCard = z.infer<typeof summaryCardSchema>;
@@ -139,6 +149,7 @@ export type TransactionListCard = z.infer<typeof transactionListCardSchema>;
 export type CategoryBreakdownCard = z.infer<typeof categoryBreakdownCardSchema>;
 export type InsightCard = z.infer<typeof insightCardSchema>;
 export type ActionCard = z.infer<typeof actionCardSchema>;
+export type EmptyCard = z.infer<typeof emptyCardSchema>;
 
 type FinanceChatRoute =
   | { page: "dashboard"; groupId?: string }

--- a/packages/analytics/src/chat/cards.ts
+++ b/packages/analytics/src/chat/cards.ts
@@ -141,7 +141,33 @@ export const financeChatCardSchema = z.discriminatedUnion("type", [
   emptyCardSchema,
 ]);
 
-export const financeChatCardsSchema = z.array(financeChatCardSchema).min(1).max(6);
+export const financeChatCardsSchema = z
+  .array(financeChatCardSchema)
+  .min(1)
+  .max(6)
+  .superRefine((cards, context) => {
+    const hasEmptyCard = cards.some((card) => card.type === "empty");
+
+    if (hasEmptyCard && (cards.length !== 1 || cards[0]?.type !== "empty")) {
+      context.addIssue({
+        code: "custom",
+        message: "An empty response must contain exactly one empty card",
+      });
+      return;
+    }
+
+    const hasAction = cards.some((card) => {
+      if ("href" in card && card.href !== undefined) return true;
+      return "action" in card && card.action !== undefined;
+    });
+
+    if (!hasEmptyCard && !hasAction) {
+      context.addIssue({
+        code: "custom",
+        message: "A non-empty response must contain at least one CTA",
+      });
+    }
+  });
 
 export type FinanceChatCard = z.infer<typeof financeChatCardSchema>;
 export type SummaryCard = z.infer<typeof summaryCardSchema>;

--- a/packages/analytics/src/chat/navigation-tool.test.ts
+++ b/packages/analytics/src/chat/navigation-tool.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { createFinanceNavigationTool } from "./navigation-tool";
+
+const execOptions = {
+  toolCallId: "test",
+  messages: [],
+  abortSignal: undefined as never,
+  context: {} as never,
+};
+
+describe("createFinanceNavigationTool", () => {
+  it("builds a group-scoped cash-flow route", async () => {
+    const tool = createFinanceNavigationTool("group-a");
+
+    await expect(
+      tool.execute?.({ page: "cashFlow", month: "2026-06" }, execOptions),
+    ).resolves.toEqual({ href: "/group-a/cf/2026-06" });
+  });
+
+  it("builds a group-scoped balance-sheet route", async () => {
+    const tool = createFinanceNavigationTool("group-a");
+
+    await expect(tool.execute?.({ page: "balanceSheet" }, execOptions)).resolves.toEqual({
+      href: "/group-a/bs",
+    });
+  });
+});

--- a/packages/analytics/src/chat/navigation-tool.ts
+++ b/packages/analytics/src/chat/navigation-tool.ts
@@ -1,0 +1,41 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { buildFinanceChatHref } from "./cards";
+
+const navigationInputSchema = z.discriminatedUnion("page", [
+  z.object({ page: z.literal("dashboard") }),
+  z.object({
+    page: z.literal("cashFlow"),
+    month: z
+      .string()
+      .regex(/^\d{4}-(0[1-9]|1[0-2])$/)
+      .optional(),
+  }),
+  z.object({ page: z.literal("balanceSheet") }),
+  z.object({ page: z.literal("accounts") }),
+  z.object({ page: z.literal("insights") }),
+  z.object({ page: z.literal("simulator") }),
+]);
+
+export function createFinanceNavigationTool(groupId: string) {
+  return tool({
+    description:
+      "回答カードのCTAに使う現在グループ内の安全なダッシュボードURLを取得する。presentFinanceCardsへhrefを渡す前に呼び出す",
+    inputSchema: navigationInputSchema,
+    execute: async (route) => {
+      switch (route.page) {
+        case "dashboard":
+          return { href: buildFinanceChatHref({ page: route.page, groupId }) };
+        case "cashFlow":
+          return {
+            href: buildFinanceChatHref({ page: route.page, groupId, month: route.month }),
+          };
+        case "balanceSheet":
+        case "accounts":
+        case "insights":
+        case "simulator":
+          return { href: buildFinanceChatHref({ page: route.page, groupId }) };
+      }
+    },
+  });
+}

--- a/packages/analytics/src/chat/presentation-tool.test.ts
+++ b/packages/analytics/src/chat/presentation-tool.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, it } from "vitest";
-import { createFinancePresentationTool, financePresentationInputSchema } from "./presentation-tool";
+import {
+  createFinancePresentationInputSchema,
+  createFinancePresentationTool,
+} from "./presentation-tool";
 
 describe("createFinancePresentationTool", () => {
   it("returns validated cards unchanged", async () => {
-    const tool = createFinancePresentationTool();
+    const tool = createFinancePresentationTool("group-a");
     const cards = [
       {
         type: "summary" as const,
         title: "今月の収支",
         metrics: [{ label: "収支", amount: 12_000, amountType: "balance" as const }],
+        href: "/group-a/cf/2026-07",
       },
     ];
 
@@ -16,6 +20,8 @@ describe("createFinancePresentationTool", () => {
   });
 
   it("requires at least one card and limits empty-state prompts", () => {
+    const financePresentationInputSchema = createFinancePresentationInputSchema("group-a");
+
     expect(financePresentationInputSchema.safeParse({ cards: [] }).success).toBe(false);
     expect(
       financePresentationInputSchema.safeParse({
@@ -29,5 +35,41 @@ describe("createFinancePresentationTool", () => {
         ],
       }).success,
     ).toBe(false);
+  });
+
+  it("requires empty cards to be exclusive and non-empty responses to include a CTA", () => {
+    const schema = createFinancePresentationInputSchema("group-a");
+    const summary = {
+      type: "summary" as const,
+      title: "今月の収支",
+      metrics: [{ label: "収支", amount: 12_000, amountType: "balance" as const }],
+    };
+    const empty = {
+      type: "empty" as const,
+      title: "見つかりません",
+      description: "条件を変えてください",
+      prompts: ["今月の支出は？"],
+    };
+
+    expect(schema.safeParse({ cards: [empty] }).success).toBe(true);
+    expect(schema.safeParse({ cards: [empty, summary] }).success).toBe(false);
+    expect(schema.safeParse({ cards: [summary] }).success).toBe(false);
+  });
+
+  it("rejects CTA routes outside the current group", () => {
+    const schema = createFinancePresentationInputSchema("group-a");
+    const card = {
+      type: "action" as const,
+      title: "詳細を確認",
+      description: "収支ページで確認できます",
+      action: { label: "収支を見る", href: "/group-b/cf/2026-07" },
+    };
+
+    expect(schema.safeParse({ cards: [card] }).success).toBe(false);
+    expect(
+      schema.safeParse({
+        cards: [{ ...card, action: { ...card.action, href: "/group-a/cf/2026-07" } }],
+      }).success,
+    ).toBe(true);
   });
 });

--- a/packages/analytics/src/chat/presentation-tool.test.ts
+++ b/packages/analytics/src/chat/presentation-tool.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { createFinancePresentationTool, financePresentationInputSchema } from "./presentation-tool";
+
+describe("createFinancePresentationTool", () => {
+  it("returns validated cards unchanged", async () => {
+    const tool = createFinancePresentationTool();
+    const cards = [
+      {
+        type: "summary" as const,
+        title: "今月の収支",
+        metrics: [{ label: "収支", amount: 12_000, amountType: "balance" as const }],
+      },
+    ];
+
+    await expect(tool.execute!({ cards }, {} as never)).resolves.toEqual(cards);
+  });
+
+  it("requires at least one card and limits empty-state prompts", () => {
+    expect(financePresentationInputSchema.safeParse({ cards: [] }).success).toBe(false);
+    expect(
+      financePresentationInputSchema.safeParse({
+        cards: [
+          {
+            type: "empty",
+            title: "見つかりません",
+            description: "条件を変えてください",
+            prompts: ["候補1", "候補2", "候補3", "候補4"],
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/analytics/src/chat/presentation-tool.ts
+++ b/packages/analytics/src/chat/presentation-tool.ts
@@ -1,0 +1,14 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { financeChatCardsSchema } from "./cards";
+
+export const financePresentationInputSchema = z.object({ cards: financeChatCardsSchema });
+
+export function createFinancePresentationTool() {
+  return tool({
+    description:
+      "取得済みの家計データを検証済みの画面カードとして提示する。必要なデータ取得後、ユーザーへの回答ごとに1回だけ呼び出す。データがない場合は推測せずemptyカードを使う",
+    inputSchema: financePresentationInputSchema,
+    execute: async ({ cards }) => cards,
+  });
+}

--- a/packages/analytics/src/chat/presentation-tool.ts
+++ b/packages/analytics/src/chat/presentation-tool.ts
@@ -1,14 +1,36 @@
 import { tool } from "ai";
 import { z } from "zod";
-import { financeChatCardsSchema } from "./cards";
+import { buildFinanceChatHref, financeChatCardsSchema, type FinanceChatCard } from "./cards";
 
-export const financePresentationInputSchema = z.object({ cards: financeChatCardsSchema });
+function getCardHrefs(cards: FinanceChatCard[]): string[] {
+  return cards.flatMap((card) => {
+    if ("href" in card && card.href !== undefined) return [card.href];
+    if ("action" in card && card.action !== undefined) return [card.action.href];
+    return [];
+  });
+}
 
-export function createFinancePresentationTool() {
+export function createFinancePresentationInputSchema(groupId: string) {
+  const groupHref = buildFinanceChatHref({ page: "dashboard", groupId });
+
+  return z.object({ cards: financeChatCardsSchema }).superRefine(({ cards }, context) => {
+    for (const href of getCardHrefs(cards)) {
+      if (href !== groupHref && !href.startsWith(`${groupHref}/`)) {
+        context.addIssue({
+          code: "custom",
+          message: "CTA routes must belong to the current group",
+          path: ["cards"],
+        });
+      }
+    }
+  });
+}
+
+export function createFinancePresentationTool(groupId: string) {
   return tool({
     description:
       "取得済みの家計データを検証済みの画面カードとして提示する。必要なデータ取得後、ユーザーへの回答ごとに1回だけ呼び出す。データがない場合は推測せずemptyカードを使う",
-    inputSchema: financePresentationInputSchema,
+    inputSchema: createFinancePresentationInputSchema(groupId),
     execute: async ({ cards }) => cards,
   });
 }

--- a/packages/analytics/src/chat/tools.test.ts
+++ b/packages/analytics/src/chat/tools.test.ts
@@ -17,6 +17,8 @@ describe("createChatTools", () => {
 
     expect(Object.keys(createChatTools(db, groupId))).toEqual([
       "searchTransactions",
+      "getFinanceDashboardRoute",
+      "presentFinanceCards",
       ...Object.keys(financialTools),
       ...Object.keys(analysisTools),
     ]);
@@ -34,6 +36,8 @@ describe("createChatTools", () => {
     expect(tools).toEqual(
       expect.objectContaining({
         searchTransactions: expect.any(Object),
+        getFinanceDashboardRoute: expect.any(Object),
+        presentFinanceCards: expect.any(Object),
         getMonthlySummaryByMonth: expect.any(Object),
         getMonthlyCategoryTotals: expect.any(Object),
         getAssetBreakdownByCategory: expect.any(Object),

--- a/packages/analytics/src/chat/tools.ts
+++ b/packages/analytics/src/chat/tools.ts
@@ -17,7 +17,7 @@ export function createFinanceChatTools(db: Db, groupId: string) {
   return {
     searchTransactions: createTransactionSearchTool(db, groupId),
     getFinanceDashboardRoute: createFinanceNavigationTool(groupId),
-    presentFinanceCards: createFinancePresentationTool(),
+    presentFinanceCards: createFinancePresentationTool(groupId),
     ...createFinancialTools(db, groupId),
     ...createAnalysisTools(db, groupId),
   };

--- a/packages/analytics/src/chat/tools.ts
+++ b/packages/analytics/src/chat/tools.ts
@@ -1,13 +1,23 @@
 import type { Db } from "@mf-dashboard/db";
 import { createAnalysisTools } from "../insights/analysis-tools";
 import { createFinancialTools } from "../insights/tools";
+import { createFinanceNavigationTool } from "./navigation-tool";
+import { createFinancePresentationTool } from "./presentation-tool";
 import { createTransactionSearchTool } from "./transaction-search-tool";
 
-export { createAnalysisTools, createFinancialTools, createTransactionSearchTool };
+export {
+  createAnalysisTools,
+  createFinanceNavigationTool,
+  createFinancePresentationTool,
+  createFinancialTools,
+  createTransactionSearchTool,
+};
 
 export function createFinanceChatTools(db: Db, groupId: string) {
   return {
     searchTransactions: createTransactionSearchTool(db, groupId),
+    getFinanceDashboardRoute: createFinanceNavigationTool(groupId),
+    presentFinanceCards: createFinancePresentationTool(),
     ...createFinancialTools(db, groupId),
     ...createAnalysisTools(db, groupId),
   };

--- a/packages/analytics/src/index.ts
+++ b/packages/analytics/src/index.ts
@@ -4,13 +4,17 @@ export {
   createAnalysisTools,
   createChatTools,
   createFinanceChatTools,
+  createFinanceNavigationTool,
+  createFinancePresentationTool,
   createFinancialTools,
 } from "./chat/tools.js";
 export {
   actionCardSchema,
   buildFinanceChatHref,
   categoryBreakdownCardSchema,
+  emptyCardSchema,
   financeChatCardSchema,
+  financeChatCardsSchema,
   financeChatHrefSchema,
   insightCardSchema,
   isFinanceChatHrefSafe,
@@ -20,6 +24,7 @@ export {
 export type {
   ActionCard,
   CategoryBreakdownCard,
+  EmptyCard,
   FinanceChatCard,
   InsightCard,
   SummaryCard,


### PR DESCRIPTION
# Summary

- Add a validated presentation tool for streaming finance chat cards and a group-scoped navigation tool for safe CTAs.
- Render Summary, TransactionList, CategoryBreakdown, Insight, Action, and Empty cards from trusted assistant tool output.
- Define the five HIR-105 MVP response recipes, reduction KPIs, empty-state behavior, and investment-capacity criteria in the system prompt.
- Add unit and Storybook coverage for structured responses, empty alternatives, and CTA links.

Linear: https://linear.app/hiroppy/issue/HIR-105/家計aiチャットのmvpユースケースを実装する

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | Each representative question requires a specific card composition and data-backed answer. | The five MVP intents map to their required card types; empty results use only Empty; CTA routes are valid. |
| Usability | Responses must combine concise text, scannable cards, and actionable alternatives. | Structured and Empty stories render clearly; alternative prompts and CTA controls are discoverable. |
| Reliability | Raw or malformed tool output must not leak into the UI, and missing data must not produce invented amounts. | Only validated presentFinanceCards output from assistant messages is rendered; empty schemas reject invalid shapes. |
| Security | Model-generated links and client history cross trust boundaries. | CTA URLs come from the group-scoped route builder; unrelated tool output is ignored. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Equivalence partitioning | Separate the five supported intents, empty results, and unrelated tool output. | Required prompt recipes and rendered card families. |
| Boundary value analysis | Dates, year-month routes, card counts, percentages, and alternative prompt counts have explicit limits. | Valid/invalid schema boundaries and route constraints. |
| Decision table testing | Intent, available data, and required card composition determine the response. | Prompt rules for daily, monthly, category, reduction, assets, and empty states. |
| Error guessing | Malformed cards, unsafe URLs, raw search output, and absent data are likely failure modes. | Validation rejects unsafe/invalid content and UI suppresses untrusted output. |

### Primary Test Conditions

- Daily expense response renders Summary, TransactionList, and Action with a working internal CTA.
- Monthly, category, reduction, and total-assets intents are encoded with their required data/tool/card recipes.
- Empty results render alternatives without fabricated metrics.
- Investment capacity references cash surplus, savings rate, emergency funds, liabilities, and concentration.
- Demo app launches with the chat panel; deterministic Storybook responses render structured and empty states.

### Out-of-Scope Risks

- Live provider response quality was not exercised because no AI provider credentials are available in the workspace; tool schemas, prompt recipes, streaming API configuration, and deterministic UI output are covered.
- Complex persisted conversation memory remains intentionally out of scope for the MVP.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [x] Storybook tests
- [ ] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/analytics test — 13 files / 147 tests passed
pnpm --filter @mf-dashboard/web test:unit — 27 files / 410 tests passed
pnpm --filter @mf-dashboard/web test:storybook — 77 files / 343 tests passed
pnpm turbo typecheck — 8/8 packages passed
pnpm lint — passed
pnpm format:check — passed
pnpm --filter @mf-dashboard/db build:demo — demo database generated
pnpm --filter @mf-dashboard/web dev:demo — app and chat panel verified at /
```

### Checks Not Run

- Web E2E suite — no live AI provider credentials are available; deterministic route, component, Storybook, and manual runtime checks cover this change.
