### PR TITLE
例: feat(web): refresh dashboard landing UI

### DIFF
--- a/apps/web/e2e/app-flows.test.ts
+++ b/apps/web/e2e/app-flows.test.ts
@@ -1,5 +1,7 @@
 import { expect, type Page, test } from "@playwright/test";
 
+const dashboardHeading = "お金の現在地を、ひと目で。";
+
 async function expectHeading(page: Page, name: string | RegExp) {
   await expect(page.getByRole("heading", { name, level: 1 })).toBeVisible();
 }
@@ -42,7 +44,7 @@ test.describe("App flows", () => {
     });
 
     const chartPages = [
-      { path: "/", heading: "ダッシュボード" },
+      { path: "/", heading: dashboardHeading },
       { path: "/cf", heading: "収支" },
       { path: "/bs", heading: "資産" },
       { path: "/insights", heading: "インサイト" },
@@ -59,7 +61,7 @@ test.describe("App flows", () => {
 
   test("navigates between primary pages from the sidebar", async ({ page }) => {
     await page.goto("/");
-    await expectHeading(page, "ダッシュボード");
+    await expectHeading(page, dashboardHeading);
 
     const destinations = [
       { link: "収支", path: "/cf", heading: "収支" },
@@ -67,7 +69,7 @@ test.describe("App flows", () => {
       { link: "インサイト", path: "/insights", heading: "インサイト" },
       { link: "連携サービス", path: "/accounts", heading: "連携サービス一覧" },
       { link: "シミュレーター", path: "/simulator", heading: "シミュレーター" },
-      { link: "ダッシュボード", path: "/", heading: "ダッシュボード" },
+      { link: "ダッシュボード", path: "/", heading: dashboardHeading },
     ] as const;
 
     for (const { link, path, heading } of destinations) {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -127,3 +127,28 @@
     transform: scaleX(0);
   }
 }
+
+@keyframes dashboard-enter {
+  from {
+    opacity: 0;
+    transform: translateY(0.875rem);
+  }
+}
+
+.dashboard-reveal {
+  animation: dashboard-enter 600ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.dashboard-delay-1 {
+  animation-delay: 100ms;
+}
+
+.dashboard-delay-2 {
+  animation-delay: 200ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dashboard-reveal {
+    animation: none;
+  }
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -5,7 +5,7 @@ import { AssetHistoryChart } from "../components/info/asset-history-chart";
 import { DailyChangeCard } from "../components/info/daily-change-card";
 import { MonthlyBalanceCard } from "../components/info/monthly-balance-card";
 import { MonthlyIncomeExpenseChart } from "../components/info/monthly-income-expense-chart";
-import { PageLayout } from "../components/layout/page-layout";
+import { DashboardLayout } from "../components/layout/dashboard-layout";
 
 export const metadata: Metadata = {
   title: "ダッシュボード",
@@ -15,18 +15,17 @@ export async function DashboardContent({ groupId }: { groupId?: string }) {
   const showDailyChange = await hasInvestmentHoldings(groupId);
 
   return (
-    <PageLayout title="ダッシュボード">
-      <div className="grid gap-4 grid-cols-1 lg:grid-cols-3">
-        <AssetBreakdownChart className="lg:col-span-2" groupId={groupId} />
-        <MonthlyBalanceCard groupId={groupId} />
-      </div>
-
-      {showDailyChange && <DailyChangeCard groupId={groupId} />}
-
-      <AssetHistoryChart groupId={groupId} />
-
-      <MonthlyIncomeExpenseChart groupId={groupId} />
-    </PageLayout>
+    <DashboardLayout
+      overview={
+        <>
+          <AssetBreakdownChart className="lg:col-span-2" groupId={groupId} />
+          <MonthlyBalanceCard groupId={groupId} />
+        </>
+      }
+      dailyChange={showDailyChange ? <DailyChangeCard groupId={groupId} /> : undefined}
+      assetHistory={<AssetHistoryChart groupId={groupId} />}
+      cashFlow={<MonthlyIncomeExpenseChart groupId={groupId} />}
+    />
   );
 }
 

--- a/apps/web/src/components/layout/dashboard-layout.stories.tsx
+++ b/apps/web/src/components/layout/dashboard-layout.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { LayoutDashboard } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
+import { DashboardLayout } from "./dashboard-layout";
+
+function PreviewCard({ title, className }: { title: string; className?: string }) {
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <CardTitle icon={LayoutDashboard}>{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="h-28 rounded-xl bg-muted" />
+      </CardContent>
+    </Card>
+  );
+}
+
+const overview = (
+  <>
+    <PreviewCard title="資産構成" className="lg:col-span-2" />
+    <PreviewCard title="今月の収支" />
+  </>
+);
+
+const meta = {
+  title: "Layout/DashboardLayout",
+  component: DashboardLayout,
+  tags: ["autodocs"],
+  args: {
+    overview,
+    dailyChange: <PreviewCard title="前日比ランキング" />,
+    assetHistory: <PreviewCard title="資産推移" />,
+    cashFlow: <PreviewCard title="月別収支推移" />,
+  },
+} satisfies Meta<typeof DashboardLayout>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithoutInvestments: Story = {
+  args: {
+    dailyChange: undefined,
+  },
+};

--- a/apps/web/src/components/layout/dashboard-layout.test.tsx
+++ b/apps/web/src/components/layout/dashboard-layout.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DashboardLayout } from "./dashboard-layout";
+
+const requiredContent = {
+  overview: <div>概要</div>,
+  assetHistory: <div>資産推移</div>,
+  cashFlow: <div>収支推移</div>,
+};
+
+describe("DashboardLayout", () => {
+  it("renders the dashboard information hierarchy", () => {
+    render(<DashboardLayout {...requiredContent} dailyChange={<div>前日比</div>} />);
+
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toBe(
+      "お金の現在地を、ひと目で。",
+    );
+    expect(screen.getByRole("heading", { level: 2, name: "資産のいま" })).toBeTruthy();
+    expect(screen.getByRole("heading", { level: 2, name: "お金の流れ" })).toBeTruthy();
+    expect(screen.getByText("前日比")).toBeTruthy();
+  });
+
+  it("keeps the overview and trends visible without investment data", () => {
+    render(<DashboardLayout {...requiredContent} />);
+
+    expect(screen.queryByText("前日比")).toBeNull();
+    expect(screen.getByText("概要")).toBeTruthy();
+    expect(screen.getByText("資産推移")).toBeTruthy();
+    expect(screen.getByText("収支推移")).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/layout/dashboard-layout.tsx
+++ b/apps/web/src/components/layout/dashboard-layout.tsx
@@ -1,0 +1,70 @@
+import { Sparkles } from "lucide-react";
+
+interface DashboardLayoutProps {
+  overview: React.ReactNode;
+  dailyChange?: React.ReactNode;
+  assetHistory: React.ReactNode;
+  cashFlow: React.ReactNode;
+}
+
+export function DashboardLayout({
+  overview,
+  dailyChange,
+  assetHistory,
+  cashFlow,
+}: DashboardLayoutProps) {
+  return (
+    <div className="space-y-10">
+      <header className="dashboard-reveal relative overflow-hidden rounded-3xl border bg-card px-6 py-8 shadow-sm sm:px-8 sm:py-10">
+        <div
+          aria-hidden="true"
+          className="absolute -right-20 -top-24 h-64 w-64 rounded-full bg-primary/10 blur-3xl"
+        />
+        <div className="relative max-w-2xl">
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-3 py-1 text-xs font-semibold tracking-wide text-primary">
+            <Sparkles aria-hidden="true" className="h-3.5 w-3.5" />
+            FINANCIAL OVERVIEW
+          </div>
+          <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            お金の現在地を、ひと目で。
+          </h1>
+          <p className="mt-3 max-w-xl text-sm leading-7 text-muted-foreground sm:text-base">
+            資産のバランスと日々の変化、毎月のお金の流れをまとめて確認できます。
+          </p>
+        </div>
+      </header>
+
+      <section
+        aria-labelledby="dashboard-overview-title"
+        className="dashboard-reveal dashboard-delay-1"
+      >
+        <div className="mb-4">
+          <p className="text-xs font-semibold tracking-[0.2em] text-primary">CURRENT</p>
+          <h2 id="dashboard-overview-title" className="mt-1 text-xl font-bold tracking-tight">
+            資産のいま
+          </h2>
+        </div>
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">{overview}</div>
+          {dailyChange}
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="dashboard-trends-title"
+        className="dashboard-reveal dashboard-delay-2"
+      >
+        <div className="mb-4">
+          <p className="text-xs font-semibold tracking-[0.2em] text-primary">TRENDS</p>
+          <h2 id="dashboard-trends-title" className="mt-1 text-xl font-bold tracking-tight">
+            お金の流れ
+          </h2>
+        </div>
+        <div className="space-y-6">
+          {assetHistory}
+          {cashFlow}
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
# Summary

- トップ画面を「導入部」「資産のいま」「お金の流れ」の情報階層へ刷新
- セクションを段階表示する motion と `prefers-reduced-motion` 対応を追加
- 投資データあり／なしの Storybook とレイアウト unit tests を追加

## Linear Issue

- [HIR-118](https://linear.app/hiroppy/issue/HIR-118/トップのuiとアニメーションを変更する)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| 機能適合性 | 既存の資産・収支カードとリンクを新レイアウトでも維持する必要がある | 全カードが従来どおり表示され、今月の収支から明細へ遷移できる |
| 操作性 | new-release 向けトップ画面の情報優先度を明確にする変更である | 導入、現在値、トレンドの順に情報を追える |
| アクセシビリティ | 登場アニメーションが motion 設定や情報取得を妨げない必要がある | reduced motion では animation が無効になり、全情報が表示される |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| 同値分割 | 投資データあり／なしで前日比セクションの有無が変わる | 両状態で概要とトレンドが維持される |
| 状態遷移テスト | 収支カードから既存明細への遷移を維持する必要がある | トップから月別収支 URL への遷移 |
| チェックリストベース／探索的テスト | desktop/mobile と motion 設定の視覚・操作回帰を確認する | 1440px/390px、通常/reduced motion の表示 |

### Primary Test Conditions

- 投資データありでは前日比ランキングを含む全セクションが表示される
- 投資データなしでも資産概要とトレンドは表示される
- 通常 motion は 0/100/200ms の段階表示になる
- reduced motion ではトップ固有 animation が `none` になる
- 今月の収支カードから対象月の明細へ遷移できる

### Out-of-Scope Risks

- 各チャート固有の描画アニメーションは既存実装のため変更対象外
- 実データは個人情報を含むため使用せず、demo データで検証

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [x] Storybook tests
- [ ] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/db build:demo — passed
pnpm --filter @mf-dashboard/web test:unit — 25 files / 384 tests passed
pnpm --filter @mf-dashboard/web test:storybook — 75 files / 332 tests passed
pnpm turbo typecheck — 9/9 tasks passed
pnpm lint — passed
pnpm format:check — passed
temporary Playwright runtime proof — desktop/mobile/reduced-motion/card navigation passed
pnpm knip — failed only on pre-existing root lefthook unused devDependency
```

### Checks Not Run

- Web E2E suite — 変更経路は対象 unit/Storybook と demo データを使った Playwright runtime walkthrough で直接検証したため未実行
