### PR TITLE
chore(dev): use demo data by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ pnpm --filter @mf-dashboard/db studio
 pnpm --filter @mf-dashboard/db build:demo
 ```
 
-Run the web app with demo data using `pnpm --filter @mf-dashboard/web dev:demo`.
+Run the web app with demo data using `pnpm --filter @mf-dashboard/web dev`.
 
 ### Crawler
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ git clone https://github.com/hiroppy/mf-dashboard.git
 cd mf-dashboard
 corepack enable pnpm
 pnpm install
-pnpm dev:demo
+pnpm dev
 ```
 
 起動後、ターミナルに表示されるURLをブラウザで開く。この手順では実際のMoney Forward MEアカウントへ接続しない。

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "dev:demo": "DB_PATH=../../data/demo.db DEMO_MODE=true next dev",
+    "dev": "DB_PATH=../../data/demo.db DEMO_MODE=true next dev",
     "build": "next build",
     "build:demo": "DB_PATH=../../data/demo.db DEMO_MODE=true next build",
     "start": "next start",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "pnpm dev:demo",
+    command: "pnpm dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "setup": "corepack enable pnpm",
     "postinstall": "pnpm --filter @mf-dashboard/crawler exec playwright install chromium",
-    "dev": "turbo dev",
+    "dev": "turbo dev --filter=@mf-dashboard/web",
     "build": "turbo build",
     "build:demo": "turbo build:demo",
     "generate:demo-insights": "pnpm --filter @mf-dashboard/analytics generate:demo-insights",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "setup": "corepack enable pnpm",
     "postinstall": "pnpm --filter @mf-dashboard/crawler exec playwright install chromium",
     "dev": "turbo dev",
-    "dev:demo": "turbo dev:demo",
     "build": "turbo build",
     "build:demo": "turbo build:demo",
     "generate:demo-insights": "pnpm --filter @mf-dashboard/analytics generate:demo-insights",

--- a/turbo.json
+++ b/turbo.json
@@ -4,10 +4,6 @@
   "tasks": {
     "dev": {
       "cache": false,
-      "persistent": true
-    },
-    "dev:demo": {
-      "cache": false,
       "persistent": true,
       "dependsOn": ["^build:demo"]
     },


### PR DESCRIPTION
# Summary

- Make the standard `dev` command launch the web app with `data/demo.db` and `DEMO_MODE=true`.
- Make the Turbo `dev` task generate demo dependencies before starting persistent development tasks.
- Remove the redundant `dev:demo` alias and update README, agent guidance, and Playwright to use `dev`.

## Linear Issue

- [HIR-111](https://linear.app/hiroppy/issue/HIR-111/dev%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89%E3%82%92demo%E3%83%87%E3%83%BC%E3%82%BF%E5%9F%BA%E6%BA%96%E3%81%AB%E5%A4%89%E6%9B%B4)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | The default development entrypoint must use demo data and prepare its database. | `dev` resolves the demo DB environment and depends on `^build:demo`. |
| Compatibility | Root, web, Turbo, documentation, and E2E must agree on one command name. | No `dev:demo` references remain and all consumers use `dev`. |
| Security | Development validation must not expose personal Money Forward data. | Validation uses generated `data/demo.db` only. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Equivalence partitioning | `dev` and the removed `dev:demo` represent the old command partitions. | Confirms the supported command receives demo behavior and the obsolete alias is absent. |
| State transition testing | Startup transitions from demo dependency generation to the persistent web process. | Confirms `^build:demo` generates the database before the app serves it. |
| Error guessing | A missing DB environment could silently fall back to personal data. | Exact script assertions and runtime output confirm `DB_PATH` and `DEMO_MODE`. |

### Primary Test Conditions

- Root `dev` resolves the web command with the demo DB environment.
- Turbo runs dependency `build:demo` tasks before development tasks.
- Playwright starts the same `dev` entrypoint and all web flows remain green.
- README and repository guidance show the supported command.

### Out-of-Scope Risks

- Live Money Forward data was intentionally excluded to avoid accessing personal financial information; generated demo fixtures cover the changed startup path.

## Verification

- [ ] Unit tests
- [ ] Type checking
- [ ] Lint
- [ ] Storybook tests
- [x] E2E tests
- [x] Manual verification

### Commands Executed

```text
node --input-type=module -e <dev configuration assertions> — passed
pnpm --filter @mf-dashboard/db build:demo — passed
pnpm --filter @mf-dashboard/web dev + HTTP/visual check — passed; HTTP 200 with demo asset data
pnpm --filter @mf-dashboard/web test:e2e — passed; 45 tests
pnpm format:check — passed
git diff --check — passed
```

### Checks Not Run

- Unit tests, type checking, lint, and Storybook tests — not applicable to package-script, task configuration, documentation, and test-server command changes; exact configuration assertions, runtime validation, formatting, and the full affected E2E suite provide direct coverage.