### PR TITLE
fix(crawler): preserve transfer classification

### DIFF
--- a/apps/crawler/src/category-decision/categorize-cash-flow.test.ts
+++ b/apps/crawler/src/category-decision/categorize-cash-flow.test.ts
@@ -114,6 +114,27 @@ describe("categorizeCashFlowMonth", () => {
     ).toBe("latest-new");
   });
 
+  test("未分類表示の振替はカテゴリ決定の対象にしない", async () => {
+    const transfer = item("transfer-new");
+    transfer.type = "transfer";
+    transfer.isTransfer = true;
+    transfer.isExcludedFromCalculation = true;
+    const initialCashFlow = cashFlow("2025-04", [transfer]);
+    vi.mocked(findExistingTransactionMfIds).mockResolvedValue(new Set());
+
+    const result = await categorizeCashFlowMonth({
+      page: {} as Page,
+      db: {} as Parameters<typeof categorizeCashFlowMonth>[0]["db"],
+      cashFlow: initialCashFlow,
+      config,
+      usage: { llmCallsUsed: 0 },
+    });
+
+    expect(result).toBe(initialCashFlow);
+    expect(scrapeCashFlowMonth).not.toHaveBeenCalled();
+    expect(applyCategoryDecisions).not.toHaveBeenCalled();
+  });
+
   test("カテゴリ反映後の再スクレイプ失敗時は反映カテゴリをローカル適用して返す", async () => {
     const initialCashFlow = cashFlow("2026-06", [item("initial-new")]);
     const latestCashFlow = cashFlow("2026-06", [item("latest-new")]);

--- a/apps/crawler/src/scrapers/cash-flow-history.test.ts
+++ b/apps/crawler/src/scrapers/cash-flow-history.test.ts
@@ -1,6 +1,16 @@
-import { chromium, type Browser, type Page } from "playwright";
+import { chromium, type Browser } from "playwright";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
-import { buildMonthRange, scrapeCashFlowMonth } from "./cash-flow-history.js";
+import { buildMonthRange, parseDetailRow, scrapeCashFlowMonth } from "./cash-flow-history.js";
+
+let browser: Browser;
+
+beforeAll(async () => {
+  browser = await chromium.launch();
+});
+
+afterAll(async () => {
+  await browser.close();
+});
 
 describe("buildMonthRange", () => {
   test.each([
@@ -15,19 +25,8 @@ describe("buildMonthRange", () => {
 });
 
 describe("scrapeCashFlowMonth", () => {
-  let browser: Browser;
-  let page: Page;
-
-  beforeAll(async () => {
-    browser = await chromium.launch();
-  });
-
-  afterAll(async () => {
-    await browser.close();
-  });
-
   test("指定月範囲のURLへ遷移して収支テーブル表示後に抽出する", async () => {
-    page = await browser.newPage();
+    const page = await browser.newPage();
     try {
       let requestedUrl: string | null = null;
       await page.route("https://moneyforward.com/cf?**", async (route) => {
@@ -70,6 +69,48 @@ describe("scrapeCashFlowMonth", () => {
         totalExpense: 0,
         balance: 0,
         items: [],
+      });
+    } finally {
+      await page.close();
+    }
+  });
+});
+
+describe("parseDetailRow", () => {
+  test("振替口座がある行はカテゴリ表示があっても振替として扱う", async () => {
+    const page = await browser.newPage();
+    try {
+      await page.setContent(`
+        <table>
+          <tbody>
+            <tr id="js-transaction-transfer-1" class="mf-grayout">
+              <td></td>
+              <td>4/15</td>
+              <td>Internal transfer</td>
+              <td>-1,200</td>
+              <td>
+                <div>Account A</div>
+                <div class="transfer_account_box">Account B</div>
+              </td>
+              <td>未分類</td>
+              <td>未分類</td>
+              <td></td>
+              <td></td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      `);
+
+      const result = await parseDetailRow(page.locator("tr"), 0, 2025);
+
+      expect(result).toMatchObject({
+        mfId: "transfer-1",
+        type: "transfer",
+        isTransfer: true,
+        isExcludedFromCalculation: true,
+        accountName: "Account B",
+        transferTarget: "Account A",
       });
     } finally {
       await page.close();

--- a/apps/crawler/src/scrapers/cash-flow-history.ts
+++ b/apps/crawler/src/scrapers/cash-flow-history.ts
@@ -112,8 +112,9 @@ async function detectMonth(page: Page): Promise<{ year: number; month: number }>
 async function detectTransactionType(
   amountCell: ReturnType<Page["locator"]>,
   categoryText: string,
+  hasTransferBox: boolean,
 ): Promise<"income" | "expense" | "transfer"> {
-  if (categoryText === "") return "transfer";
+  if (hasTransferBox || categoryText === "") return "transfer";
 
   // 並列取得
   const [amountClass, amountStyle, amountHtml] = await Promise.all([
@@ -169,7 +170,11 @@ export async function parseDetailRow(
 
   const isExcludedFromCalculation = (rowClass ?? "").includes("mf-grayout");
 
-  const type = await detectTransactionType(cells.nth(DETAIL_COLUMNS.AMOUNT), categoryText);
+  const type = await detectTransactionType(
+    cells.nth(DETAIL_COLUMNS.AMOUNT),
+    categoryText,
+    hasTransferBox,
+  );
   const isTransfer = type === "transfer";
 
   let accountName: string | undefined;


### PR DESCRIPTION
# Summary

- Treat the explicit transfer-account DOM as the authoritative transfer signal even when a category label is present.
- Keep those transfers out of automatic category decisions.
- Add Playwright-backed parser coverage and a category-decision regression test.

## Linear Issue

- [HIR-126](https://linear.app/hiroppy/issue/HIR-126)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | Transfer rows must retain their transaction type throughout scraping and categorization. | A row with transfer-account markup remains `type=transfer` and `isTransfer=true`, including when its category cell is non-empty. |
| Compatibility | Normal uncategorized income and expense processing must continue through the existing category-decision flow. | Only rows carrying the explicit transfer signal take the transfer path; existing category-decision tests remain green. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Decision table testing | Transaction type depends on transfer markup and category-cell state. | Covers the previously missing combination of transfer markup with a non-empty category. |
| Branch testing | The parser's transfer branch must take precedence over income/expense styling. | Confirms transfer flags and account endpoints are preserved. |
| Regression testing | The parser output feeds automatic categorization. | Confirms parsed transfers do not trigger a rescrape or category update. |

### Primary Test Conditions

- Transfer-account markup plus a non-empty category is parsed as a transfer.
- Account name, transfer target, and excluded-from-calculation state remain available.
- A parsed transfer does not enter category decision processing.
- Existing non-transfer categorization remains green in the full test suite.

### Out-of-Scope Risks

- Live Money Forward E2E was not run because this workspace has no authentication state; equivalent DOM behavior is exercised with Playwright fixtures.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [x] Storybook tests
- [ ] E2E tests
- [ ] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/crawler test -- src/scrapers/cash-flow-history.test.ts src/category-decision/categorize-cash-flow.test.ts — pass (22 files, 172 tests)
pnpm test — pass (6/6 workspace tasks; crawler 172, DB 295, web 712 tests)
pnpm turbo typecheck — pass (9/9 tasks)
pnpm lint — pass
pnpm format:check — pass
```

### Checks Not Run

- Live crawler E2E — Money Forward authentication state is unavailable in this workspace; Playwright DOM fixtures cover the changed parsing path.
- Manual verification — the affected flow requires the same unavailable authentication state; parser and categorization behavior were verified with automated fixtures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction recognition so transfers are correctly identified even when transfer details are present.
  * Transfer transactions are now excluded from category calculations when marked as excluded.
  * Preserved cash-flow results when a period contains only excluded transfer transactions.

* **Tests**
  * Added coverage for transfer detection, account details, exclusion handling, and cash-flow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->