### PR TITLE
fix(web): move repository link into help dialog

### DIFF
--- a/apps/web/src/components/layout/action-icons.test.tsx
+++ b/apps/web/src/components/layout/action-icons.test.tsx
@@ -48,7 +48,8 @@ describe("ActionIcons", () => {
     const issuesLink = screen.getByRole("link", { name: "バグ報告・機能要望" });
 
     expect(repositoryLink.getAttribute("href")).toBe("https://github.com/hiroppy/mf-dashboard");
-    expect(repositoryLink.nextElementSibling).toBe(issuesLink);
+    expect(repositoryLink.querySelector("svg")).not.toBeNull();
+    expect(repositoryLink.parentElement?.nextElementSibling?.contains(issuesLink)).toBe(true);
   });
 
   it("does not render a link to the removed daily update workflow", () => {

--- a/apps/web/src/components/layout/action-icons.test.tsx
+++ b/apps/web/src/components/layout/action-icons.test.tsx
@@ -37,6 +37,20 @@ afterEach(() => {
 });
 
 describe("ActionIcons", () => {
+  it("moves the repository link from the header into the help dialog", () => {
+    render(<ActionIcons variant="header" />);
+
+    expect(screen.queryByRole("link", { name: "GitHub リポジトリ" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "ヘルプ" }));
+
+    const repositoryLink = screen.getByRole("link", { name: "GitHub リポジトリ" });
+    const issuesLink = screen.getByRole("link", { name: "バグ報告・機能要望" });
+
+    expect(repositoryLink.getAttribute("href")).toBe("https://github.com/hiroppy/mf-dashboard");
+    expect(repositoryLink.nextElementSibling).toBe(issuesLink);
+  });
+
   it("does not render a link to the removed daily update workflow", () => {
     process.env.NEXT_PUBLIC_GITHUB_ORG = "org-a";
     process.env.NEXT_PUBLIC_GITHUB_REPO = "repo-a";

--- a/apps/web/src/components/layout/action-icons.tsx
+++ b/apps/web/src/components/layout/action-icons.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { mfUrls } from "@mf-dashboard/meta/urls";
-import { Home, Code2, HelpCircle, RefreshCw } from "lucide-react";
+import { Home, HelpCircle, RefreshCw } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { formatDateTime } from "../../lib/format";
@@ -49,7 +49,6 @@ export function ActionIcons({ variant, notifications }: ActionIconsProps) {
     return (
       <div className="border-t p-4 flex items-center gap-1 lg:hidden">
         <HelpButton iconSize={iconSize} />
-        <GitHubButton iconSize={iconSize} />
       </div>
     );
   }
@@ -59,7 +58,6 @@ export function ActionIcons({ variant, notifications }: ActionIconsProps) {
       {notifications}
       <RefreshButton iconSize={iconSize} />
       <HomeButton iconSize={iconSize} />
-      <GitHubButton iconSize={iconSize} className="hidden lg:block" />
       <HelpButton iconSize={iconSize} className="hidden lg:block" />
     </div>
   );
@@ -195,7 +193,15 @@ function HelpButton({ iconSize, className }: { iconSize: string; className?: str
                 </li>
               </ul>
             </div>
-            <div className="pt-2 border-t">
+            <div className="pt-2 border-t flex flex-col items-start gap-2">
+              <a
+                href="https://github.com/hiroppy/mf-dashboard"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-primary hover:underline"
+              >
+                GitHub リポジトリ
+              </a>
               <a
                 href="https://github.com/hiroppy/mf-dashboard/issues"
                 target="_blank"
@@ -209,18 +215,6 @@ function HelpButton({ iconSize, className }: { iconSize: string; className?: str
         </DialogDescription>
       </DialogContent>
     </Dialog>
-  );
-}
-
-function GitHubButton({ iconSize, className }: { iconSize: string; className?: string }) {
-  return (
-    <IconButton
-      icon={<Code2 className={iconSize} />}
-      href="https://github.com/hiroppy/mf-dashboard"
-      ariaLabel="GitHub"
-      className={className}
-      isExternal
-    />
   );
 }
 

--- a/apps/web/src/components/layout/action-icons.tsx
+++ b/apps/web/src/components/layout/action-icons.tsx
@@ -155,7 +155,19 @@ function HelpButton({ iconSize, className }: { iconSize: string; className?: str
         <IconButton icon={<HelpCircle className={iconSize} />} ariaLabel="ヘルプ" />
       </DialogTrigger>
       <DialogContent>
-        <DialogTitle>MoneyForward Me Dashboard について</DialogTitle>
+        <div className="flex items-center justify-between gap-4">
+          <DialogTitle>MoneyForward Me Dashboard について</DialogTitle>
+          <IconButton
+            icon={
+              <svg aria-hidden="true" viewBox="0 0 24 24" className="h-5 w-5" fill="currentColor">
+                <path d="M12 .3a12 12 0 0 0-3.8 23.4c.6.1.8-.3.8-.6v-2.3c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-5.9 0-1.3.5-2.4 1.2-3.2-.1-.3-.5-1.5.1-3.2 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0c2.3-1.5 3.3-1.2 3.3-1.2.6 1.7.2 2.9.1 3.2.8.8 1.2 1.9 1.2 3.2 0 4.6-2.8 5.6-5.5 5.9.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6A12 12 0 0 0 12 .3Z" />
+              </svg>
+            }
+            href="https://github.com/hiroppy/mf-dashboard"
+            ariaLabel="GitHub リポジトリ"
+            isExternal
+          />
+        </div>
         <DialogDescription asChild>
           <div className="mt-2 text-sm text-muted-foreground space-y-4">
             <p>MoneyForward Me を自動化・可視化するダッシュボードです。</p>
@@ -193,15 +205,7 @@ function HelpButton({ iconSize, className }: { iconSize: string; className?: str
                 </li>
               </ul>
             </div>
-            <div className="pt-2 border-t flex flex-col items-start gap-2">
-              <a
-                href="https://github.com/hiroppy/mf-dashboard"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm text-primary hover:underline"
-              >
-                GitHub リポジトリ
-              </a>
+            <div className="pt-2 border-t">
               <a
                 href="https://github.com/hiroppy/mf-dashboard/issues"
                 target="_blank"


### PR DESCRIPTION
# Summary

- Remove the standalone repository code-icon action from the header and mobile sidebar.
- Place an accessible GitHub repository icon opposite the help dialog title.
- Preserve the bug-report and feature-request link below the dialog content.
- Add regression coverage for visibility, destination, icon rendering, and placement.

## Linear Issue

- [HIR-114](https://linear.app/hiroppy/issue/HIR-114/headerのrepoのボタンコードのアイコンを無くす)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | The repository entry point must move without changing its destination. | The standalone icon is absent and the dialog icon opens the existing repository URL. |
| Interaction capability | The new location must remain discoverable and match the reviewed layout. | Opening Help shows the GitHub icon opposite the title and above the issue/feature-request link. |
| Maintainability | The UI state and placement need focused regression coverage. | Unit tests assert pre-open visibility, URL, icon rendering, and DOM placement. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| State transition testing | The repository link changes from unavailable to available when Help opens. | Dialog closed and open states. |
| Checklist-based testing | The request and review specify placement, destination, accessibility, and preservation of the issue link. | Header icon removal, title-row icon, href, accessible name, and existing link retention. |
| Error guessing | Likely regressions are a leftover header icon, a text link in the old location, or a misplaced/missing icon. | Explicit negative, icon, and placement assertions. |

### Primary Test Conditions

- Header has no standalone GitHub repository action.
- Help dialog contains an accessible GitHub icon opposite its title.
- Repository href remains https://github.com/hiroppy/mf-dashboard.
- Bug-report and feature-request link remains below the dialog content.
- Mobile sidebar also uses the single Help entry point.
- Anonymous demo data renders the dashboard and supports the complete interaction walkthrough.

### Out-of-Scope Risks

- External GitHub availability is not exercised; the exact href and external-link attributes are verified locally.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [x] Storybook tests
- [x] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/web test:unit -- action-icons.test.tsx — 24 files / 382 tests passed
pnpm --filter @mf-dashboard/web test:storybook — 74 files / 330 tests passed
pnpm turbo typecheck — 9 packages passed
pnpm lint — passed
pnpm format:check — 492 files passed
pnpm --filter @mf-dashboard/web dev — HTTP 200; Playwright walkthrough passed
CI e2e-web — passed
```

### Checks Not Run

- Full E2E suite — not proportional to this isolated link-placement change; focused unit, Storybook, and browser walkthrough cover the affected behavior.