### PR TITLE
fix(crawler): install only Chromium

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,8 +12,9 @@
     "test:unit": "vitest run --project unit",
     "test:storybook": "vitest run --project storybook",
     "test:watch": "vitest",
+    "pretest:e2e": "playwright install chromium webkit",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:ui": "pnpm pretest:e2e && playwright test --ui",
     "typecheck": "next typegen && tsc --noEmit",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "setup": "corepack enable pnpm",
-    "postinstall": "pnpm --filter @mf-dashboard/crawler exec playwright install",
+    "postinstall": "pnpm --filter @mf-dashboard/crawler exec playwright install chromium",
     "dev": "turbo dev",
     "dev:demo": "turbo dev:demo",
     "build": "turbo build",


### PR DESCRIPTION
# Summary

- Limit the root postinstall Playwright browser installation to Chromium.
- Keep the crawler Docker installation Chromium-only.
- Preserve the web E2E Chromium and mobile Safari projects by installing Chromium and WebKit immediately before web E2E runs.

## Linear Issue

- [HIR-108](https://linear.app/hiroppy/issue/HIR-108/pnpm-filter-mf-dashboardcrawler-exec-playwright-install-%E5%AE%9F%E8%A1%8C%E6%99%82%E3%81%AF-chromium)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | Root postinstall and Docker must select the requested browser only. | Both crawler install paths select Chromium and exclude Firefox/WebKit. |
| Compatibility | Web E2E includes a WebKit-backed mobile Safari project. | The web E2E command prepares Chromium and WebKit and all configured projects run. |
| Performance efficiency | Avoiding unused crawler browser downloads reduces installation resources. | Crawler Playwright dry-run lists Chromium artifacts and support tooling only. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Equivalence partitioning | Browser targets divide into requested Chromium and excluded Firefox/WebKit targets for crawler setup. | Confirms Chromium is present and excluded browser families are absent from crawler installation. |
| Regression testing | The changed install policy can remove WebKit required by mobile Safari tests. | Runs all 42 web E2E cases across Chromium, mobile Chrome, and mobile Safari. |
| Checklist-based testing | The implementation is package-script configuration. | Covers exact script values, formatting, synchronization, and diff scope. |

### Primary Test Conditions

- Root postinstall ends with the Chromium browser argument.
- Crawler Playwright dry-run resolves Chromium, Chromium Headless Shell, and FFmpeg, with no Firefox or WebKit.
- Docker continues to use `playwright install --with-deps chromium`.
- Web E2E setup resolves Chromium and WebKit.
- All Chromium, mobile Chrome, and mobile Safari E2E projects pass.

### Out-of-Scope Risks

- Unit, type, lint, and Storybook checks were not run because runtime code and UI output are unchanged; exact configuration assertions, formatting, and the full affected E2E suite provide direct coverage.

## Verification

- [ ] Unit tests
- [ ] Type checking
- [ ] Lint
- [ ] Storybook tests
- [x] E2E tests
- [x] Manual verification

### Commands Executed

```text
node -e <package script exact-match assertions> - passed
pnpm --filter @mf-dashboard/crawler exec playwright install --dry-run chromium - passed; no Firefox/WebKit
pnpm --filter @mf-dashboard/web exec playwright install --dry-run chromium webkit - passed
pnpm --filter @mf-dashboard/web test:e2e --list - passed; 42 tests across 3 projects
pnpm --filter @mf-dashboard/web test:e2e - passed; 42 tests
pnpm exec oxfmt --check package.json apps/web/package.json - passed
git diff --check origin/new-release...HEAD - passed
```

### Checks Not Run

- Unit tests, type checking, lint, and Storybook tests - not applicable to package-script-only changes; full web E2E covers the affected runtime path.