### PR TITLE
feat(crawler): add run state persistence

### DIFF
--- a/apps/crawler/src/crawler-run-state.test.ts
+++ b/apps/crawler/src/crawler-run-state.test.ts
@@ -25,7 +25,7 @@ const runningState: CrawlerRunStateSnapshot = {
     label: "金融機関を更新",
     metadata: {
       kind: "refresh",
-      maxWaitMinutes: 20,
+      maxWaitMinutes: 0.5,
       remainingAccounts: 1,
       incompleteAccounts: ["Institution A"],
     },
@@ -43,7 +43,7 @@ const runningState: CrawlerRunStateSnapshot = {
       reason: null,
       metadata: {
         kind: "refresh",
-        maxWaitMinutes: 20,
+        maxWaitMinutes: 0.5,
         remainingAccounts: 1,
         incompleteAccounts: ["Institution A"],
       },

--- a/apps/crawler/src/crawler-run-state.test.ts
+++ b/apps/crawler/src/crawler-run-state.test.ts
@@ -1,0 +1,151 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  getCrawlerRunStatePath,
+  readCrawlerRunState,
+  type CrawlerRunStateSnapshot,
+  writeCrawlerRunState,
+} from "./crawler-run-state.js";
+
+const startedAt = "2026-01-01T00:00:00.000Z";
+const finishedAt = "2026-01-01T00:01:00.000Z";
+
+const runningState: CrawlerRunStateSnapshot = {
+  version: 1,
+  runId: "run-running",
+  runStatus: "running",
+  source: "manual",
+  startedAt,
+  finishedAt: null,
+  current: {
+    timelineItemId: "refresh",
+    step: "moneyforward_refresh",
+    label: "金融機関を更新",
+    metadata: {
+      kind: "refresh",
+      maxWaitMinutes: 20,
+      remainingAccounts: 1,
+      incompleteAccounts: ["Institution A"],
+    },
+  },
+  waitingFor: "更新中の金融機関が0件になるのを待機",
+  progress: { completed: 1, total: 3 },
+  timeline: [
+    {
+      id: "refresh",
+      step: "moneyforward_refresh",
+      label: "金融機関を更新",
+      status: "running",
+      startedAt,
+      finishedAt: null,
+      reason: null,
+      metadata: {
+        kind: "refresh",
+        maxWaitMinutes: 20,
+        remainingAccounts: 1,
+        incompleteAccounts: ["Institution A"],
+      },
+    },
+  ],
+  reason: null,
+};
+
+const successState: CrawlerRunStateSnapshot = {
+  ...runningState,
+  runId: "run-success",
+  runStatus: "success",
+  finishedAt,
+  current: null,
+  waitingFor: null,
+  progress: { completed: 3, total: 3 },
+  timeline: [
+    {
+      ...runningState.timeline[0],
+      status: "done",
+      startedAt,
+      finishedAt,
+      reason: null,
+    },
+  ],
+};
+
+const failedState: CrawlerRunStateSnapshot = {
+  ...runningState,
+  runId: "run-failed",
+  runStatus: "failed",
+  finishedAt,
+  waitingFor: null,
+  timeline: [
+    {
+      id: "group-a",
+      step: "group_data",
+      label: "グループを取得",
+      status: "failed",
+      startedAt,
+      finishedAt,
+      reason: {
+        code: "selector_not_found",
+        message: "必要な項目が見つかりませんでした",
+        selector: "[data-test=group]",
+      },
+      metadata: { kind: "group", groupName: "Group A" },
+    },
+  ],
+  reason: {
+    code: "selector_not_found",
+    message: "必要な項目が見つかりませんでした",
+    selector: "[data-test=group]",
+  },
+};
+
+describe("crawler run state file", () => {
+  let directory: string;
+  let statePath: string;
+
+  beforeEach(async () => {
+    directory = await mkdtemp(path.join(os.tmpdir(), "crawler-run-state-"));
+    statePath = path.join(directory, "nested", "crawler-run-state.json");
+    await mkdir(path.dirname(statePath), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  test("uses data/crawler-run-state.json by default", () => {
+    expect(getCrawlerRunStatePath()).toBe(
+      path.resolve(import.meta.dirname, "../../../data/crawler-run-state.json"),
+    );
+  });
+
+  test.each([
+    ["running", runningState],
+    ["success", successState],
+    ["failed", failedState],
+  ])("atomically writes and reads a %s snapshot", async (_status, state) => {
+    await writeCrawlerRunState(state, { statePath });
+
+    await expect(readCrawlerRunState({ statePath })).resolves.toEqual(state);
+    await expect(readdir(path.dirname(statePath))).resolves.toEqual(["crawler-run-state.json"]);
+    await expect(readFile(statePath, "utf8")).resolves.toBe(`${JSON.stringify(state, null, 2)}\n`);
+  });
+
+  test("returns null when the state file does not exist", async () => {
+    await expect(readCrawlerRunState({ statePath })).resolves.toBeNull();
+  });
+
+  test("returns null for invalid JSON", async () => {
+    await writeFile(statePath, "{ invalid json");
+
+    await expect(readCrawlerRunState({ statePath })).resolves.toBeNull();
+  });
+
+  test("returns null for JSON with an invalid state shape", async () => {
+    await writeCrawlerRunState(runningState, { statePath });
+    await writeFile(statePath, JSON.stringify({ ...runningState, runStatus: "idle" }));
+
+    await expect(readCrawlerRunState({ statePath })).resolves.toBeNull();
+  });
+});

--- a/apps/crawler/src/crawler-run-state.ts
+++ b/apps/crawler/src/crawler-run-state.ts
@@ -1,0 +1,338 @@
+import { randomUUID } from "node:crypto";
+import { open, mkdir, readFile, rename, rm } from "node:fs/promises";
+import path from "node:path";
+
+const DEFAULT_STATE_PATH = path.resolve(
+  import.meta.dirname,
+  "../../../data/crawler-run-state.json",
+);
+
+export type CrawlerRunStatus = "running" | "success" | "failed";
+
+export type CrawlerRunStepStatus =
+  | "pending"
+  | "running"
+  | "done"
+  | "warning"
+  | "failed"
+  | "skipped";
+
+export type CrawlerRunReason =
+  | { code: "auth_failed"; message: string }
+  | {
+      code: "refresh_timeout";
+      message: string;
+      maxWaitMinutes: number;
+      incompleteAccounts: string[];
+    }
+  | { code: "moneyforward_timeout"; message: string; operation: string; timeoutMs: number }
+  | { code: "navigation_failed"; message: string; url: string }
+  | { code: "selector_not_found"; message: string; selector: string }
+  | { code: "unknown_error"; message: string };
+
+export interface CrawlerRunGroupMetadata {
+  kind: "group";
+  groupName: string;
+}
+
+export interface CrawlerRunMonthMetadata {
+  kind: "month";
+  month: string;
+}
+
+export interface CrawlerRunRefreshMetadata {
+  kind: "refresh";
+  maxWaitMinutes: number;
+  remainingAccounts: number;
+  incompleteAccounts: string[];
+}
+
+export type CrawlerRunStepDetails =
+  | { step: "authentication"; metadata: null }
+  | { step: "moneyforward_refresh"; metadata: CrawlerRunRefreshMetadata }
+  | { step: "global_data"; metadata: null }
+  | { step: "group_data"; metadata: CrawlerRunGroupMetadata }
+  | { step: "cash_flow_history"; metadata: CrawlerRunMonthMetadata }
+  | { step: "database_save"; metadata: null }
+  | { step: "institution_categories"; metadata: null }
+  | { step: "analytics"; metadata: null }
+  | { step: "notification"; metadata: null }
+  | { step: "web_cache_refresh"; metadata: null };
+
+type CrawlerRunTimelineStatusDetails =
+  | { status: "pending"; startedAt: null; finishedAt: null; reason: null }
+  | { status: "running"; startedAt: string; finishedAt: null; reason: null }
+  | { status: "done"; startedAt: string; finishedAt: string; reason: null }
+  | {
+      status: "warning" | "failed";
+      startedAt: string;
+      finishedAt: string;
+      reason: CrawlerRunReason;
+    }
+  | { status: "skipped"; startedAt: null; finishedAt: string; reason: null };
+
+export type CrawlerRunTimelineItem = {
+  id: string;
+  label: string;
+} & CrawlerRunStepDetails &
+  CrawlerRunTimelineStatusDetails;
+
+export type CrawlerRunCurrent = {
+  timelineItemId: string;
+  label: string;
+} & CrawlerRunStepDetails;
+
+export interface CrawlerRunProgress {
+  completed: number;
+  total: number;
+}
+
+interface CrawlerRunStateBase {
+  version: 1;
+  runId: string;
+  source: string;
+  startedAt: string;
+  timeline: CrawlerRunTimelineItem[];
+}
+
+export type CrawlerRunStateSnapshot =
+  | (CrawlerRunStateBase & {
+      runStatus: "running";
+      finishedAt: null;
+      current: CrawlerRunCurrent | null;
+      waitingFor: string | null;
+      progress: CrawlerRunProgress | null;
+      reason: null;
+    })
+  | (CrawlerRunStateBase & {
+      runStatus: "success";
+      finishedAt: string;
+      current: null;
+      waitingFor: null;
+      progress: CrawlerRunProgress;
+      reason: null;
+    })
+  | (CrawlerRunStateBase & {
+      runStatus: "failed";
+      finishedAt: string;
+      current: CrawlerRunCurrent | null;
+      waitingFor: null;
+      progress: CrawlerRunProgress | null;
+      reason: CrawlerRunReason;
+    });
+
+export interface CrawlerRunStateFileOptions {
+  statePath?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function isCrawlerRunReason(value: unknown): value is CrawlerRunReason {
+  if (!isRecord(value) || typeof value.message !== "string") {
+    return false;
+  }
+
+  switch (value.code) {
+    case "auth_failed":
+    case "unknown_error":
+      return true;
+    case "refresh_timeout":
+      return isNonNegativeInteger(value.maxWaitMinutes) && isStringArray(value.incompleteAccounts);
+    case "moneyforward_timeout":
+      return typeof value.operation === "string" && isNonNegativeInteger(value.timeoutMs);
+    case "navigation_failed":
+      return typeof value.url === "string";
+    case "selector_not_found":
+      return typeof value.selector === "string";
+    default:
+      return false;
+  }
+}
+
+function isCrawlerRunStepDetails(value: Record<string, unknown>): boolean {
+  const metadata = value.metadata;
+
+  switch (value.step) {
+    case "authentication":
+    case "global_data":
+    case "database_save":
+    case "institution_categories":
+    case "analytics":
+    case "notification":
+    case "web_cache_refresh":
+      return metadata === null;
+    case "moneyforward_refresh":
+      return (
+        isRecord(metadata) &&
+        metadata.kind === "refresh" &&
+        isNonNegativeInteger(metadata.maxWaitMinutes) &&
+        isNonNegativeInteger(metadata.remainingAccounts) &&
+        isStringArray(metadata.incompleteAccounts)
+      );
+    case "group_data":
+      return (
+        isRecord(metadata) && metadata.kind === "group" && typeof metadata.groupName === "string"
+      );
+    case "cash_flow_history":
+      return isRecord(metadata) && metadata.kind === "month" && typeof metadata.month === "string";
+    default:
+      return false;
+  }
+}
+
+function isCrawlerRunTimelineItem(value: unknown): value is CrawlerRunTimelineItem {
+  if (
+    !isRecord(value) ||
+    typeof value.id !== "string" ||
+    typeof value.label !== "string" ||
+    !isCrawlerRunStepDetails(value)
+  ) {
+    return false;
+  }
+
+  switch (value.status) {
+    case "pending":
+      return value.startedAt === null && value.finishedAt === null && value.reason === null;
+    case "running":
+      return (
+        typeof value.startedAt === "string" && value.finishedAt === null && value.reason === null
+      );
+    case "done":
+      return (
+        typeof value.startedAt === "string" &&
+        typeof value.finishedAt === "string" &&
+        value.reason === null
+      );
+    case "warning":
+    case "failed":
+      return (
+        typeof value.startedAt === "string" &&
+        typeof value.finishedAt === "string" &&
+        isCrawlerRunReason(value.reason)
+      );
+    case "skipped":
+      return (
+        value.startedAt === null && typeof value.finishedAt === "string" && value.reason === null
+      );
+    default:
+      return false;
+  }
+}
+
+function isCrawlerRunCurrent(value: unknown): value is CrawlerRunCurrent {
+  return (
+    isRecord(value) &&
+    typeof value.timelineItemId === "string" &&
+    typeof value.label === "string" &&
+    isCrawlerRunStepDetails(value)
+  );
+}
+
+function isCrawlerRunProgress(value: unknown): value is CrawlerRunProgress {
+  return (
+    isRecord(value) &&
+    isNonNegativeInteger(value.completed) &&
+    isNonNegativeInteger(value.total) &&
+    value.completed <= value.total
+  );
+}
+
+export function isCrawlerRunStateSnapshot(value: unknown): value is CrawlerRunStateSnapshot {
+  if (
+    !isRecord(value) ||
+    value.version !== 1 ||
+    typeof value.runId !== "string" ||
+    typeof value.source !== "string" ||
+    typeof value.startedAt !== "string" ||
+    !Array.isArray(value.timeline) ||
+    !value.timeline.every(isCrawlerRunTimelineItem)
+  ) {
+    return false;
+  }
+
+  switch (value.runStatus) {
+    case "running":
+      return (
+        value.finishedAt === null &&
+        (value.current === null || isCrawlerRunCurrent(value.current)) &&
+        (value.waitingFor === null || typeof value.waitingFor === "string") &&
+        (value.progress === null || isCrawlerRunProgress(value.progress)) &&
+        value.reason === null
+      );
+    case "success":
+      return (
+        typeof value.finishedAt === "string" &&
+        value.current === null &&
+        value.waitingFor === null &&
+        isCrawlerRunProgress(value.progress) &&
+        value.reason === null
+      );
+    case "failed":
+      return (
+        typeof value.finishedAt === "string" &&
+        (value.current === null || isCrawlerRunCurrent(value.current)) &&
+        value.waitingFor === null &&
+        (value.progress === null || isCrawlerRunProgress(value.progress)) &&
+        isCrawlerRunReason(value.reason)
+      );
+    default:
+      return false;
+  }
+}
+
+export function getCrawlerRunStatePath(options: CrawlerRunStateFileOptions = {}): string {
+  return options.statePath ?? DEFAULT_STATE_PATH;
+}
+
+export async function readCrawlerRunState(
+  options: CrawlerRunStateFileOptions = {},
+): Promise<CrawlerRunStateSnapshot | null> {
+  let contents: string;
+  try {
+    contents = await readFile(getCrawlerRunStatePath(options), "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+
+  try {
+    const value: unknown = JSON.parse(contents);
+    return isCrawlerRunStateSnapshot(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeCrawlerRunState(
+  state: CrawlerRunStateSnapshot,
+  options: CrawlerRunStateFileOptions = {},
+): Promise<void> {
+  const statePath = getCrawlerRunStatePath(options);
+  await mkdir(path.dirname(statePath), { recursive: true });
+
+  const temporaryPath = `${statePath}.${process.pid}.${randomUUID()}.tmp`;
+  let file: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    file = await open(temporaryPath, "wx", 0o600);
+    await file.writeFile(`${JSON.stringify(state, null, 2)}\n`, "utf8");
+    await file.sync();
+    await file.close();
+    file = null;
+    await rename(temporaryPath, statePath);
+  } finally {
+    await file?.close();
+    await rm(temporaryPath, { force: true });
+  }
+}

--- a/apps/crawler/src/crawler-run-state.ts
+++ b/apps/crawler/src/crawler-run-state.ts
@@ -137,6 +137,10 @@ function isNonNegativeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value >= 0;
 }
 
+function isNonNegativeFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
 function isCrawlerRunReason(value: unknown): value is CrawlerRunReason {
   if (!isRecord(value) || typeof value.message !== "string") {
     return false;
@@ -147,9 +151,11 @@ function isCrawlerRunReason(value: unknown): value is CrawlerRunReason {
     case "unknown_error":
       return true;
     case "refresh_timeout":
-      return isNonNegativeInteger(value.maxWaitMinutes) && isStringArray(value.incompleteAccounts);
+      return (
+        isNonNegativeFiniteNumber(value.maxWaitMinutes) && isStringArray(value.incompleteAccounts)
+      );
     case "moneyforward_timeout":
-      return typeof value.operation === "string" && isNonNegativeInteger(value.timeoutMs);
+      return typeof value.operation === "string" && isNonNegativeFiniteNumber(value.timeoutMs);
     case "navigation_failed":
       return typeof value.url === "string";
     case "selector_not_found":
@@ -175,7 +181,7 @@ function isCrawlerRunStepDetails(value: Record<string, unknown>): boolean {
       return (
         isRecord(metadata) &&
         metadata.kind === "refresh" &&
-        isNonNegativeInteger(metadata.maxWaitMinutes) &&
+        isNonNegativeFiniteNumber(metadata.maxWaitMinutes) &&
         isNonNegativeInteger(metadata.remainingAccounts) &&
         isStringArray(metadata.incompleteAccounts)
       );
@@ -331,8 +337,24 @@ export async function writeCrawlerRunState(
     await file.close();
     file = null;
     await rename(temporaryPath, statePath);
+    await syncDirectory(path.dirname(statePath));
   } finally {
     await file?.close();
     await rm(temporaryPath, { force: true });
+  }
+}
+
+async function syncDirectory(directoryPath: string): Promise<void> {
+  let directory: Awaited<ReturnType<typeof open>> | null = null;
+  try {
+    directory = await open(directoryPath, "r");
+    await directory.sync();
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (!code || !["EBADF", "EINVAL", "EISDIR", "ENOSYS", "ENOTSUP", "EPERM"].includes(code)) {
+      throw error;
+    }
+  } finally {
+    await directory?.close();
   }
 }


### PR DESCRIPTION
## Summary

- crawler run、step、reason、timeline、metadata、snapshot を strict discriminated union で定義
- latest state を `data/crawler-run-state.json` へ同一ディレクトリの temp file + fsync + rename で atomic write
- missing/invalid JSON/invalid shape を `null` に fallback する runtime validation 付き read を追加
- running/success/failed の round-trip と失敗入力を unit test で検証

## Linear Issue

- [HIR-128](https://linear.app/hiroppy/issue/HIR-128/最初に実装-crawler-run-state-の型と保存レイヤーを追加する)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | 後続の timeline/UI が status、step、reason を漏れなく分岐できる必要がある | 限定 union と runtime validator が running/success/failed および step/reason の契約を保持する |
| Reliability | 書き込み中の read や破損 JSON で crawler status API を壊さない必要がある | temp file + fsync + rename を使い、missing/invalid state は安全に `null` へ fallback する |
| Maintainability | lock と latest state の責務分離、および後続チケットでの拡張容易性が必要 | lock 実装を変更せず、step metadata と reason を明示的な discriminated union に分離する |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| State transition testing | run と timeline は status ごとに timestamp/reason の許容形が異なる | running/success/failed の代表 snapshot と running/done/failed timeline を検証する |
| Decision table testing | JSON parse 可否と schema validity の組み合わせで read 結果が分岐する | valid、missing、invalid JSON、invalid shape の結果を検証する |
| Error guessing | state file の途中書き込み・残存 temp・欠損は実運用上の主要障害 | atomic rename 後に完成ファイルだけが残ることと安全な fallback を検証する |

### Primary Test Conditions

- running/success/failed snapshot の write/read round-trip
- atomic write 後に temp file が残らず、完成 JSON のみ存在する
- missing file、invalid JSON、valid JSON だが invalid schema の read が `null`
- crawler package と monorepo 全体の TypeScript contract に回帰がない

### Out-of-Scope Risks

- 実行フェーズからの state 更新と Web 表示は後続 HIR-129/HIR-130 の範囲
- 複数プロセスの長時間 stress test は未実施。atomicity は同一ディレクトリ rename と unit test で担保

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [ ] Storybook tests
- [ ] E2E tests
- [ ] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/crawler test — 23 files / 177 tests passed
pnpm --filter @mf-dashboard/crawler typecheck — passed
pnpm turbo typecheck — 9/9 packages passed
pnpm lint — passed
pnpm format:check — 494 files matched
git diff --check — passed
```

### Checks Not Run

- Storybook/E2E/manual runtime — 保存レイヤーはまだ実行経路や UI に接続されておらず、対象となる user flow はないため。後続 HIR-129/HIR-130 で実施
