### PR TITLE
perf(ci): avoid redundant Playwright installs

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -3,7 +3,7 @@ description: Setup pnpm and Node.js with dependencies
 inputs:
   playwright-browsers:
     description: "Space-separated list of Playwright browsers to install (e.g. chromium webkit)"
-    default: "chromium webkit"
+    default: ""
     required: false
 runs:
   using: composite
@@ -14,26 +14,31 @@ runs:
         node-version-file: .node-version
         cache: pnpm
     - run: pnpm install --frozen-lockfile
+      env:
+        SKIP_PLAYWRIGHT_BROWSER_INSTALL: "true"
       shell: bash
     - name: Get Playwright version
+      if: inputs.playwright-browsers != ''
       id: playwright-version
       run: echo "version=$(pnpm list @playwright/test playwright --json --recursive | jq -r '[.[] | (.devDependencies["@playwright/test"].version, .dependencies["@playwright/test"].version, .devDependencies["playwright"].version, .dependencies["playwright"].version)] | map(select(. != null)) | first')" >> $GITHUB_OUTPUT
       shell: bash
     - name: Set Playwright cache key
+      if: inputs.playwright-browsers != ''
       id: playwright-cache-key
       run: echo "value=playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-$(echo '${{ inputs.playwright-browsers }}' | tr ' ' '-')" >> $GITHUB_OUTPUT
       shell: bash
     - name: Cache Playwright browsers
+      if: inputs.playwright-browsers != ''
       id: playwright-cache
       uses: actions/cache@v5.0.5
       with:
         path: ~/.cache/ms-playwright
         key: ${{ steps.playwright-cache-key.outputs.value }}
     - name: Install Playwright browsers
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
+      if: inputs.playwright-browsers != '' && steps.playwright-cache.outputs.cache-hit != 'true'
       run: pnpm dlx playwright@${{ steps.playwright-version.outputs.version }} install --with-deps ${{ inputs.playwright-browsers }}
       shell: bash
     - name: Install Playwright system dependencies
-      if: steps.playwright-cache.outputs.cache-hit == 'true'
+      if: inputs.playwright-browsers != '' && steps.playwright-cache.outputs.cache-hit == 'true'
       run: pnpm dlx playwright@${{ steps.playwright-version.outputs.version }} install-deps ${{ inputs.playwright-browsers }}
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
       - uses: ./.github/actions/setup-node
+        with:
+          playwright-browsers: chromium
       - run: pnpm lint --format=github
       - run: pnpm format --check
       - run: pnpm knip
@@ -33,8 +35,8 @@ jobs:
       - uses: actions/checkout@v6.0.3
       - uses: ./.github/actions/setup-node
         with:
-          playwright-browsers: chromium webkit
-      - run: pnpm test:e2e:web
+          playwright-browsers: chromium
+      - run: pnpm test:e2e:web -- --project=chromium --project=mobile-chrome
       - if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.3
       - uses: ./.github/actions/setup-node
+        with:
+          playwright-browsers: chromium webkit
       - run: pnpm test:e2e:web
       - if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7.0.1

--- a/apps/crawler/src/install-setup.test.ts
+++ b/apps/crawler/src/install-setup.test.ts
@@ -10,13 +10,14 @@ type RootPackageJson = {
 };
 
 describe("root install setup", () => {
-  test("installs Playwright browsers for the crawler after root install", () => {
+  test("allows CI to skip the Playwright browser install", () => {
     const packageJson = JSON.parse(
       readFileSync(path.join(repositoryRoot, "package.json"), "utf8"),
     ) as RootPackageJson;
 
     expect(packageJson.scripts).toMatchObject({
-      postinstall: "pnpm --filter @mf-dashboard/crawler exec playwright install",
+      postinstall:
+        '[ -n "$SKIP_PLAYWRIGHT_BROWSER_INSTALL" ] || pnpm --filter @mf-dashboard/crawler exec playwright install',
     });
   });
 });

--- a/apps/crawler/src/install-setup.test.ts
+++ b/apps/crawler/src/install-setup.test.ts
@@ -1,7 +1,9 @@
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 
@@ -10,14 +12,52 @@ type RootPackageJson = {
 };
 
 describe("root install setup", () => {
-  test("allows CI to skip the Playwright browser install", () => {
+  let temporaryDirectory: string;
+  let markerPath: string;
+  let postinstall: string;
+
+  beforeEach(() => {
+    temporaryDirectory = mkdtempSync(path.join(os.tmpdir(), "mf-dashboard-install-"));
+    markerPath = path.join(temporaryDirectory, "pnpm-invocation");
+
     const packageJson = JSON.parse(
       readFileSync(path.join(repositoryRoot, "package.json"), "utf8"),
     ) as RootPackageJson;
+    postinstall = packageJson.scripts?.postinstall ?? "";
 
-    expect(packageJson.scripts).toMatchObject({
-      postinstall:
-        '[ -n "$SKIP_PLAYWRIGHT_BROWSER_INSTALL" ] || pnpm --filter @mf-dashboard/crawler exec playwright install',
+    const fakePnpmPath = path.join(temporaryDirectory, "pnpm");
+    writeFileSync(fakePnpmPath, '#!/bin/sh\nprintf "%s" "$*" > "$PLAYWRIGHT_TEST_MARKER"\n');
+    chmodSync(fakePnpmPath, 0o755);
+  });
+
+  afterEach(() => {
+    rmSync(temporaryDirectory, { recursive: true, force: true });
+  });
+
+  test("installs Playwright browsers by default", () => {
+    const result = spawnSync("/bin/sh", ["-c", postinstall], {
+      env: {
+        PATH: temporaryDirectory,
+        PLAYWRIGHT_TEST_MARKER: markerPath,
+      },
     });
+
+    expect(result.status).toBe(0);
+    expect(readFileSync(markerPath, "utf8")).toBe(
+      "--filter @mf-dashboard/crawler exec playwright install",
+    );
+  });
+
+  test("skips Playwright browser installation when requested", () => {
+    const result = spawnSync("/bin/sh", ["-c", postinstall], {
+      env: {
+        PATH: temporaryDirectory,
+        PLAYWRIGHT_TEST_MARKER: markerPath,
+        SKIP_PLAYWRIGHT_BROWSER_INSTALL: "true",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(existsSync(markerPath)).toBe(false);
   });
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "setup": "corepack enable pnpm",
-    "postinstall": "pnpm --filter @mf-dashboard/crawler exec playwright install",
+    "postinstall": "[ -n \"$SKIP_PLAYWRIGHT_BROWSER_INSTALL\" ] || pnpm --filter @mf-dashboard/crawler exec playwright install",
     "dev": "turbo dev",
     "dev:demo": "turbo dev:demo",
     "build": "turbo build",


### PR DESCRIPTION
## Summary

- skip the root Playwright browser installation during the shared CI dependency install
- make Playwright browser setup opt-in for the composite action
- restore cached Chromium only in jobs that launch browser tests
- run web E2E on Chromium desktop and mobile projects without WebKit

## Linear Issue

- [HIR-119](https://linear.app/hiroppy/issue/HIR-119/ci%E3%81%AEpnpm-i%E3%81%8C%E7%95%B0%E5%B8%B8%E3%81%AB%E9%95%B7%E3%81%84%E3%81%AE%E3%82%92%E6%94%B9%E5%96%84%E3%81%99%E3%82%8B)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| --- | --- | --- |
| Performance efficiency | Browser downloads dominated the cached dependency install and ran in jobs that do not use a browser. | Browser setup is removed from pnpm install; build-demo installs no browser; test and E2E restore Chromium through a dedicated cache. |
| Functional suitability | Crawler unit tests and web E2E require Chromium. | Both jobs prepare Chromium; E2E runs desktop and mobile Chromium projects and passes. |
| Maintainability | CI-only behavior must remain explicit and easy to audit. | Browser setup is controlled by one composite-action input and is enabled only at browser-test call sites. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| --- | --- | --- |
| Checklist-based testing | Workflow changes have a small set of required invariants. | Frozen lockfile install, pnpm store cache, Chromium input, and browser-free build behavior. |
| Error guessing | Cache miss/hit and empty browser inputs are the likely regression paths. | No browser command with an empty input; cache miss downloads Chromium; cache hit installs system dependencies only. |

### Primary Test Conditions

- Test and E2E jobs request cached Chromium explicitly.
- Build-demo uses the shared setup action without browser inputs.
- Web E2E selects the chromium and mobile-chrome projects only.
- Root postinstall exits without a browser download when the CI setup sets the skip variable.
- pnpm install continues to use the frozen lockfile and setup-node pnpm store cache.

### Out-of-Scope Risks

- GitHub-hosted runner or Playwright CDN outages remain external to the workflow.
- Application behavior is unchanged; no browser UI walkthrough is applicable.

## Verification

- [x] `SKIP_PLAYWRIGHT_BROWSER_INSTALL=true pnpm run postinstall`
- [x] `SKIP_PLAYWRIGHT_BROWSER_INSTALL=true pnpm install --frozen-lockfile`
- [x] `pnpm --filter @mf-dashboard/crawler test`
- [x] `pnpm test:e2e:web -- --list --project=chromium --project=mobile-chrome`
- [x] `pnpm format:check`
- [x] `pnpm lint`
- [x] YAML parsed with Ruby Psych; package.json parsed with Node.js
- [x] `git diff --check`
- [ ] GitHub Actions CI
