### PR TITLE
chore(renovate): target new-release branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, new-release]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
   ],
   "rangeStrategy": "pin",
   "labels": ["deps"],
+  "baseBranchPatterns": ["new-release"],
   "packageRules": [
     {
       "groupName": "npm patch dependencies",


### PR DESCRIPTION
## Summary

- configure Renovate to target the `new-release` branch
- use the current `baseBranchPatterns` option validated by Renovate
- run CI for pull requests whose base branch is `new-release`

## Validation

- `pnpm --package=renovate dlx renovate-config-validator renovate.json`
- `pnpm format:check`
- `git diff --check origin/main...HEAD`
- `rg -n '"baseBranchPatterns": \["new-release"\]|branches: \[main, new-release\]' renovate.json .github/workflows/ci.yml`

## QA

- Quality characteristics: functional suitability (correct target branch and CI coverage), maintainability (current non-deprecated option)
- Test techniques: decision-table coverage of `main` / `new-release` pull-request bases, checklist-based configuration inspection, and error guessing with the Renovate validator
- Primary conditions: Renovate targets only `new-release`; CI accepts both `main` and `new-release` pull-request bases
- Out of scope: executing a live hosted Renovate run; configuration validation provides the deterministic local proof

## Risk

- Renovate dependency PRs will temporarily stop targeting `main` and target `new-release` as requested.

Linear: HIR-117