### PR TITLE
feat(crawler): record phase progress in run timeline

### DIFF
--- a/apps/crawler/src/crawler-phases.test.ts
+++ b/apps/crawler/src/crawler-phases.test.ts
@@ -258,7 +258,6 @@ describe("runCashFlowHistoryPhase", () => {
     try {
       const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
         id: "run-a",
-        pid: 123,
         source: "test",
         startedAt: "2026-07-01T00:00:00.000Z",
       });
@@ -281,9 +280,9 @@ describe("runCashFlowHistoryPhase", () => {
 
       expect(progress.getState().timeline).toEqual([
         expect.objectContaining({
-          code: "monthly_cash_flow",
-          status: "success",
-          metadata: { month: "2026-06" },
+          step: "cash_flow_history",
+          status: "done",
+          metadata: { kind: "month", month: "2026-06" },
         }),
       ]);
     } finally {

--- a/apps/crawler/src/crawler-phases.test.ts
+++ b/apps/crawler/src/crawler-phases.test.ts
@@ -250,6 +250,52 @@ describe("runSavePhase", () => {
 });
 
 describe("runCashFlowHistoryPhase", () => {
+  test("後続月の取得失敗時に未保存の月 step をすべて failed にする", async () => {
+    const page = {};
+    const db = {};
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-history-later-failure-"));
+    try {
+      const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
+        id: "run-a",
+        source: "test",
+        startedAt: "2026-07-01T00:00:00.000Z",
+      });
+      vi.mocked(buildAccountIdMap).mockResolvedValue(new Map());
+      vi.mocked(hasTransactionsForMonth).mockResolvedValue(false);
+      vi.mocked(scrapeCashFlowHistory).mockImplementation(async (_page, _months, callbacks) => {
+        await callbacks?.onMonthStart?.("2026-06");
+        await callbacks?.onMonthComplete?.("2026-06");
+        await callbacks?.onMonthStart?.("2026-05");
+        const failure = new Error("history page unavailable");
+        await callbacks?.onMonthFailure?.("2026-05", failure);
+        throw failure;
+      });
+
+      await expect(
+        runCashFlowHistoryPhase(
+          db as Parameters<typeof runCashFlowHistoryPhase>[0],
+          page as Parameters<typeof runCashFlowHistoryPhase>[1],
+          { isHistoryMode: true },
+          undefined,
+          progress,
+        ),
+      ).rejects.toThrow("history page unavailable");
+
+      expect(progress.getState().timeline).toEqual([
+        expect.objectContaining({
+          status: "failed",
+          metadata: { kind: "month", month: "2026-06" },
+        }),
+        expect.objectContaining({
+          status: "failed",
+          metadata: { kind: "month", month: "2026-05" },
+        }),
+      ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("履歴月の保存失敗を対象月の failed step にする", async () => {
     const page = {};
     const db = {};

--- a/apps/crawler/src/crawler-phases.test.ts
+++ b/apps/crawler/src/crawler-phases.test.ts
@@ -1,3 +1,5 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { buildAccountIdMap } from "@mf-dashboard/db/repository/accounts";
 import { saveGroupOnlyData, saveScrapedData } from "@mf-dashboard/db/repository/save-scraped-data";
@@ -15,6 +17,7 @@ import {
   runSavePhase,
   type CategoryDecisionRuntime,
 } from "./crawler-phases.js";
+import { createCrawlerProgressReporter } from "./crawler-progress.js";
 import { buildGroupOnlyScrapedData, buildScrapedData } from "./data-builder.js";
 import type { ScrapeResult } from "./scraper.js";
 import { scrapeCashFlowHistory } from "./scrapers/cash-flow-history.js";
@@ -247,6 +250,47 @@ describe("runSavePhase", () => {
 });
 
 describe("runCashFlowHistoryPhase", () => {
+  test("history mode の各対象月を YYYY-MM metadata として記録する", async () => {
+    const page = {};
+    const db = {};
+    const monthData = cashFlow("2026-06", "Service A");
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-history-progress-"));
+    try {
+      const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
+        id: "run-a",
+        pid: 123,
+        source: "test",
+        startedAt: "2026-07-01T00:00:00.000Z",
+      });
+      vi.mocked(buildAccountIdMap).mockResolvedValue(new Map());
+      vi.mocked(hasTransactionsForMonth).mockResolvedValue(true);
+      vi.mocked(scrapeCashFlowHistory).mockImplementation(async (_page, _months, callbacks) => {
+        await callbacks?.onMonthStart?.("2026-06");
+        await callbacks?.onMonthComplete?.("2026-06");
+        return [{ month: "2026-06", data: monthData }];
+      });
+      vi.mocked(saveTransactionsForMonth).mockResolvedValue(1);
+
+      await runCashFlowHistoryPhase(
+        db as Parameters<typeof runCashFlowHistoryPhase>[0],
+        page as Parameters<typeof runCashFlowHistoryPhase>[1],
+        { isHistoryMode: true },
+        undefined,
+        progress,
+      );
+
+      expect(progress.getState().timeline).toEqual([
+        expect.objectContaining({
+          code: "monthly_cash_flow",
+          status: "success",
+          metadata: { month: "2026-06" },
+        }),
+      ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("カテゴリ決定が有効な場合は履歴月を分類してから取引保存する", async () => {
     const page = {};
     const db = {};

--- a/apps/crawler/src/crawler-phases.test.ts
+++ b/apps/crawler/src/crawler-phases.test.ts
@@ -250,6 +250,80 @@ describe("runSavePhase", () => {
 });
 
 describe("runCashFlowHistoryPhase", () => {
+  test("初期 navigation 失敗を対象月 step に記録する", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-history-setup-failure-"));
+    try {
+      const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
+        id: "run-a",
+        source: "test",
+        startedAt: "2026-07-01T00:00:00.000Z",
+      });
+      vi.mocked(buildAccountIdMap).mockResolvedValue(new Map());
+      vi.mocked(hasTransactionsForMonth).mockResolvedValue(true);
+      vi.mocked(switchGroup).mockRejectedValueOnce(new Error("navigation failed"));
+
+      await expect(
+        runCashFlowHistoryPhase(
+          {} as never,
+          {} as never,
+          { isHistoryMode: true },
+          undefined,
+          progress,
+        ),
+      ).rejects.toThrow("navigation failed");
+
+      expect(progress.getState().timeline).toEqual([
+        expect.objectContaining({
+          step: "cash_flow_history",
+          status: "failed",
+          metadata: expect.objectContaining({
+            kind: "month",
+            month: expect.stringMatching(/^\d{4}-\d{2}$/),
+          }),
+        }),
+      ]);
+      expect(scrapeCashFlowHistory).not.toHaveBeenCalled();
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("表示月と抽出月が異なっても開始済み month step を完了する", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-history-month-key-"));
+    try {
+      const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
+        id: "run-a",
+        source: "test",
+        startedAt: "2026-07-01T00:00:00.000Z",
+      });
+      const monthData = cashFlow("2026-05", "Service A");
+      vi.mocked(buildAccountIdMap).mockResolvedValue(new Map());
+      vi.mocked(hasTransactionsForMonth).mockResolvedValue(true);
+      vi.mocked(scrapeCashFlowHistory).mockImplementation(async (_page, _months, callbacks) => {
+        await callbacks?.onMonthStart?.("2026-06");
+        return [{ month: "2026-05", progressMonth: "2026-06", data: monthData }];
+      });
+      vi.mocked(saveTransactionsForMonth).mockResolvedValue(1);
+
+      await runCashFlowHistoryPhase(
+        {} as never,
+        {} as never,
+        { isHistoryMode: true },
+        undefined,
+        progress,
+      );
+
+      expect(progress.getState().timeline).toEqual([
+        expect.objectContaining({
+          status: "done",
+          metadata: { kind: "month", month: "2026-06" },
+        }),
+      ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("後続月の取得失敗時に未保存の月 step をすべて failed にする", async () => {
     const page = {};
     const db = {};

--- a/apps/crawler/src/crawler-phases.test.ts
+++ b/apps/crawler/src/crawler-phases.test.ts
@@ -250,6 +250,47 @@ describe("runSavePhase", () => {
 });
 
 describe("runCashFlowHistoryPhase", () => {
+  test("履歴月の保存失敗を対象月の failed step にする", async () => {
+    const page = {};
+    const db = {};
+    const monthData = cashFlow("2026-06", "Service A");
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-history-failure-"));
+    try {
+      const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
+        id: "run-a",
+        source: "test",
+        startedAt: "2026-07-01T00:00:00.000Z",
+      });
+      vi.mocked(buildAccountIdMap).mockResolvedValue(new Map());
+      vi.mocked(hasTransactionsForMonth).mockResolvedValue(true);
+      vi.mocked(scrapeCashFlowHistory).mockImplementation(async (_page, _months, callbacks) => {
+        await callbacks?.onMonthStart?.("2026-06");
+        return [{ month: "2026-06", data: monthData }];
+      });
+      vi.mocked(saveTransactionsForMonth).mockRejectedValue(new Error("database unavailable"));
+
+      await expect(
+        runCashFlowHistoryPhase(
+          db as Parameters<typeof runCashFlowHistoryPhase>[0],
+          page as Parameters<typeof runCashFlowHistoryPhase>[1],
+          { isHistoryMode: true },
+          undefined,
+          progress,
+        ),
+      ).rejects.toThrow("database unavailable");
+
+      expect(progress.getState().timeline).toEqual([
+        expect.objectContaining({
+          step: "cash_flow_history",
+          status: "failed",
+          metadata: { kind: "month", month: "2026-06" },
+        }),
+      ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("history mode の各対象月を YYYY-MM metadata として記録する", async () => {
     const page = {};
     const db = {};

--- a/apps/crawler/src/crawler-phases.ts
+++ b/apps/crawler/src/crawler-phases.ts
@@ -294,9 +294,13 @@ export async function runCashFlowHistoryPhase(
 
   info(`Fetching ${monthsToFetch} months`);
 
-  await switchGroup(page, NO_GROUP_ID);
-
   const monthSteps = new Map<string, string>();
+  const setupMonth = getHistoryMonth(now, 0);
+  let setupStepId: string | null = null;
+  if (progress) {
+    setupStepId = await progress.startStep(CRAWLER_STEPS.monthlyCashFlow, { month: setupMonth });
+    monthSteps.set(setupMonth, setupStepId);
+  }
   async function failRunningMonthSteps(failure: unknown): Promise<void> {
     if (!progress) return;
 
@@ -314,11 +318,22 @@ export async function runCashFlowHistoryPhase(
   }
 
   try {
+    await switchGroup(page, NO_GROUP_ID);
     const historyResults = await scrapeCashFlowHistory(page, monthsToFetch, {
       onMonthStart: async (month) => {
-        if (progress) {
-          monthSteps.set(month, await progress.startStep(CRAWLER_STEPS.monthlyCashFlow, { month }));
+        if (!progress) return;
+        if (monthSteps.has(month)) {
+          setupStepId = null;
+          return;
         }
+        if (setupStepId) {
+          monthSteps.delete(setupMonth);
+          monthSteps.set(month, setupStepId);
+          await progress.updateWaiting(setupStepId, "対象月のデータ取得を待機", { month });
+          setupStepId = null;
+          return;
+        }
+        monthSteps.set(month, await progress.startStep(CRAWLER_STEPS.monthlyCashFlow, { month }));
       },
       onMonthFailure: async (month, failure) => {
         const stepId = monthSteps.get(month);
@@ -331,10 +346,12 @@ export async function runCashFlowHistoryPhase(
       },
     });
 
-    for (const { month, data: monthData } of historyResults) {
-      let stepId = monthSteps.get(month);
+    for (const { month, progressMonth = month, data: monthData } of historyResults) {
+      let stepId = monthSteps.get(progressMonth);
       if (progress && !stepId) {
-        stepId = await progress.startStep(CRAWLER_STEPS.monthlyCashFlow, { month });
+        stepId = await progress.startStep(CRAWLER_STEPS.monthlyCashFlow, {
+          month: progressMonth,
+        });
       }
       const categorizedMonthData = categoryDecision.config
         ? await categorizeCashFlowMonth({

--- a/apps/crawler/src/crawler-phases.ts
+++ b/apps/crawler/src/crawler-phases.ts
@@ -21,6 +21,11 @@ import type {
   NormalizedCategoryDecisionConfig,
 } from "./category-decision/types.js";
 import { buildCleanupGroupIds } from "./cleanup-groups.js";
+import {
+  CRAWLER_STEPS,
+  normalizeCrawlerError,
+  type CrawlerProgressReporter,
+} from "./crawler-progress.js";
 import { buildScrapedData, buildGroupOnlyScrapedData } from "./data-builder.js";
 import { getHistoryMaxMonths, getHistoryMonth } from "./history-months.js";
 import { runHooks } from "./hooks/runner.js";
@@ -168,9 +173,10 @@ export async function runAuthPhase(page: Page, context: BrowserContext): Promise
 export async function runScrapePhase(
   page: Page,
   config: Pick<CrawlerConfig, "skipRefresh">,
+  progress: CrawlerProgressReporter,
 ): Promise<ScrapeResult> {
   phase("Scrape");
-  const scrapeResult = await scrapeAllGroups(page, {
+  const scrapeResult = await scrapeAllGroups(page, progress, {
     skipRefresh: config.skipRefresh,
   });
 
@@ -265,6 +271,7 @@ export async function runCashFlowHistoryPhase(
   page: Page,
   config: Pick<CrawlerConfig, "isHistoryMode">,
   categoryDecision: CategoryDecisionRuntime = { config: null, usage: { llmCallsUsed: 0 } },
+  progress?: CrawlerProgressReporter,
 ): Promise<void> {
   phase("Cash Flow History");
 
@@ -289,7 +296,24 @@ export async function runCashFlowHistoryPhase(
 
   await switchGroup(page, NO_GROUP_ID);
 
-  const historyResults = await scrapeCashFlowHistory(page, monthsToFetch);
+  const monthSteps = new Map<string, string>();
+  const historyResults = await scrapeCashFlowHistory(page, monthsToFetch, {
+    onMonthStart: async (month) => {
+      if (progress) {
+        monthSteps.set(month, await progress.startStep(CRAWLER_STEPS.monthlyCashFlow, { month }));
+      }
+    },
+    onMonthComplete: async (month) => {
+      const stepId = monthSteps.get(month);
+      if (progress && stepId) await progress.completeStep(stepId);
+    },
+    onMonthFailure: async (month, failure) => {
+      const stepId = monthSteps.get(month);
+      if (progress && stepId) {
+        await progress.failStep(stepId, normalizeCrawlerError(failure, "monthly_cash_flow_failed"));
+      }
+    },
+  });
 
   for (const { month, data: monthData } of historyResults) {
     const categorizedMonthData = categoryDecision.config
@@ -337,13 +361,15 @@ export async function runAnalyticsPhase(db: Db, groupDataList: GroupData[]): Pro
 export async function runNotificationPhase(
   groupDataList: GroupData[],
   defaultGroup: ScrapeResult["defaultGroup"],
-): Promise<void> {
+): Promise<Error | null> {
   phase("Notification");
 
   try {
     await sendSuccessNotifications(groupDataList, defaultGroup);
+    return null;
   } catch (err) {
     error("Failed to send notification:", err);
+    return err instanceof Error ? err : new Error(String(err));
   }
 }
 

--- a/apps/crawler/src/crawler-phases.ts
+++ b/apps/crawler/src/crawler-phases.ts
@@ -303,10 +303,6 @@ export async function runCashFlowHistoryPhase(
         monthSteps.set(month, await progress.startStep(CRAWLER_STEPS.monthlyCashFlow, { month }));
       }
     },
-    onMonthComplete: async (month) => {
-      const stepId = monthSteps.get(month);
-      if (progress && stepId) await progress.completeStep(stepId);
-    },
     onMonthFailure: async (month, failure) => {
       const stepId = monthSteps.get(month);
       if (progress && stepId) {
@@ -316,22 +312,34 @@ export async function runCashFlowHistoryPhase(
   });
 
   for (const { month, data: monthData } of historyResults) {
-    const categorizedMonthData = categoryDecision.config
-      ? await categorizeCashFlowMonth({
-          page,
-          db,
-          cashFlow: monthData,
-          config: categoryDecision.config,
-          usage: categoryDecision.usage,
-        })
-      : monthData;
-    const savedCount = await saveTransactionsForMonth(
-      db,
-      month,
-      categorizedMonthData.items,
-      accountIdMap,
-    );
-    log(`  ${month}: saved ${savedCount} transactions`);
+    let stepId = monthSteps.get(month);
+    if (progress && !stepId) {
+      stepId = await progress.startStep(CRAWLER_STEPS.monthlyCashFlow, { month });
+    }
+    try {
+      const categorizedMonthData = categoryDecision.config
+        ? await categorizeCashFlowMonth({
+            page,
+            db,
+            cashFlow: monthData,
+            config: categoryDecision.config,
+            usage: categoryDecision.usage,
+          })
+        : monthData;
+      const savedCount = await saveTransactionsForMonth(
+        db,
+        month,
+        categorizedMonthData.items,
+        accountIdMap,
+      );
+      log(`  ${month}: saved ${savedCount} transactions`);
+      if (progress && stepId) await progress.completeStep(stepId);
+    } catch (failure) {
+      if (progress && stepId) {
+        await progress.failStep(stepId, normalizeCrawlerError(failure, "monthly_cash_flow_failed"));
+      }
+      throw failure;
+    }
   }
 }
 

--- a/apps/crawler/src/crawler-phases.ts
+++ b/apps/crawler/src/crawler-phases.ts
@@ -297,26 +297,45 @@ export async function runCashFlowHistoryPhase(
   await switchGroup(page, NO_GROUP_ID);
 
   const monthSteps = new Map<string, string>();
-  const historyResults = await scrapeCashFlowHistory(page, monthsToFetch, {
-    onMonthStart: async (month) => {
-      if (progress) {
-        monthSteps.set(month, await progress.startStep(CRAWLER_STEPS.monthlyCashFlow, { month }));
-      }
-    },
-    onMonthFailure: async (month, failure) => {
-      const stepId = monthSteps.get(month);
-      if (progress && stepId) {
+  async function failRunningMonthSteps(failure: unknown): Promise<void> {
+    if (!progress) return;
+
+    const runningStepIds = new Set(
+      progress
+        .getState()
+        .timeline.filter(({ status }) => status === "running")
+        .map(({ id }) => id),
+    );
+    for (const stepId of monthSteps.values()) {
+      if (runningStepIds.has(stepId)) {
         await progress.failStep(stepId, normalizeCrawlerError(failure, "monthly_cash_flow_failed"));
       }
-    },
-  });
-
-  for (const { month, data: monthData } of historyResults) {
-    let stepId = monthSteps.get(month);
-    if (progress && !stepId) {
-      stepId = await progress.startStep(CRAWLER_STEPS.monthlyCashFlow, { month });
     }
-    try {
+  }
+
+  try {
+    const historyResults = await scrapeCashFlowHistory(page, monthsToFetch, {
+      onMonthStart: async (month) => {
+        if (progress) {
+          monthSteps.set(month, await progress.startStep(CRAWLER_STEPS.monthlyCashFlow, { month }));
+        }
+      },
+      onMonthFailure: async (month, failure) => {
+        const stepId = monthSteps.get(month);
+        if (progress && stepId) {
+          await progress.failStep(
+            stepId,
+            normalizeCrawlerError(failure, "monthly_cash_flow_failed"),
+          );
+        }
+      },
+    });
+
+    for (const { month, data: monthData } of historyResults) {
+      let stepId = monthSteps.get(month);
+      if (progress && !stepId) {
+        stepId = await progress.startStep(CRAWLER_STEPS.monthlyCashFlow, { month });
+      }
       const categorizedMonthData = categoryDecision.config
         ? await categorizeCashFlowMonth({
             page,
@@ -334,12 +353,10 @@ export async function runCashFlowHistoryPhase(
       );
       log(`  ${month}: saved ${savedCount} transactions`);
       if (progress && stepId) await progress.completeStep(stepId);
-    } catch (failure) {
-      if (progress && stepId) {
-        await progress.failStep(stepId, normalizeCrawlerError(failure, "monthly_cash_flow_failed"));
-      }
-      throw failure;
     }
+  } catch (failure) {
+    await failRunningMonthSteps(failure);
+    throw failure;
   }
 }
 

--- a/apps/crawler/src/crawler-progress.test.ts
+++ b/apps/crawler/src/crawler-progress.test.ts
@@ -21,6 +21,20 @@ describe("crawler progress", () => {
     });
   });
 
+  test.each([
+    ["database_save", "データベース保存がタイムアウトしました"],
+    ["notification_failed", "更新結果の通知がタイムアウトしました"],
+    ["web_cache_refresh_failed", "Webキャッシュ更新がタイムアウトしました"],
+  ])("MoneyForward外の %s timeout に処理名を残す", (fallbackCode, expectedMessage) => {
+    const timeout = new Error("Timeout 5000ms exceeded");
+    timeout.name = "TimeoutError";
+
+    expect(normalizeCrawlerError(timeout, fallbackCode)).toEqual({
+      code: "unknown_error",
+      message: expectedMessage,
+    });
+  });
+
   test("通常終了後も success と finishedAt を latest state に残す", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-progress-success-"));
     const lockPath = path.join(tempDir, "crawler-run.lock");

--- a/apps/crawler/src/crawler-progress.test.ts
+++ b/apps/crawler/src/crawler-progress.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, test } from "vitest";
@@ -35,6 +35,19 @@ describe("crawler progress", () => {
     });
   });
 
+  test("Playwright navigation error を安全な reason に分類する", () => {
+    expect(
+      normalizeCrawlerError(
+        new Error("page.goto: net::ERR_ABORTED at https://example.invalid/?token=secret"),
+        "global_data_failed",
+      ),
+    ).toEqual({
+      code: "navigation_failed",
+      message: "MoneyForward の画面遷移に失敗しました",
+      url: "MoneyForward画面",
+    });
+  });
+
   test("nested step 完了後に外側の running step を current に戻す", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-progress-nested-"));
     try {
@@ -52,6 +65,29 @@ describe("crawler progress", () => {
         timelineItemId: globalStep,
         step: "global_data",
       });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("state write 失敗時に未永続 step を in-memory state へ反映しない", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-progress-write-failure-"));
+    const statePath = path.join(tempDir, "state.json");
+    try {
+      const progress = await createCrawlerProgressReporter(statePath, {
+        id: "run-a",
+        source: "test",
+        startedAt: "2026-07-01T00:00:00.000Z",
+      });
+      await rm(statePath);
+      await mkdir(statePath);
+
+      await expect(progress.startStep(CRAWLER_STEPS.analytics)).rejects.toThrow(/EISDIR|directory/);
+      expect(progress.getState().timeline).toEqual([]);
+
+      await rm(statePath, { recursive: true });
+      await progress.finish("failed");
+      expect(progress.getState().timeline).toEqual([]);
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }

--- a/apps/crawler/src/crawler-progress.test.ts
+++ b/apps/crawler/src/crawler-progress.test.ts
@@ -35,6 +35,28 @@ describe("crawler progress", () => {
     });
   });
 
+  test("nested step 完了後に外側の running step を current に戻す", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-progress-nested-"));
+    try {
+      const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
+        id: "run-a",
+        source: "test",
+        startedAt: "2026-07-01T00:00:00.000Z",
+      });
+      const globalStep = await progress.startStep(CRAWLER_STEPS.globalData);
+      const refreshStep = await progress.startStep(CRAWLER_STEPS.refresh);
+
+      await progress.completeStep(refreshStep);
+
+      expect(progress.getState().current).toMatchObject({
+        timelineItemId: globalStep,
+        step: "global_data",
+      });
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   test("通常終了後も success と finishedAt を latest state に残す", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-progress-success-"));
     const lockPath = path.join(tempDir, "crawler-run.lock");

--- a/apps/crawler/src/crawler-progress.test.ts
+++ b/apps/crawler/src/crawler-progress.test.ts
@@ -28,6 +28,7 @@ describe("crawler progress", () => {
       await runWithCrawlerRunLock(
         "test",
         async (progress) => {
+          expect(progress.getState().progress).toEqual({ completed: 0, total: 10 });
           await runCrawlerStep(progress, CRAWLER_STEPS.analytics, async () => {
             expect(progress.getState().progress).toEqual({ completed: 0, total: 10 });
           });

--- a/apps/crawler/src/crawler-progress.test.ts
+++ b/apps/crawler/src/crawler-progress.test.ts
@@ -1,0 +1,85 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  CRAWLER_STEPS,
+  createCrawlerProgressReporter,
+  runCrawlerStep,
+} from "./crawler-progress.js";
+import { getCrawlerRunState, runWithCrawlerRunLock } from "./crawler-run-lock.js";
+
+describe("crawler progress", () => {
+  test("通常終了後も success と finishedAt を latest state に残す", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-progress-success-"));
+    const lockPath = path.join(tempDir, "crawler-run.lock");
+    try {
+      await runWithCrawlerRunLock(
+        "test",
+        async (progress) => {
+          await runCrawlerStep(progress, CRAWLER_STEPS.analytics, async () => undefined);
+        },
+        { lockPath },
+      );
+
+      const state = await getCrawlerRunState({ lockPath });
+      expect(state).toMatchObject({
+        running: false,
+        runStatus: "success",
+        current: null,
+        waitingFor: null,
+      });
+      expect(state.finishedAt).toEqual(expect.any(String));
+      expect(state.timeline).toEqual([
+        expect.objectContaining({ code: "analytics", status: "success" }),
+      ]);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("認証失敗を authentication step と安全な reason に記録する", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-progress-auth-"));
+    const statePath = path.join(tempDir, "crawler.state");
+    try {
+      const progress = await createCrawlerProgressReporter(statePath, {
+        id: "run-a",
+        pid: 123,
+        source: "test",
+        startedAt: "2026-07-01T00:00:00.000Z",
+      });
+
+      await expect(
+        runCrawlerStep(
+          progress,
+          CRAWLER_STEPS.authentication,
+          async () => {
+            throw new Error("credentials: secret-value");
+          },
+          { failureCode: "auth_failed" },
+        ),
+      ).rejects.toThrow("credentials: secret-value");
+      await progress.finish("failed", progress.getState().reason ?? undefined);
+
+      expect(progress.getState()).toMatchObject({
+        runStatus: "failed",
+        finishedAt: expect.any(String),
+        current: expect.objectContaining({ code: "authentication" }),
+        reason: {
+          code: "auth_failed",
+          message: "処理中にエラーが発生しました",
+        },
+        timeline: [
+          expect.objectContaining({
+            code: "authentication",
+            status: "failed",
+            reason: { code: "auth_failed", message: "処理中にエラーが発生しました" },
+          }),
+        ],
+      });
+      expect(JSON.stringify(progress.getState())).not.toContain("secret-value");
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/crawler/src/crawler-progress.test.ts
+++ b/apps/crawler/src/crawler-progress.test.ts
@@ -31,7 +31,7 @@ describe("crawler progress", () => {
       });
       expect(state.finishedAt).toEqual(expect.any(String));
       expect(state.timeline).toEqual([
-        expect.objectContaining({ code: "analytics", status: "success" }),
+        expect.objectContaining({ step: "analytics", status: "done" }),
       ]);
     } finally {
       await rm(tempDir, { recursive: true, force: true });
@@ -44,7 +44,6 @@ describe("crawler progress", () => {
     try {
       const progress = await createCrawlerProgressReporter(statePath, {
         id: "run-a",
-        pid: 123,
         source: "test",
         startedAt: "2026-07-01T00:00:00.000Z",
       });
@@ -64,16 +63,19 @@ describe("crawler progress", () => {
       expect(progress.getState()).toMatchObject({
         runStatus: "failed",
         finishedAt: expect.any(String),
-        current: expect.objectContaining({ code: "authentication" }),
+        current: expect.objectContaining({ step: "authentication" }),
         reason: {
           code: "auth_failed",
-          message: "処理中にエラーが発生しました",
+          message: "MoneyForward の認証に失敗しました",
         },
         timeline: [
           expect.objectContaining({
-            code: "authentication",
+            step: "authentication",
             status: "failed",
-            reason: { code: "auth_failed", message: "処理中にエラーが発生しました" },
+            reason: {
+              code: "auth_failed",
+              message: "MoneyForward の認証に失敗しました",
+            },
           }),
         ],
       });

--- a/apps/crawler/src/crawler-progress.test.ts
+++ b/apps/crawler/src/crawler-progress.test.ts
@@ -5,11 +5,22 @@ import { describe, expect, test } from "vitest";
 import {
   CRAWLER_STEPS,
   createCrawlerProgressReporter,
+  normalizeCrawlerError,
   runCrawlerStep,
 } from "./crawler-progress.js";
 import { getCrawlerRunState, runWithCrawlerRunLock } from "./crawler-run-lock.js";
 
 describe("crawler progress", () => {
+  test("認証中の Playwright timeout を auth_failed に分類する", () => {
+    const timeout = new Error("locator.waitFor: Timeout 30000ms exceeded");
+    timeout.name = "TimeoutError";
+
+    expect(normalizeCrawlerError(timeout, "auth_failed")).toEqual({
+      code: "auth_failed",
+      message: "MoneyForward の認証に失敗しました",
+    });
+  });
+
   test("通常終了後も success と finishedAt を latest state に残す", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-progress-success-"));
     const lockPath = path.join(tempDir, "crawler-run.lock");
@@ -18,6 +29,7 @@ describe("crawler progress", () => {
         "test",
         async (progress) => {
           await runCrawlerStep(progress, CRAWLER_STEPS.analytics, async () => undefined);
+          expect(progress.getState().progress).toBeNull();
         },
         { lockPath },
       );

--- a/apps/crawler/src/crawler-progress.test.ts
+++ b/apps/crawler/src/crawler-progress.test.ts
@@ -28,8 +28,10 @@ describe("crawler progress", () => {
       await runWithCrawlerRunLock(
         "test",
         async (progress) => {
-          await runCrawlerStep(progress, CRAWLER_STEPS.analytics, async () => undefined);
-          expect(progress.getState().progress).toBeNull();
+          await runCrawlerStep(progress, CRAWLER_STEPS.analytics, async () => {
+            expect(progress.getState().progress).toEqual({ completed: 0, total: 10 });
+          });
+          expect(progress.getState().progress).toEqual({ completed: 1, total: 10 });
         },
         { lockPath },
       );

--- a/apps/crawler/src/crawler-progress.ts
+++ b/apps/crawler/src/crawler-progress.ts
@@ -1,67 +1,29 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import path from "node:path";
-
-export const DEFAULT_CRAWLER_STATE_PATH = path.resolve(
-  import.meta.dirname,
-  "../../../data/crawler-run.lock.state",
-);
-
-export type CrawlerRunStatus = "running" | "success" | "failed";
-export type CrawlerStepStatus = "running" | "success" | "warning" | "failed";
-export type CrawlerStepCode =
-  | "authentication"
-  | "refresh"
-  | "global_data"
-  | "group_data"
-  | "monthly_cash_flow"
-  | "database_save"
-  | "institution_categories"
-  | "analytics"
-  | "notification"
-  | "web_cache_refresh";
+import {
+  getCrawlerRunStatePath,
+  writeCrawlerRunState,
+  type CrawlerRunCurrent,
+  type CrawlerRunReason,
+  type CrawlerRunStateSnapshot,
+  type CrawlerRunStepDetails,
+  type CrawlerRunTimelineItem,
+} from "./crawler-run-state.js";
 
 export type CrawlerStepMetadata = Record<string, string | number | string[]>;
-
-export interface CrawlerReason {
-  code: string;
-  message: string;
-}
+export type CrawlerReason = CrawlerRunReason;
 
 export interface CrawlerCurrentStep {
-  code: CrawlerStepCode;
+  code: CrawlerRunStepDetails["step"];
   label: string;
   metadata?: CrawlerStepMetadata;
 }
 
-export interface CrawlerTimelineStep extends CrawlerCurrentStep {
-  id: string;
-  status: CrawlerStepStatus;
-  startedAt: string;
-  finishedAt: string | null;
-  reason?: CrawlerReason;
-}
-
-export interface CrawlerProgressState {
-  runId: string;
-  running: boolean;
-  pid: number;
-  source: string;
-  startedAt: string;
-  finishedAt: string | null;
-  runStatus: CrawlerRunStatus;
-  current: CrawlerCurrentStep | null;
-  waitingFor: string | null;
-  reason: CrawlerReason | null;
-  timeline: CrawlerTimelineStep[];
-}
-
 export const CRAWLER_STEPS = {
   authentication: { code: "authentication", label: "MoneyForward に認証" },
-  refresh: { code: "refresh", label: "金融機関データを一括更新" },
+  refresh: { code: "moneyforward_refresh", label: "金融機関データを一括更新" },
   globalData: { code: "global_data", label: "全体データを取得" },
   groupData: { code: "group_data", label: "グループデータを取得" },
-  monthlyCashFlow: { code: "monthly_cash_flow", label: "月次入出金を取得" },
+  monthlyCashFlow: { code: "cash_flow_history", label: "月次入出金を取得" },
   databaseSave: { code: "database_save", label: "データベースに保存" },
   institutionCategories: {
     code: "institution_categories",
@@ -73,7 +35,7 @@ export const CRAWLER_STEPS = {
 } as const satisfies Record<string, CrawlerCurrentStep>;
 
 export interface CrawlerProgressReporter {
-  getState: () => CrawlerProgressState;
+  getState: () => CrawlerRunStateSnapshot;
   startStep: (step: CrawlerCurrentStep, metadata?: CrawlerStepMetadata) => Promise<string>;
   updateWaiting: (
     stepId: string,
@@ -87,75 +49,110 @@ export interface CrawlerProgressReporter {
     metadata?: CrawlerStepMetadata,
   ) => Promise<void>;
   failStep: (stepId: string, reason: CrawlerReason) => Promise<void>;
-  finish: (status: Exclude<CrawlerRunStatus, "running">, reason?: CrawlerReason) => Promise<void>;
+  finish: (status: "success" | "failed", reason?: CrawlerReason) => Promise<void>;
 }
 
-function mergeMetadata(
-  current: CrawlerStepMetadata | undefined,
-  update: CrawlerStepMetadata | undefined,
-): CrawlerStepMetadata | undefined {
-  if (!current && !update) return undefined;
-  return { ...current, ...update };
-}
-
-async function writeState(statePath: string, state: CrawlerProgressState): Promise<void> {
-  await mkdir(path.dirname(statePath), { recursive: true });
-  const temporaryPath = `${statePath}.${randomUUID()}.tmp`;
-  await writeFile(temporaryPath, JSON.stringify(state));
-  await rename(temporaryPath, statePath);
-}
-
-export async function readCrawlerProgressState(
-  statePath: string,
-): Promise<CrawlerProgressState | null> {
-  try {
-    const parsed = JSON.parse(await readFile(statePath, "utf8")) as Partial<CrawlerProgressState>;
-    if (
-      typeof parsed.runId !== "string" ||
-      typeof parsed.running !== "boolean" ||
-      typeof parsed.pid !== "number" ||
-      typeof parsed.source !== "string" ||
-      typeof parsed.startedAt !== "string" ||
-      !Array.isArray(parsed.timeline)
-    ) {
-      return null;
-    }
-    return parsed as CrawlerProgressState;
-  } catch {
-    return null;
+function toStepDetails(
+  code: CrawlerCurrentStep["code"],
+  metadata: CrawlerStepMetadata = {},
+): CrawlerRunStepDetails {
+  switch (code) {
+    case "moneyforward_refresh":
+      return {
+        step: code,
+        metadata: {
+          kind: "refresh",
+          maxWaitMinutes: Number(metadata.maxWaitMinutes ?? 0),
+          remainingAccounts: Number(metadata.remainingCount ?? 0),
+          incompleteAccounts: Array.isArray(metadata.incompleteAccounts)
+            ? metadata.incompleteAccounts
+            : [],
+        },
+      };
+    case "group_data":
+      return {
+        step: code,
+        metadata: { kind: "group", groupName: String(metadata.groupName ?? "") },
+      };
+    case "cash_flow_history":
+      return {
+        step: code,
+        metadata: { kind: "month", month: String(metadata.month ?? "") },
+      };
+    default:
+      return { step: code, metadata: null };
   }
+}
+
+function toCurrent(item: CrawlerRunTimelineItem): CrawlerRunCurrent {
+  return {
+    timelineItemId: item.id,
+    label: item.label,
+    step: item.step,
+    metadata: item.metadata,
+  } as CrawlerRunCurrent;
+}
+
+function progressFor(timeline: CrawlerRunTimelineItem[]) {
+  return {
+    completed: timeline.filter(({ status }) =>
+      ["done", "warning", "failed", "skipped"].includes(status),
+    ).length,
+    total: timeline.length,
+  };
 }
 
 export async function createCrawlerProgressReporter(
   statePath: string,
-  run: { id: string; pid: number; source: string; startedAt: string },
+  run: { id: string; source: string; startedAt: string },
 ): Promise<CrawlerProgressReporter> {
-  let state: CrawlerProgressState = {
+  let state: CrawlerRunStateSnapshot = {
+    version: 1,
     runId: run.id,
-    running: true,
-    pid: run.pid,
     source: run.source,
     startedAt: run.startedAt,
     finishedAt: null,
     runStatus: "running",
     current: null,
     waitingFor: null,
+    progress: null,
     reason: null,
     timeline: [],
   };
-  await writeState(statePath, state);
+  const options = { statePath: statePath || getCrawlerRunStatePath() };
+  await writeCrawlerRunState(state, options);
 
-  async function update(mutator: (draft: CrawlerProgressState) => void): Promise<void> {
+  async function update(mutator: (draft: CrawlerRunStateSnapshot) => void): Promise<void> {
     const draft = structuredClone(state);
     mutator(draft);
     state = draft;
-    await writeState(statePath, state);
+    await writeCrawlerRunState(state, options);
   }
 
-  function findStep(draft: CrawlerProgressState, stepId: string): CrawlerTimelineStep {
+  function findStep(draft: CrawlerRunStateSnapshot, stepId: string): CrawlerRunTimelineItem {
     const step = draft.timeline.find((candidate) => candidate.id === stepId);
     if (!step) throw new Error(`Unknown crawler progress step: ${stepId}`);
     return step;
+  }
+
+  function updateStepMetadata(
+    item: CrawlerRunTimelineItem,
+    metadata: CrawlerStepMetadata | undefined,
+  ): void {
+    if (!metadata) return;
+    let currentMetadata: CrawlerStepMetadata = {};
+    if (item.metadata?.kind === "refresh") {
+      currentMetadata = {
+        maxWaitMinutes: item.metadata.maxWaitMinutes,
+        remainingCount: item.metadata.remainingAccounts,
+        incompleteAccounts: item.metadata.incompleteAccounts,
+      };
+    } else if (item.metadata?.kind === "group") {
+      currentMetadata = { groupName: item.metadata.groupName };
+    } else if (item.metadata?.kind === "month") {
+      currentMetadata = { month: item.metadata.month };
+    }
+    Object.assign(item, toStepDetails(item.step, { ...currentMetadata, ...metadata }));
   }
 
   return {
@@ -163,70 +160,82 @@ export async function createCrawlerProgressReporter(
     startStep: async (step, metadata) => {
       const id = randomUUID();
       await update((draft) => {
-        const current = { ...step, ...(metadata ? { metadata } : {}) };
-        draft.current = current;
-        draft.waitingFor = null;
-        draft.reason = null;
-        draft.timeline.push({
-          ...current,
+        const item: CrawlerRunTimelineItem = {
           id,
+          label: step.label,
+          ...toStepDetails(step.code, metadata),
           status: "running",
           startedAt: new Date().toISOString(),
           finishedAt: null,
-        });
+          reason: null,
+        };
+        draft.current = toCurrent(item);
+        draft.waitingFor = null;
+        draft.timeline.push(item);
+        draft.progress = progressFor(draft.timeline);
       });
       return id;
     },
     updateWaiting: async (stepId, waitingFor, metadata) => {
       await update((draft) => {
         const step = findStep(draft, stepId);
-        step.metadata = mergeMetadata(step.metadata, metadata);
-        draft.current = { code: step.code, label: step.label, metadata: step.metadata };
+        updateStepMetadata(step, metadata);
+        draft.current = toCurrent(step);
         draft.waitingFor = waitingFor;
+        draft.progress = progressFor(draft.timeline);
       });
     },
     completeStep: async (stepId, metadata) => {
       await update((draft) => {
         const step = findStep(draft, stepId);
-        step.status = "success";
-        step.finishedAt = new Date().toISOString();
-        step.metadata = mergeMetadata(step.metadata, metadata);
+        updateStepMetadata(step, metadata);
+        Object.assign(step, {
+          status: "done",
+          finishedAt: new Date().toISOString(),
+          reason: null,
+        });
         draft.current = null;
         draft.waitingFor = null;
-        draft.reason = null;
+        draft.progress = progressFor(draft.timeline);
       });
     },
     warnStep: async (stepId, reason, metadata) => {
       await update((draft) => {
         const step = findStep(draft, stepId);
-        step.status = "warning";
-        step.finishedAt = new Date().toISOString();
-        step.reason = reason;
-        step.metadata = mergeMetadata(step.metadata, metadata);
+        updateStepMetadata(step, metadata);
+        Object.assign(step, { status: "warning", finishedAt: new Date().toISOString(), reason });
         draft.current = null;
         draft.waitingFor = null;
-        draft.reason = reason;
+        draft.progress = progressFor(draft.timeline);
       });
     },
     failStep: async (stepId, reason) => {
       await update((draft) => {
         const step = findStep(draft, stepId);
-        step.status = "failed";
-        step.finishedAt = new Date().toISOString();
-        step.reason = reason;
-        draft.current = { code: step.code, label: step.label, metadata: step.metadata };
+        Object.assign(step, { status: "failed", finishedAt: new Date().toISOString(), reason });
+        draft.current = toCurrent(step);
         draft.waitingFor = null;
-        draft.reason = reason;
+        draft.progress = progressFor(draft.timeline);
       });
     },
     finish: async (status, reason) => {
       await update((draft) => {
-        draft.running = false;
-        draft.runStatus = status;
-        draft.finishedAt = new Date().toISOString();
-        if (status === "success") draft.current = null;
-        draft.waitingFor = null;
-        if (reason) draft.reason = reason;
+        Object.assign(draft, {
+          runStatus: status,
+          finishedAt: new Date().toISOString(),
+          waitingFor: null,
+          progress: progressFor(draft.timeline),
+        });
+        if (status === "success") {
+          draft.current = null;
+          draft.reason = null;
+        } else {
+          const failedStep = draft.timeline.findLast(
+            ({ status: stepStatus }) => stepStatus === "failed",
+          );
+          draft.reason = reason ??
+            failedStep?.reason ?? { code: "unknown_error", message: "処理に失敗しました" };
+        }
       });
     },
   };
@@ -236,12 +245,25 @@ export function normalizeCrawlerError(error: unknown, fallbackCode: string): Cra
   const name = error instanceof Error ? error.name : "";
   const message = error instanceof Error ? error.message : String(error);
   if (name === "TimeoutError" || /timeout|timed out/i.test(message)) {
-    return { code: "playwright_timeout", message: "画面の応答待ちがタイムアウトしました" };
+    const timeoutMs = Number(message.match(/(\d+)\s*ms/i)?.[1] ?? 0);
+    return {
+      code: "moneyforward_timeout",
+      message: "画面の応答待ちがタイムアウトしました",
+      operation: "MoneyForward画面の応答待ち",
+      timeoutMs,
+    };
   }
   if (/selector|locator|waiting for .* to be|not found|no element/i.test(message)) {
-    return { code: "selector_not_found", message: "必要な画面要素を確認できませんでした" };
+    return {
+      code: "selector_not_found",
+      message: "必要な画面要素を確認できませんでした",
+      selector: "MoneyForward画面の操作対象",
+    };
   }
-  return { code: fallbackCode, message: "処理中にエラーが発生しました" };
+  if (fallbackCode === "auth_failed") {
+    return { code: "auth_failed", message: "MoneyForward の認証に失敗しました" };
+  }
+  return { code: "unknown_error", message: "処理中にエラーが発生しました" };
 }
 
 export async function runCrawlerStep<T>(

--- a/apps/crawler/src/crawler-progress.ts
+++ b/apps/crawler/src/crawler-progress.ts
@@ -1,0 +1,262 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export const DEFAULT_CRAWLER_STATE_PATH = path.resolve(
+  import.meta.dirname,
+  "../../../data/crawler-run.lock.state",
+);
+
+export type CrawlerRunStatus = "running" | "success" | "failed";
+export type CrawlerStepStatus = "running" | "success" | "warning" | "failed";
+export type CrawlerStepCode =
+  | "authentication"
+  | "refresh"
+  | "global_data"
+  | "group_data"
+  | "monthly_cash_flow"
+  | "database_save"
+  | "institution_categories"
+  | "analytics"
+  | "notification"
+  | "web_cache_refresh";
+
+export type CrawlerStepMetadata = Record<string, string | number | string[]>;
+
+export interface CrawlerReason {
+  code: string;
+  message: string;
+}
+
+export interface CrawlerCurrentStep {
+  code: CrawlerStepCode;
+  label: string;
+  metadata?: CrawlerStepMetadata;
+}
+
+export interface CrawlerTimelineStep extends CrawlerCurrentStep {
+  id: string;
+  status: CrawlerStepStatus;
+  startedAt: string;
+  finishedAt: string | null;
+  reason?: CrawlerReason;
+}
+
+export interface CrawlerProgressState {
+  runId: string;
+  running: boolean;
+  pid: number;
+  source: string;
+  startedAt: string;
+  finishedAt: string | null;
+  runStatus: CrawlerRunStatus;
+  current: CrawlerCurrentStep | null;
+  waitingFor: string | null;
+  reason: CrawlerReason | null;
+  timeline: CrawlerTimelineStep[];
+}
+
+export const CRAWLER_STEPS = {
+  authentication: { code: "authentication", label: "MoneyForward に認証" },
+  refresh: { code: "refresh", label: "金融機関データを一括更新" },
+  globalData: { code: "global_data", label: "全体データを取得" },
+  groupData: { code: "group_data", label: "グループデータを取得" },
+  monthlyCashFlow: { code: "monthly_cash_flow", label: "月次入出金を取得" },
+  databaseSave: { code: "database_save", label: "データベースに保存" },
+  institutionCategories: {
+    code: "institution_categories",
+    label: "金融機関カテゴリを更新",
+  },
+  analytics: { code: "analytics", label: "金融データを分析" },
+  notification: { code: "notification", label: "更新結果を通知" },
+  webCacheRefresh: { code: "web_cache_refresh", label: "Web キャッシュを更新" },
+} as const satisfies Record<string, CrawlerCurrentStep>;
+
+export interface CrawlerProgressReporter {
+  getState: () => CrawlerProgressState;
+  startStep: (step: CrawlerCurrentStep, metadata?: CrawlerStepMetadata) => Promise<string>;
+  updateWaiting: (
+    stepId: string,
+    waitingFor: string,
+    metadata?: CrawlerStepMetadata,
+  ) => Promise<void>;
+  completeStep: (stepId: string, metadata?: CrawlerStepMetadata) => Promise<void>;
+  warnStep: (
+    stepId: string,
+    reason: CrawlerReason,
+    metadata?: CrawlerStepMetadata,
+  ) => Promise<void>;
+  failStep: (stepId: string, reason: CrawlerReason) => Promise<void>;
+  finish: (status: Exclude<CrawlerRunStatus, "running">, reason?: CrawlerReason) => Promise<void>;
+}
+
+function mergeMetadata(
+  current: CrawlerStepMetadata | undefined,
+  update: CrawlerStepMetadata | undefined,
+): CrawlerStepMetadata | undefined {
+  if (!current && !update) return undefined;
+  return { ...current, ...update };
+}
+
+async function writeState(statePath: string, state: CrawlerProgressState): Promise<void> {
+  await mkdir(path.dirname(statePath), { recursive: true });
+  const temporaryPath = `${statePath}.${randomUUID()}.tmp`;
+  await writeFile(temporaryPath, JSON.stringify(state));
+  await rename(temporaryPath, statePath);
+}
+
+export async function readCrawlerProgressState(
+  statePath: string,
+): Promise<CrawlerProgressState | null> {
+  try {
+    const parsed = JSON.parse(await readFile(statePath, "utf8")) as Partial<CrawlerProgressState>;
+    if (
+      typeof parsed.runId !== "string" ||
+      typeof parsed.running !== "boolean" ||
+      typeof parsed.pid !== "number" ||
+      typeof parsed.source !== "string" ||
+      typeof parsed.startedAt !== "string" ||
+      !Array.isArray(parsed.timeline)
+    ) {
+      return null;
+    }
+    return parsed as CrawlerProgressState;
+  } catch {
+    return null;
+  }
+}
+
+export async function createCrawlerProgressReporter(
+  statePath: string,
+  run: { id: string; pid: number; source: string; startedAt: string },
+): Promise<CrawlerProgressReporter> {
+  let state: CrawlerProgressState = {
+    runId: run.id,
+    running: true,
+    pid: run.pid,
+    source: run.source,
+    startedAt: run.startedAt,
+    finishedAt: null,
+    runStatus: "running",
+    current: null,
+    waitingFor: null,
+    reason: null,
+    timeline: [],
+  };
+  await writeState(statePath, state);
+
+  async function update(mutator: (draft: CrawlerProgressState) => void): Promise<void> {
+    const draft = structuredClone(state);
+    mutator(draft);
+    state = draft;
+    await writeState(statePath, state);
+  }
+
+  function findStep(draft: CrawlerProgressState, stepId: string): CrawlerTimelineStep {
+    const step = draft.timeline.find((candidate) => candidate.id === stepId);
+    if (!step) throw new Error(`Unknown crawler progress step: ${stepId}`);
+    return step;
+  }
+
+  return {
+    getState: () => structuredClone(state),
+    startStep: async (step, metadata) => {
+      const id = randomUUID();
+      await update((draft) => {
+        const current = { ...step, ...(metadata ? { metadata } : {}) };
+        draft.current = current;
+        draft.waitingFor = null;
+        draft.reason = null;
+        draft.timeline.push({
+          ...current,
+          id,
+          status: "running",
+          startedAt: new Date().toISOString(),
+          finishedAt: null,
+        });
+      });
+      return id;
+    },
+    updateWaiting: async (stepId, waitingFor, metadata) => {
+      await update((draft) => {
+        const step = findStep(draft, stepId);
+        step.metadata = mergeMetadata(step.metadata, metadata);
+        draft.current = { code: step.code, label: step.label, metadata: step.metadata };
+        draft.waitingFor = waitingFor;
+      });
+    },
+    completeStep: async (stepId, metadata) => {
+      await update((draft) => {
+        const step = findStep(draft, stepId);
+        step.status = "success";
+        step.finishedAt = new Date().toISOString();
+        step.metadata = mergeMetadata(step.metadata, metadata);
+        draft.current = null;
+        draft.waitingFor = null;
+        draft.reason = null;
+      });
+    },
+    warnStep: async (stepId, reason, metadata) => {
+      await update((draft) => {
+        const step = findStep(draft, stepId);
+        step.status = "warning";
+        step.finishedAt = new Date().toISOString();
+        step.reason = reason;
+        step.metadata = mergeMetadata(step.metadata, metadata);
+        draft.current = null;
+        draft.waitingFor = null;
+        draft.reason = reason;
+      });
+    },
+    failStep: async (stepId, reason) => {
+      await update((draft) => {
+        const step = findStep(draft, stepId);
+        step.status = "failed";
+        step.finishedAt = new Date().toISOString();
+        step.reason = reason;
+        draft.current = { code: step.code, label: step.label, metadata: step.metadata };
+        draft.waitingFor = null;
+        draft.reason = reason;
+      });
+    },
+    finish: async (status, reason) => {
+      await update((draft) => {
+        draft.running = false;
+        draft.runStatus = status;
+        draft.finishedAt = new Date().toISOString();
+        if (status === "success") draft.current = null;
+        draft.waitingFor = null;
+        if (reason) draft.reason = reason;
+      });
+    },
+  };
+}
+
+export function normalizeCrawlerError(error: unknown, fallbackCode: string): CrawlerReason {
+  const name = error instanceof Error ? error.name : "";
+  const message = error instanceof Error ? error.message : String(error);
+  if (name === "TimeoutError" || /timeout|timed out/i.test(message)) {
+    return { code: "playwright_timeout", message: "画面の応答待ちがタイムアウトしました" };
+  }
+  if (/selector|locator|waiting for .* to be|not found|no element/i.test(message)) {
+    return { code: "selector_not_found", message: "必要な画面要素を確認できませんでした" };
+  }
+  return { code: fallbackCode, message: "処理中にエラーが発生しました" };
+}
+
+export async function runCrawlerStep<T>(
+  reporter: CrawlerProgressReporter,
+  step: CrawlerCurrentStep,
+  task: () => Promise<T>,
+  options: { metadata?: CrawlerStepMetadata; failureCode?: string } = {},
+): Promise<T> {
+  const stepId = await reporter.startStep(step, options.metadata);
+  try {
+    const result = await task();
+    await reporter.completeStep(stepId);
+    return result;
+  } catch (error) {
+    await reporter.failStep(stepId, normalizeCrawlerError(error, options.failureCode ?? step.code));
+    throw error;
+  }
+}

--- a/apps/crawler/src/crawler-progress.ts
+++ b/apps/crawler/src/crawler-progress.ts
@@ -43,6 +43,7 @@ export interface CrawlerProgressReporter {
     metadata?: CrawlerStepMetadata,
   ) => Promise<void>;
   completeStep: (stepId: string, metadata?: CrawlerStepMetadata) => Promise<void>;
+  skipStep: (stepId: string) => Promise<void>;
   warnStep: (
     stepId: string,
     reason: CrawlerReason,
@@ -172,7 +173,7 @@ export async function createCrawlerProgressReporter(
         draft.current = toCurrent(item);
         draft.waitingFor = null;
         draft.timeline.push(item);
-        draft.progress = progressFor(draft.timeline);
+        draft.progress = null;
       });
       return id;
     },
@@ -182,7 +183,7 @@ export async function createCrawlerProgressReporter(
         updateStepMetadata(step, metadata);
         draft.current = toCurrent(step);
         draft.waitingFor = waitingFor;
-        draft.progress = progressFor(draft.timeline);
+        draft.progress = null;
       });
     },
     completeStep: async (stepId, metadata) => {
@@ -196,7 +197,21 @@ export async function createCrawlerProgressReporter(
         });
         draft.current = null;
         draft.waitingFor = null;
-        draft.progress = progressFor(draft.timeline);
+        draft.progress = null;
+      });
+    },
+    skipStep: async (stepId) => {
+      await update((draft) => {
+        const step = findStep(draft, stepId);
+        Object.assign(step, {
+          status: "skipped",
+          startedAt: null,
+          finishedAt: new Date().toISOString(),
+          reason: null,
+        });
+        draft.current = null;
+        draft.waitingFor = null;
+        draft.progress = null;
       });
     },
     warnStep: async (stepId, reason, metadata) => {
@@ -206,7 +221,7 @@ export async function createCrawlerProgressReporter(
         Object.assign(step, { status: "warning", finishedAt: new Date().toISOString(), reason });
         draft.current = null;
         draft.waitingFor = null;
-        draft.progress = progressFor(draft.timeline);
+        draft.progress = null;
       });
     },
     failStep: async (stepId, reason) => {
@@ -215,7 +230,7 @@ export async function createCrawlerProgressReporter(
         Object.assign(step, { status: "failed", finishedAt: new Date().toISOString(), reason });
         draft.current = toCurrent(step);
         draft.waitingFor = null;
-        draft.progress = progressFor(draft.timeline);
+        draft.progress = null;
       });
     },
     finish: async (status, reason) => {
@@ -244,6 +259,9 @@ export async function createCrawlerProgressReporter(
 export function normalizeCrawlerError(error: unknown, fallbackCode: string): CrawlerReason {
   const name = error instanceof Error ? error.name : "";
   const message = error instanceof Error ? error.message : String(error);
+  if (fallbackCode === "auth_failed") {
+    return { code: "auth_failed", message: "MoneyForward の認証に失敗しました" };
+  }
   if (name === "TimeoutError" || /timeout|timed out/i.test(message)) {
     const timeoutMs = Number(message.match(/(\d+)\s*ms/i)?.[1] ?? 0);
     return {
@@ -259,9 +277,6 @@ export function normalizeCrawlerError(error: unknown, fallbackCode: string): Cra
       message: "必要な画面要素を確認できませんでした",
       selector: "MoneyForward画面の操作対象",
     };
-  }
-  if (fallbackCode === "auth_failed") {
-    return { code: "auth_failed", message: "MoneyForward の認証に失敗しました" };
   }
   return { code: "unknown_error", message: "処理中にエラーが発生しました" };
 }

--- a/apps/crawler/src/crawler-progress.ts
+++ b/apps/crawler/src/crawler-progress.ts
@@ -165,6 +165,12 @@ export async function createCrawlerProgressReporter(
     Object.assign(item, toStepDetails(item.step, { ...currentMetadata, ...metadata }));
   }
 
+  function restoreRunningCurrent(draft: CrawlerRunStateSnapshot): void {
+    const runningStep = draft.timeline.findLast(({ status }) => status === "running");
+    draft.current = runningStep ? toCurrent(runningStep) : null;
+    draft.waitingFor = null;
+  }
+
   return {
     getState: () => structuredClone(state),
     startStep: async (step, metadata) => {
@@ -204,8 +210,7 @@ export async function createCrawlerProgressReporter(
           finishedAt: new Date().toISOString(),
           reason: null,
         });
-        draft.current = null;
-        draft.waitingFor = null;
+        restoreRunningCurrent(draft);
         draft.progress = runningProgressFor(draft.timeline);
       });
     },
@@ -218,8 +223,7 @@ export async function createCrawlerProgressReporter(
           finishedAt: new Date().toISOString(),
           reason: null,
         });
-        draft.current = null;
-        draft.waitingFor = null;
+        restoreRunningCurrent(draft);
         draft.progress = runningProgressFor(draft.timeline);
       });
     },
@@ -228,8 +232,7 @@ export async function createCrawlerProgressReporter(
         const step = findStep(draft, stepId);
         updateStepMetadata(step, metadata);
         Object.assign(step, { status: "warning", finishedAt: new Date().toISOString(), reason });
-        draft.current = null;
-        draft.waitingFor = null;
+        restoreRunningCurrent(draft);
         draft.progress = runningProgressFor(draft.timeline);
       });
     },

--- a/apps/crawler/src/crawler-progress.ts
+++ b/apps/crawler/src/crawler-progress.ts
@@ -11,6 +11,7 @@ import {
 
 export type CrawlerStepMetadata = Record<string, string | number | string[]>;
 export type CrawlerReason = CrawlerRunReason;
+const BASELINE_STEP_COUNT = 10;
 
 export interface CrawlerCurrentStep {
   code: CrawlerRunStepDetails["step"];
@@ -103,6 +104,14 @@ function progressFor(timeline: CrawlerRunTimelineItem[]) {
   };
 }
 
+function runningProgressFor(timeline: CrawlerRunTimelineItem[]) {
+  const { completed } = progressFor(timeline);
+  return {
+    completed,
+    total: Math.max(BASELINE_STEP_COUNT, timeline.length, completed + 1),
+  };
+}
+
 export async function createCrawlerProgressReporter(
   statePath: string,
   run: { id: string; source: string; startedAt: string },
@@ -173,7 +182,7 @@ export async function createCrawlerProgressReporter(
         draft.current = toCurrent(item);
         draft.waitingFor = null;
         draft.timeline.push(item);
-        draft.progress = null;
+        draft.progress = runningProgressFor(draft.timeline);
       });
       return id;
     },
@@ -183,7 +192,7 @@ export async function createCrawlerProgressReporter(
         updateStepMetadata(step, metadata);
         draft.current = toCurrent(step);
         draft.waitingFor = waitingFor;
-        draft.progress = null;
+        draft.progress = runningProgressFor(draft.timeline);
       });
     },
     completeStep: async (stepId, metadata) => {
@@ -197,7 +206,7 @@ export async function createCrawlerProgressReporter(
         });
         draft.current = null;
         draft.waitingFor = null;
-        draft.progress = null;
+        draft.progress = runningProgressFor(draft.timeline);
       });
     },
     skipStep: async (stepId) => {
@@ -211,7 +220,7 @@ export async function createCrawlerProgressReporter(
         });
         draft.current = null;
         draft.waitingFor = null;
-        draft.progress = null;
+        draft.progress = runningProgressFor(draft.timeline);
       });
     },
     warnStep: async (stepId, reason, metadata) => {
@@ -221,7 +230,7 @@ export async function createCrawlerProgressReporter(
         Object.assign(step, { status: "warning", finishedAt: new Date().toISOString(), reason });
         draft.current = null;
         draft.waitingFor = null;
-        draft.progress = null;
+        draft.progress = runningProgressFor(draft.timeline);
       });
     },
     failStep: async (stepId, reason) => {
@@ -230,7 +239,7 @@ export async function createCrawlerProgressReporter(
         Object.assign(step, { status: "failed", finishedAt: new Date().toISOString(), reason });
         draft.current = toCurrent(step);
         draft.waitingFor = null;
-        draft.progress = null;
+        draft.progress = runningProgressFor(draft.timeline);
       });
     },
     finish: async (status, reason) => {

--- a/apps/crawler/src/crawler-progress.ts
+++ b/apps/crawler/src/crawler-progress.ts
@@ -273,6 +273,15 @@ export function normalizeCrawlerError(error: unknown, fallbackCode: string): Cra
   }
   if (name === "TimeoutError" || /timeout|timed out/i.test(message)) {
     const timeoutMs = Number(message.match(/(\d+)\s*ms/i)?.[1] ?? 0);
+    const operationLabels: Record<string, string> = {
+      database_save: "データベース保存",
+      notification_failed: "更新結果の通知",
+      web_cache_refresh_failed: "Webキャッシュ更新",
+    };
+    const operationLabel = operationLabels[fallbackCode];
+    if (operationLabel) {
+      return { code: "unknown_error", message: `${operationLabel}がタイムアウトしました` };
+    }
     return {
       code: "moneyforward_timeout",
       message: "画面の応答待ちがタイムアウトしました",

--- a/apps/crawler/src/crawler-progress.ts
+++ b/apps/crawler/src/crawler-progress.ts
@@ -135,8 +135,8 @@ export async function createCrawlerProgressReporter(
   async function update(mutator: (draft: CrawlerRunStateSnapshot) => void): Promise<void> {
     const draft = structuredClone(state);
     mutator(draft);
+    await writeCrawlerRunState(draft, options);
     state = draft;
-    await writeCrawlerRunState(state, options);
   }
 
   function findStep(draft: CrawlerRunStateSnapshot, stepId: string): CrawlerRunTimelineItem {
@@ -290,6 +290,13 @@ export function normalizeCrawlerError(error: unknown, fallbackCode: string): Cra
       message: "画面の応答待ちがタイムアウトしました",
       operation: "MoneyForward画面の応答待ち",
       timeoutMs,
+    };
+  }
+  if (/net::ERR_|page\.goto|navigation/i.test(message)) {
+    return {
+      code: "navigation_failed",
+      message: "MoneyForward の画面遷移に失敗しました",
+      url: "MoneyForward画面",
     };
   }
   if (/selector|locator|waiting for .* to be|not found|no element/i.test(message)) {

--- a/apps/crawler/src/crawler-progress.ts
+++ b/apps/crawler/src/crawler-progress.ts
@@ -125,7 +125,7 @@ export async function createCrawlerProgressReporter(
     runStatus: "running",
     current: null,
     waitingFor: null,
-    progress: null,
+    progress: runningProgressFor([]),
     reason: null,
     timeline: [],
   };

--- a/apps/crawler/src/crawler-run-lock.test.ts
+++ b/apps/crawler/src/crawler-run-lock.test.ts
@@ -70,6 +70,42 @@ describe("crawler run lock", () => {
     });
   });
 
+  test("preserves a run that finishes while checking an absent lock", async () => {
+    const statePath = `${lockPath}.state`;
+    const runningState = {
+      version: 1 as const,
+      runId: "run-a",
+      source: "scheduled",
+      startedAt: "2026-07-01T00:00:00.000Z",
+      finishedAt: null,
+      runStatus: "running" as const,
+      current: null,
+      waitingFor: "処理の完了を待機",
+      progress: null,
+      reason: null,
+      timeline: [],
+    };
+    await writeCrawlerRunState(runningState, { statePath });
+
+    const finishedState = {
+      ...runningState,
+      finishedAt: "2026-07-01T00:01:00.000Z",
+      runStatus: "success" as const,
+      waitingFor: null,
+      progress: { completed: 0, total: 0 },
+    };
+    const state = await getCrawlerRunState({
+      afterLockMutationGuardAcquired: async () => {
+        await writeCrawlerRunState(finishedState, { statePath });
+      },
+      lockPath,
+      statePath,
+    });
+
+    expect(state).toEqual({ ...finishedState, running: false, pid: null });
+    await expect(readCrawlerRunState({ statePath })).resolves.toEqual(finishedState);
+  });
+
   test("returns idle state when no lock exists", async () => {
     await expect(getCrawlerRunState({ lockPath })).resolves.toEqual({
       running: false,

--- a/apps/crawler/src/crawler-run-lock.test.ts
+++ b/apps/crawler/src/crawler-run-lock.test.ts
@@ -7,7 +7,9 @@ import {
   acquireCrawlerRunLock,
   CrawlerAlreadyRunningError,
   getCrawlerRunState,
+  runWithCrawlerRunLock,
 } from "./crawler-run-lock.js";
+import { readCrawlerRunState, writeCrawlerRunState } from "./crawler-run-state.js";
 
 let tempDir: string;
 let lockPath: string;
@@ -22,6 +24,52 @@ afterEach(async () => {
 });
 
 describe("crawler run lock", () => {
+  test("releases the lock when progress reporter initialization fails", async () => {
+    await expect(
+      runWithCrawlerRunLock("manual", async () => undefined, {
+        lockPath,
+        statePath: tempDir,
+      }),
+    ).rejects.toThrow(/EISDIR|directory/);
+
+    const lock = await acquireCrawlerRunLock("manual", { lockPath });
+    await lock.release();
+  });
+
+  test("marks an orphaned running state as failed when no lock exists", async () => {
+    const statePath = `${lockPath}.state`;
+    await writeCrawlerRunState(
+      {
+        version: 1,
+        runId: "run-a",
+        source: "scheduled",
+        startedAt: "2026-07-01T00:00:00.000Z",
+        finishedAt: null,
+        runStatus: "running",
+        current: null,
+        waitingFor: "処理の完了を待機",
+        progress: null,
+        reason: null,
+        timeline: [],
+      },
+      { statePath },
+    );
+
+    await expect(getCrawlerRunState({ lockPath })).resolves.toMatchObject({
+      running: false,
+      runStatus: "failed",
+      finishedAt: expect.any(String),
+      reason: {
+        code: "unknown_error",
+        message: "前回の実行は完了を確認できませんでした",
+      },
+    });
+    await expect(readCrawlerRunState({ statePath })).resolves.toMatchObject({
+      runStatus: "failed",
+      finishedAt: expect.any(String),
+    });
+  });
+
   test("returns idle state when no lock exists", async () => {
     await expect(getCrawlerRunState({ lockPath })).resolves.toEqual({
       running: false,

--- a/apps/crawler/src/crawler-run-lock.test.ts
+++ b/apps/crawler/src/crawler-run-lock.test.ts
@@ -150,6 +150,57 @@ describe("crawler run lock", () => {
     });
   });
 
+  test("finalizes an absent-lock state before allowing a new run to acquire the lock", async () => {
+    const statePath = `${lockPath}.state`;
+    await writeCrawlerRunState(
+      {
+        version: 1,
+        runId: "old-run",
+        source: "scheduled",
+        startedAt: "2026-07-01T00:00:00.000Z",
+        finishedAt: null,
+        runStatus: "running",
+        current: null,
+        waitingFor: null,
+        progress: { completed: 0, total: 10 },
+        reason: null,
+        timeline: [],
+      },
+      { statePath },
+    );
+
+    let acquisition: ReturnType<typeof acquireCrawlerRunLock> | undefined;
+    let markBlocked!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      markBlocked = resolve;
+    });
+    const status = getCrawlerRunState({
+      afterLockMutationGuardAcquired: async () => {
+        acquisition = acquireCrawlerRunLock("manual", {
+          afterLockMutationGuardBlocked: async () => markBlocked(),
+          lockPath,
+          statePath,
+        });
+        await blocked;
+      },
+      lockPath,
+      statePath,
+    });
+
+    await blocked;
+    if (!acquisition) throw new Error("Expected the competing lock acquisition to start");
+    await expect(
+      Promise.race([
+        status.then(() => "status" as const),
+        acquisition.then(() => "acquired" as const),
+      ]),
+    ).resolves.toBe("status");
+    await expect(status).resolves.toMatchObject({ running: false, runStatus: "failed" });
+
+    const newLock = await acquisition;
+    await newLock.release();
+  });
+
   test("returns idle state when no lock exists", async () => {
     await expect(getCrawlerRunState({ lockPath })).resolves.toEqual({
       running: false,
@@ -662,8 +713,7 @@ describe("crawler run lock", () => {
     await acquisitionBlocked;
     finishCleanup();
 
-    await expect(statePromise).resolves.toEqual({
-      running: false,
+    await expect(statePromise).resolves.toMatchObject({
       pid: null,
       source: null,
       startedAt: null,

--- a/apps/crawler/src/crawler-run-lock.test.ts
+++ b/apps/crawler/src/crawler-run-lock.test.ts
@@ -106,6 +106,50 @@ describe("crawler run lock", () => {
     await expect(readCrawlerRunState({ statePath })).resolves.toEqual(finishedState);
   });
 
+  test("does not finalize a new run while reconciling an absent lock", async () => {
+    const statePath = `${lockPath}.state`;
+    await writeCrawlerRunState(
+      {
+        version: 1,
+        runId: "orphaned-run",
+        source: "scheduled",
+        startedAt: "2026-07-01T00:00:00.000Z",
+        finishedAt: null,
+        runStatus: "running",
+        current: null,
+        waitingFor: null,
+        progress: null,
+        reason: null,
+        timeline: [],
+      },
+      { statePath },
+    );
+
+    let newRunPromise!: ReturnType<typeof runWithCrawlerRunLock>;
+    let newRunSettled = false;
+    const state = await getCrawlerRunState({
+      afterLockMutationGuardAcquired: async () => {
+        newRunPromise = runWithCrawlerRunLock("manual", async () => undefined, {
+          lockPath,
+          statePath,
+        });
+        void newRunPromise.finally(() => {
+          newRunSettled = true;
+        });
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(newRunSettled).toBe(false);
+      },
+      lockPath,
+      statePath,
+    });
+
+    expect(state).toMatchObject({ runId: "orphaned-run", runStatus: "failed" });
+    await newRunPromise;
+    await expect(readCrawlerRunState({ statePath })).resolves.toMatchObject({
+      runStatus: "success",
+    });
+  });
+
   test("returns idle state when no lock exists", async () => {
     await expect(getCrawlerRunState({ lockPath })).resolves.toEqual({
       running: false,

--- a/apps/crawler/src/crawler-run-lock.test.ts
+++ b/apps/crawler/src/crawler-run-lock.test.ts
@@ -714,6 +714,7 @@ describe("crawler run lock", () => {
     finishCleanup();
 
     await expect(statePromise).resolves.toMatchObject({
+      running: false,
       pid: null,
       source: null,
       startedAt: null,

--- a/apps/crawler/src/crawler-run-lock.test.ts
+++ b/apps/crawler/src/crawler-run-lock.test.ts
@@ -392,6 +392,36 @@ describe("crawler run lock", () => {
     await lock.release();
   });
 
+  test("keeps an old lock when its live process start time still matches", async () => {
+    const startedAt = new Date(Date.now() - 120_000).toISOString();
+    await writeFile(
+      lockPath,
+      JSON.stringify({
+        id: "live-lock",
+        pid: process.pid,
+        pidStartedAt: "current-process-start",
+        source: "scheduled",
+        startedAt,
+      }),
+    );
+    const options = {
+      getPidStartedAt: () => "current-process-start",
+      lockPath,
+      pidExists: () => true,
+      staleMs: 1_000,
+    };
+
+    await expect(getCrawlerRunState(options)).resolves.toMatchObject({
+      running: true,
+      pid: process.pid,
+      source: "scheduled",
+      startedAt,
+    });
+    await expect(acquireCrawlerRunLock("manual", options)).rejects.toBeInstanceOf(
+      CrawlerAlreadyRunningError,
+    );
+  });
+
   test("clears a lock when the recorded PID was reused by a restarted process", async () => {
     await writeFile(
       lockPath,

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -6,7 +6,10 @@ import { createCrawlerProgressReporter, type CrawlerProgressReporter } from "./c
 import {
   getCrawlerRunStatePath,
   readCrawlerRunState,
+  writeCrawlerRunState,
+  type CrawlerRunReason,
   type CrawlerRunStateSnapshot,
+  type CrawlerRunTimelineItem,
 } from "./crawler-run-state.js";
 
 const DEFAULT_LOCK_PATH = path.resolve(import.meta.dirname, "../../../data/crawler-run.lock");
@@ -146,6 +149,39 @@ function toRunState(record: CrawlerRunLockRecord): CrawlerRunState {
 
 function toUnknownRunningState(): CrawlerRunState {
   return { running: true, pid: null, source: null, startedAt: null };
+}
+
+async function toStoppedRunState(
+  progressState: CrawlerRunStateSnapshot,
+  statePath: string,
+): Promise<CrawlerRunState> {
+  if (progressState.runStatus !== "running") {
+    return { ...progressState, running: false, pid: null };
+  }
+
+  const finishedAt = new Date().toISOString();
+  const reason: CrawlerRunReason = {
+    code: "unknown_error",
+    message: "前回の実行は完了を確認できませんでした",
+  };
+  const timeline = progressState.timeline.map((item): CrawlerRunTimelineItem => {
+    if (item.status !== "running") return item;
+    return { ...item, status: "failed", finishedAt, reason };
+  });
+  const failedState: CrawlerRunStateSnapshot = {
+    ...progressState,
+    runStatus: "failed",
+    finishedAt,
+    waitingFor: null,
+    reason,
+    progress: {
+      completed: timeline.filter(({ status }) => status !== "pending").length,
+      total: timeline.length,
+    },
+    timeline,
+  };
+  await writeCrawlerRunState(failedState, { statePath });
+  return { ...failedState, running: false, pid: null };
 }
 
 function isExpired(startedAt: string, staleMs: number): boolean {
@@ -505,7 +541,7 @@ export async function getCrawlerRunState(
     snapshot = await readLockSnapshot(resolved.lockPath);
     if (!snapshot) {
       return progressState
-        ? { ...progressState, running: false, pid: null }
+        ? toStoppedRunState(progressState, resolved.statePath)
         : { running: false, pid: null, source: null, startedAt: null };
     }
   }
@@ -531,7 +567,7 @@ export async function getCrawlerRunState(
   const removal = await removeStaleLockIfCurrent(snapshot, resolved);
   if (removal === "removed") {
     return progressState
-      ? { ...progressState, running: false, pid: null }
+      ? toStoppedRunState(progressState, resolved.statePath)
       : { running: false, pid: null, source: null, startedAt: null };
   }
   if (removal === "changed") {
@@ -616,7 +652,13 @@ export async function runWithCrawlerRunLock<T>(
   options: CrawlerRunLockOptions = {},
 ): Promise<T> {
   const lock = await acquireCrawlerRunLock(source, options);
-  const progress = await createCrawlerProgressReporter(getOptions(options).statePath, lock.record);
+  let progress: CrawlerProgressReporter;
+  try {
+    progress = await createCrawlerProgressReporter(getOptions(options).statePath, lock.record);
+  } catch (err) {
+    await lock.release();
+    throw err;
+  }
   try {
     const result = await task(progress);
     await progress.finish("success");

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -540,8 +540,9 @@ export async function getCrawlerRunState(
 
     snapshot = await readLockSnapshot(resolved.lockPath);
     if (!snapshot) {
-      return progressState
-        ? toStoppedRunState(progressState, resolved.statePath)
+      const latestProgressState = await readCrawlerRunState({ statePath: resolved.statePath });
+      return latestProgressState
+        ? toStoppedRunState(latestProgressState, resolved.statePath)
         : { running: false, pid: null, source: null, startedAt: null };
     }
   }
@@ -566,8 +567,9 @@ export async function getCrawlerRunState(
   await resolved.beforeStaleLockCleanup?.();
   const removal = await removeStaleLockIfCurrent(snapshot, resolved);
   if (removal === "removed") {
-    return progressState
-      ? toStoppedRunState(progressState, resolved.statePath)
+    const latestProgressState = await readCrawlerRunState({ statePath: resolved.statePath });
+    return latestProgressState
+      ? toStoppedRunState(latestProgressState, resolved.statePath)
       : { running: false, pid: null, source: null, startedAt: null };
   }
   if (removal === "changed") {

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -264,6 +264,9 @@ function isStaleLock(
     if (currentPidStartedAt && currentPidStartedAt !== record.pidStartedAt) {
       return true;
     }
+    if (currentPidStartedAt === record.pidStartedAt) {
+      return false;
+    }
   }
 
   return isExpired(record.startedAt, options.staleMs);

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -2,16 +2,12 @@ import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { link, mkdir, open, readdir, rename, rm } from "node:fs/promises";
 import path from "node:path";
+import { createCrawlerProgressReporter, type CrawlerProgressReporter } from "./crawler-progress.js";
 import {
-  createCrawlerProgressReporter,
-  normalizeCrawlerError,
-  readCrawlerProgressState,
-  type CrawlerCurrentStep,
-  type CrawlerProgressReporter,
-  type CrawlerReason,
-  type CrawlerRunStatus,
-  type CrawlerTimelineStep,
-} from "./crawler-progress.js";
+  getCrawlerRunStatePath,
+  readCrawlerRunState,
+  type CrawlerRunStateSnapshot,
+} from "./crawler-run-state.js";
 
 const DEFAULT_LOCK_PATH = path.resolve(import.meta.dirname, "../../../data/crawler-run.lock");
 const DEFAULT_MAX_WAIT_MINUTES = 20;
@@ -24,12 +20,14 @@ export interface CrawlerRunState {
   pid: number | null;
   source: string | null;
   startedAt: string | null;
+  version?: 1;
   finishedAt?: string | null;
-  runStatus?: CrawlerRunStatus;
-  current?: CrawlerCurrentStep | null;
+  runStatus?: CrawlerRunStateSnapshot["runStatus"];
+  current?: CrawlerRunStateSnapshot["current"];
   waitingFor?: string | null;
-  reason?: CrawlerReason | null;
-  timeline?: CrawlerTimelineStep[];
+  progress?: CrawlerRunStateSnapshot["progress"];
+  reason?: CrawlerRunStateSnapshot["reason"];
+  timeline?: CrawlerRunStateSnapshot["timeline"];
 }
 
 interface CrawlerRunLockRecord {
@@ -133,7 +131,7 @@ function getOptions(options: CrawlerRunLockOptions = {}) {
     statePath:
       options.statePath ??
       process.env.CRAWLER_STATE_PATH ??
-      `${options.lockPath ?? DEFAULT_LOCK_PATH}.state`,
+      (options.lockPath ? `${options.lockPath}.state` : getCrawlerRunStatePath()),
   };
 }
 
@@ -489,7 +487,7 @@ export async function getCrawlerRunState(
   options: CrawlerRunLockOptions = {},
 ): Promise<CrawlerRunState> {
   const resolved = getOptions(options);
-  const progressState = await readCrawlerProgressState(resolved.statePath);
+  const progressState = await readCrawlerRunState({ statePath: resolved.statePath });
   await mkdir(path.dirname(resolved.lockPath), { recursive: true });
   let snapshot = await readLockSnapshot(resolved.lockPath);
 
@@ -506,7 +504,9 @@ export async function getCrawlerRunState(
 
     snapshot = await readLockSnapshot(resolved.lockPath);
     if (!snapshot) {
-      return progressState ?? { running: false, pid: null, source: null, startedAt: null };
+      return progressState
+        ? { ...progressState, running: false, pid: null }
+        : { running: false, pid: null, source: null, startedAt: null };
     }
   }
 
@@ -522,7 +522,7 @@ export async function getCrawlerRunState(
 
   if (!isStaleSnapshot(snapshot, resolved)) {
     if (record && progressState?.runId === record.id) {
-      return progressState;
+      return { ...progressState, running: true, pid: record.pid };
     }
     return snapshotState;
   }
@@ -530,7 +530,9 @@ export async function getCrawlerRunState(
   await resolved.beforeStaleLockCleanup?.();
   const removal = await removeStaleLockIfCurrent(snapshot, resolved);
   if (removal === "removed") {
-    return progressState ?? { running: false, pid: null, source: null, startedAt: null };
+    return progressState
+      ? { ...progressState, running: false, pid: null }
+      : { running: false, pid: null, source: null, startedAt: null };
   }
   if (removal === "changed") {
     return getCrawlerRunState(options);
@@ -620,8 +622,7 @@ export async function runWithCrawlerRunLock<T>(
     await progress.finish("success");
     return result;
   } catch (err) {
-    const reason = progress.getState().reason ?? normalizeCrawlerError(err, "run_failed");
-    await progress.finish("failed", reason);
+    await progress.finish("failed");
     throw err;
   } finally {
     await lock.release();

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -538,7 +538,7 @@ export async function getCrawlerRunState(
       if (!snapshot) {
         const latestProgressState = await readCrawlerRunState({ statePath: resolved.statePath });
         return latestProgressState
-          ? toStoppedRunState(latestProgressState, resolved.statePath)
+          ? await toStoppedRunState(latestProgressState, resolved.statePath)
           : { running: false, pid: null, source: null, startedAt: null };
       }
     } finally {

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -2,6 +2,16 @@ import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { link, mkdir, open, readdir, rename, rm } from "node:fs/promises";
 import path from "node:path";
+import {
+  createCrawlerProgressReporter,
+  normalizeCrawlerError,
+  readCrawlerProgressState,
+  type CrawlerCurrentStep,
+  type CrawlerProgressReporter,
+  type CrawlerReason,
+  type CrawlerRunStatus,
+  type CrawlerTimelineStep,
+} from "./crawler-progress.js";
 
 const DEFAULT_LOCK_PATH = path.resolve(import.meta.dirname, "../../../data/crawler-run.lock");
 const DEFAULT_MAX_WAIT_MINUTES = 20;
@@ -9,10 +19,17 @@ const LOCK_STALE_BUFFER_MINUTES = 100;
 const LOCK_MUTATION_INTENT_STALE_MS = 60_000;
 
 export interface CrawlerRunState {
+  runId?: string;
   running: boolean;
   pid: number | null;
   source: string | null;
   startedAt: string | null;
+  finishedAt?: string | null;
+  runStatus?: CrawlerRunStatus;
+  current?: CrawlerCurrentStep | null;
+  waitingFor?: string | null;
+  reason?: CrawlerReason | null;
+  timeline?: CrawlerTimelineStep[];
 }
 
 interface CrawlerRunLockRecord {
@@ -34,6 +51,7 @@ interface CrawlerRunLockOptions {
   getPidStartedAt?: (pid: number) => string | null;
   pidExists?: (pid: number) => boolean;
   staleMs?: number;
+  statePath?: string;
 }
 
 export class CrawlerAlreadyRunningError extends Error {
@@ -112,6 +130,10 @@ function getOptions(options: CrawlerRunLockOptions = {}) {
     lockPath: options.lockPath ?? DEFAULT_LOCK_PATH,
     pidExists: options.pidExists ?? defaultPidExists,
     staleMs: options.staleMs ?? getDefaultStaleMs(),
+    statePath:
+      options.statePath ??
+      process.env.CRAWLER_STATE_PATH ??
+      `${options.lockPath ?? DEFAULT_LOCK_PATH}.state`,
   };
 }
 
@@ -467,6 +489,7 @@ export async function getCrawlerRunState(
   options: CrawlerRunLockOptions = {},
 ): Promise<CrawlerRunState> {
   const resolved = getOptions(options);
+  const progressState = await readCrawlerProgressState(resolved.statePath);
   await mkdir(path.dirname(resolved.lockPath), { recursive: true });
   let snapshot = await readLockSnapshot(resolved.lockPath);
 
@@ -483,7 +506,7 @@ export async function getCrawlerRunState(
 
     snapshot = await readLockSnapshot(resolved.lockPath);
     if (!snapshot) {
-      return { running: false, pid: null, source: null, startedAt: null };
+      return progressState ?? { running: false, pid: null, source: null, startedAt: null };
     }
   }
 
@@ -498,13 +521,16 @@ export async function getCrawlerRunState(
       };
 
   if (!isStaleSnapshot(snapshot, resolved)) {
+    if (record && progressState?.runId === record.id) {
+      return progressState;
+    }
     return snapshotState;
   }
 
   await resolved.beforeStaleLockCleanup?.();
   const removal = await removeStaleLockIfCurrent(snapshot, resolved);
   if (removal === "removed") {
-    return { running: false, pid: null, source: null, startedAt: null };
+    return progressState ?? { running: false, pid: null, source: null, startedAt: null };
   }
   if (removal === "changed") {
     return getCrawlerRunState(options);
@@ -584,12 +610,19 @@ export async function acquireCrawlerRunLock(
 
 export async function runWithCrawlerRunLock<T>(
   source: string,
-  task: () => Promise<T>,
+  task: (progress: CrawlerProgressReporter) => Promise<T>,
   options: CrawlerRunLockOptions = {},
 ): Promise<T> {
   const lock = await acquireCrawlerRunLock(source, options);
+  const progress = await createCrawlerProgressReporter(getOptions(options).statePath, lock.record);
   try {
-    return await task();
+    const result = await task(progress);
+    await progress.finish("success");
+    return result;
+  } catch (err) {
+    const reason = progress.getState().reason ?? normalizeCrawlerError(err, "run_failed");
+    await progress.finish("failed", reason);
+    throw err;
   } finally {
     await lock.release();
   }

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -534,16 +534,15 @@ export async function getCrawlerRunState(
     }
     try {
       await recoverQuarantinedLock(resolved.lockPath);
+      snapshot = await readLockSnapshot(resolved.lockPath);
+      if (!snapshot) {
+        const latestProgressState = await readCrawlerRunState({ statePath: resolved.statePath });
+        return latestProgressState
+          ? toStoppedRunState(latestProgressState, resolved.statePath)
+          : { running: false, pid: null, source: null, startedAt: null };
+      }
     } finally {
       await mutationGuard.release();
-    }
-
-    snapshot = await readLockSnapshot(resolved.lockPath);
-    if (!snapshot) {
-      const latestProgressState = await readCrawlerRunState({ statePath: resolved.statePath });
-      return latestProgressState
-        ? toStoppedRunState(latestProgressState, resolved.statePath)
-        : { running: false, pid: null, source: null, startedAt: null };
     }
   }
 
@@ -567,10 +566,7 @@ export async function getCrawlerRunState(
   await resolved.beforeStaleLockCleanup?.();
   const removal = await removeStaleLockIfCurrent(snapshot, resolved);
   if (removal === "removed") {
-    const latestProgressState = await readCrawlerRunState({ statePath: resolved.statePath });
-    return latestProgressState
-      ? toStoppedRunState(latestProgressState, resolved.statePath)
-      : { running: false, pid: null, source: null, startedAt: null };
+    return getCrawlerRunState(options);
   }
   if (removal === "changed") {
     return getCrawlerRunState(options);

--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -85,7 +85,9 @@ interface LockMutationIntentRecord {
   pidStartedAt: string | null;
 }
 
-type StaleLockRemovalResult = "busy" | "changed" | "removed";
+type StaleLockRemovalResult =
+  | { kind: "busy" | "changed" }
+  | { kind: "removed"; state: CrawlerRunState };
 
 function defaultPidExists(pid: number): boolean {
   try {
@@ -476,7 +478,7 @@ async function removeStaleLockIfCurrent(
 ): Promise<StaleLockRemovalResult> {
   const mutationGuard = await tryAcquireLockMutationGuard(options);
   if (!mutationGuard) {
-    return "busy";
+    return { kind: "busy" };
   }
 
   const quarantinePath = `${options.lockPath}.stale-${randomUUID()}`;
@@ -488,7 +490,7 @@ async function removeStaleLockIfCurrent(
       await options.afterStaleLockQuarantine?.();
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-        return "changed";
+        return { kind: "changed" };
       }
       throw err;
     }
@@ -501,7 +503,11 @@ async function removeStaleLockIfCurrent(
       current.contents === expected.contents
     ) {
       await rm(quarantinePath, { force: true });
-      return "removed";
+      const latestProgressState = await readCrawlerRunState({ statePath: options.statePath });
+      const state = latestProgressState
+        ? await toStoppedRunState(latestProgressState, options.statePath)
+        : { running: false as const, pid: null, source: null, startedAt: null };
+      return { kind: "removed", state };
     }
 
     try {
@@ -513,7 +519,7 @@ async function removeStaleLockIfCurrent(
       }
     }
 
-    return "changed";
+    return { kind: "changed" };
   } finally {
     await mutationGuard.release();
   }
@@ -565,10 +571,10 @@ export async function getCrawlerRunState(
 
   await resolved.beforeStaleLockCleanup?.();
   const removal = await removeStaleLockIfCurrent(snapshot, resolved);
-  if (removal === "removed") {
-    return getCrawlerRunState(options);
+  if (removal.kind === "removed") {
+    return removal.state;
   }
-  if (removal === "changed") {
+  if (removal.kind === "changed") {
     return getCrawlerRunState(options);
   }
 

--- a/apps/crawler/src/run.test.ts
+++ b/apps/crawler/src/run.test.ts
@@ -39,6 +39,7 @@ vi.mock("./web-refresh.js", () => ({ notifyWebRefresh: vi.fn<() => void>() }));
 let tempDir: string;
 
 beforeEach(async () => {
+  vi.clearAllMocks();
   tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-run-progress-"));
   vi.mocked(runLoadPhase).mockReturnValue({
     skipRefresh: false,
@@ -99,6 +100,21 @@ afterEach(async () => {
 });
 
 describe("runCrawler progress", () => {
+  test("group cleanup 失敗を database save step に記録する", async () => {
+    const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
+      id: "run-a",
+      source: "test",
+      startedAt: "2026-07-01T00:00:00.000Z",
+    });
+    vi.mocked(runCleanupPhase).mockRejectedValueOnce(new Error("database cleanup failed"));
+
+    await expect(runCrawler(progress)).rejects.toThrow("database cleanup failed");
+
+    expect(progress.getState().timeline).toContainEqual(
+      expect.objectContaining({ step: "database_save", status: "failed" }),
+    );
+  });
+
   test("通常成功でユーザー向けの全 step を順に記録する", async () => {
     const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
       id: "run-a",

--- a/apps/crawler/src/run.test.ts
+++ b/apps/crawler/src/run.test.ts
@@ -1,0 +1,133 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  runAnalyticsPhase,
+  runAuthPhase,
+  runCashFlowHistoryPhase,
+  runCleanupPhase,
+  runInstitutionCategoryPhase,
+  runLoadPhase,
+  runNotificationPhase,
+  runSavePhase,
+  runScrapePhase,
+  runSetupPhase,
+} from "./crawler-phases.js";
+import { CRAWLER_STEPS, createCrawlerProgressReporter } from "./crawler-progress.js";
+import { runCrawler } from "./run.js";
+import { createGroupScope } from "./scrapers/group.js";
+import { notifyWebRefresh } from "./web-refresh.js";
+
+vi.mock("@mf-dashboard/db", () => ({ closeDb: vi.fn<() => void>() }));
+vi.mock("./crawler-phases.js", () => ({
+  handleCrawlerFailure: vi.fn<() => void>(),
+  runAnalyticsPhase: vi.fn<() => void>(),
+  runAuthPhase: vi.fn<() => void>(),
+  runCashFlowHistoryPhase: vi.fn<() => void>(),
+  runCleanupPhase: vi.fn<() => void>(),
+  runInstitutionCategoryPhase: vi.fn<() => void>(),
+  runLoadPhase: vi.fn<() => void>(),
+  runNotificationPhase: vi.fn<() => void>(),
+  runSavePhase: vi.fn<() => void>(),
+  runScrapePhase: vi.fn<() => void>(),
+  runSetupPhase: vi.fn<() => void>(),
+}));
+vi.mock("./scrapers/group.js", () => ({ createGroupScope: vi.fn<() => void>() }));
+vi.mock("./web-refresh.js", () => ({ notifyWebRefresh: vi.fn<() => void>() }));
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-run-progress-"));
+  vi.mocked(runLoadPhase).mockReturnValue({
+    skipRefresh: false,
+    cleanupGroups: false,
+    authState: "configured",
+    dbPath: "/tmp/demo.db",
+    dbExists: true,
+    scrapeMode: "month",
+    isHistoryMode: false,
+    isDebug: false,
+    isHeaded: false,
+  });
+  vi.mocked(runSetupPhase).mockResolvedValue({
+    db: {} as never,
+    browser: { close: vi.fn<() => Promise<void>>() } as never,
+    context: {} as never,
+    page: {} as never,
+    categoryDecision: { config: null, usage: { llmCallsUsed: 0 } },
+  });
+  vi.mocked(createGroupScope).mockResolvedValue({
+    originalGroup: null,
+    [Symbol.asyncDispose]: vi.fn<() => Promise<void>>(),
+  });
+  vi.mocked(runNotificationPhase).mockResolvedValue(null);
+  vi.mocked(notifyWebRefresh).mockResolvedValue(undefined);
+  vi.mocked(runScrapePhase).mockImplementation(async (_page, _config, progress) => {
+    for (const [step, metadata] of [
+      [CRAWLER_STEPS.refresh],
+      [CRAWLER_STEPS.globalData],
+      [CRAWLER_STEPS.monthlyCashFlow, { month: "2026-07" }],
+      [CRAWLER_STEPS.groupData, { groupName: "Group A" }],
+    ] as const) {
+      const stepId = await progress.startStep(step, metadata);
+      await progress.completeStep(stepId);
+    }
+    return {
+      defaultGroup: null,
+      globalData: {
+        registeredAccounts: { accounts: [] },
+        portfolio: { items: [], totalAssets: 0 },
+        liabilities: { items: [], totalLiabilities: 0 },
+        cashFlow: {
+          month: "2026-07",
+          totalIncome: 0,
+          totalExpense: 0,
+          balance: 0,
+          items: [],
+        },
+        refreshResult: { completed: true, incompleteAccounts: [] },
+      },
+      groupDataList: [],
+    };
+  });
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("runCrawler progress", () => {
+  test("通常成功でユーザー向けの全 step を順に記録する", async () => {
+    const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
+      id: "run-a",
+      pid: 123,
+      source: "test",
+      startedAt: "2026-07-01T00:00:00.000Z",
+    });
+
+    await runCrawler(progress);
+    await progress.finish("success");
+
+    expect(progress.getState().runStatus).toBe("success");
+    expect(progress.getState().timeline.map(({ code, status }) => ({ code, status }))).toEqual([
+      { code: "authentication", status: "success" },
+      { code: "refresh", status: "success" },
+      { code: "global_data", status: "success" },
+      { code: "monthly_cash_flow", status: "success" },
+      { code: "group_data", status: "success" },
+      { code: "database_save", status: "success" },
+      { code: "institution_categories", status: "success" },
+      { code: "analytics", status: "success" },
+      { code: "notification", status: "success" },
+      { code: "web_cache_refresh", status: "success" },
+    ]);
+    expect(runAuthPhase).toHaveBeenCalledOnce();
+    expect(runSavePhase).toHaveBeenCalledOnce();
+    expect(runCleanupPhase).toHaveBeenCalledOnce();
+    expect(runInstitutionCategoryPhase).toHaveBeenCalledOnce();
+    expect(runCashFlowHistoryPhase).toHaveBeenCalledOnce();
+    expect(runAnalyticsPhase).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/crawler/src/run.test.ts
+++ b/apps/crawler/src/run.test.ts
@@ -102,7 +102,6 @@ describe("runCrawler progress", () => {
   test("通常成功でユーザー向けの全 step を順に記録する", async () => {
     const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
       id: "run-a",
-      pid: 123,
       source: "test",
       startedAt: "2026-07-01T00:00:00.000Z",
     });
@@ -111,17 +110,17 @@ describe("runCrawler progress", () => {
     await progress.finish("success");
 
     expect(progress.getState().runStatus).toBe("success");
-    expect(progress.getState().timeline.map(({ code, status }) => ({ code, status }))).toEqual([
-      { code: "authentication", status: "success" },
-      { code: "refresh", status: "success" },
-      { code: "global_data", status: "success" },
-      { code: "monthly_cash_flow", status: "success" },
-      { code: "group_data", status: "success" },
-      { code: "database_save", status: "success" },
-      { code: "institution_categories", status: "success" },
-      { code: "analytics", status: "success" },
-      { code: "notification", status: "success" },
-      { code: "web_cache_refresh", status: "success" },
+    expect(progress.getState().timeline.map(({ step, status }) => ({ step, status }))).toEqual([
+      { step: "authentication", status: "done" },
+      { step: "moneyforward_refresh", status: "done" },
+      { step: "global_data", status: "done" },
+      { step: "cash_flow_history", status: "done" },
+      { step: "group_data", status: "done" },
+      { step: "database_save", status: "done" },
+      { step: "institution_categories", status: "done" },
+      { step: "analytics", status: "done" },
+      { step: "notification", status: "done" },
+      { step: "web_cache_refresh", status: "done" },
     ]);
     expect(runAuthPhase).toHaveBeenCalledOnce();
     expect(runSavePhase).toHaveBeenCalledOnce();

--- a/apps/crawler/src/run.ts
+++ b/apps/crawler/src/run.ts
@@ -13,30 +13,77 @@ import {
   runSetupPhase,
   type CrawlerRuntime,
 } from "./crawler-phases.js";
+import {
+  CRAWLER_STEPS,
+  normalizeCrawlerError,
+  runCrawlerStep,
+  type CrawlerProgressReporter,
+} from "./crawler-progress.js";
 import { error, info } from "./logger.js";
 import { createGroupScope } from "./scrapers/group.js";
 import { notifyWebRefresh } from "./web-refresh.js";
 
-export async function runCrawler(): Promise<void> {
+export async function runCrawler(progress: CrawlerProgressReporter): Promise<void> {
   const config = runLoadPhase();
   let runtime: CrawlerRuntime | null = null;
 
   try {
-    runtime = await runSetupPhase(config);
-    await runAuthPhase(runtime.page, runtime.context);
+    const activeRuntime = await runSetupPhase(config);
+    runtime = activeRuntime;
+    await runCrawlerStep(
+      progress,
+      CRAWLER_STEPS.authentication,
+      () => runAuthPhase(activeRuntime.page, activeRuntime.context),
+      { failureCode: "auth_failed" },
+    );
 
-    await using groupScope = await createGroupScope(runtime.page);
-    const scrapeResult = await runScrapePhase(runtime.page, config);
-    await runSavePhase(runtime.db, runtime.page, scrapeResult, runtime.categoryDecision);
-    await runCleanupPhase(runtime.db, scrapeResult.groupDataList, config);
-    await runInstitutionCategoryPhase(runtime.db, runtime.page);
-    await runCashFlowHistoryPhase(runtime.db, runtime.page, config, runtime.categoryDecision);
-    await runAnalyticsPhase(runtime.db, scrapeResult.groupDataList);
-    await runNotificationPhase(scrapeResult.groupDataList, groupScope.originalGroup);
+    await using groupScope = await createGroupScope(activeRuntime.page);
+    const scrapeResult = await runScrapePhase(activeRuntime.page, config, progress);
+    await runCrawlerStep(progress, CRAWLER_STEPS.databaseSave, () =>
+      runSavePhase(
+        activeRuntime.db,
+        activeRuntime.page,
+        scrapeResult,
+        activeRuntime.categoryDecision,
+      ),
+    );
+    await runCleanupPhase(activeRuntime.db, scrapeResult.groupDataList, config);
+    await runCrawlerStep(progress, CRAWLER_STEPS.institutionCategories, () =>
+      runInstitutionCategoryPhase(activeRuntime.db, activeRuntime.page),
+    );
+    await runCashFlowHistoryPhase(
+      activeRuntime.db,
+      activeRuntime.page,
+      config,
+      activeRuntime.categoryDecision,
+      progress,
+    );
+    await runCrawlerStep(progress, CRAWLER_STEPS.analytics, () =>
+      runAnalyticsPhase(activeRuntime.db, scrapeResult.groupDataList),
+    );
+    const notificationStep = await progress.startStep(CRAWLER_STEPS.notification);
+    const notificationFailure = await runNotificationPhase(
+      scrapeResult.groupDataList,
+      groupScope.originalGroup,
+    );
+    if (notificationFailure) {
+      await progress.warnStep(
+        notificationStep,
+        normalizeCrawlerError(notificationFailure, "notification_failed"),
+      );
+    } else {
+      await progress.completeStep(notificationStep);
+    }
 
+    const webRefreshStep = await progress.startStep(CRAWLER_STEPS.webCacheRefresh);
     try {
       await notifyWebRefresh();
+      await progress.completeStep(webRefreshStep);
     } catch (err) {
+      await progress.warnStep(
+        webRefreshStep,
+        normalizeCrawlerError(err, "web_cache_refresh_failed"),
+      );
       error("Failed to refresh web cache:", err);
     }
 

--- a/apps/crawler/src/run.ts
+++ b/apps/crawler/src/run.ts
@@ -39,15 +39,15 @@ export async function runCrawler(progress: CrawlerProgressReporter): Promise<voi
 
     await using groupScope = await createGroupScope(activeRuntime.page);
     const scrapeResult = await runScrapePhase(activeRuntime.page, config, progress);
-    await runCrawlerStep(progress, CRAWLER_STEPS.databaseSave, () =>
-      runSavePhase(
+    await runCrawlerStep(progress, CRAWLER_STEPS.databaseSave, async () => {
+      await runSavePhase(
         activeRuntime.db,
         activeRuntime.page,
         scrapeResult,
         activeRuntime.categoryDecision,
-      ),
-    );
-    await runCleanupPhase(activeRuntime.db, scrapeResult.groupDataList, config);
+      );
+      await runCleanupPhase(activeRuntime.db, scrapeResult.groupDataList, config);
+    });
     await runCrawlerStep(progress, CRAWLER_STEPS.institutionCategories, () =>
       runInstitutionCategoryPhase(activeRuntime.db, activeRuntime.page),
     );

--- a/apps/crawler/src/scraper-progress.test.ts
+++ b/apps/crawler/src/scraper-progress.test.ts
@@ -79,7 +79,6 @@ describe("scraper progress", () => {
   test("refresh timeout を warning にし、未完了機関と group name を保持する", async () => {
     const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
       id: "run-a",
-      pid: 123,
       source: "test",
       startedAt: "2026-07-01T00:00:00.000Z",
     });
@@ -104,10 +103,11 @@ describe("scraper progress", () => {
     expect(waitingState).toMatchObject({
       waitingFor: "更新中の金融機関が0件になるのを待機",
       current: {
-        code: "refresh",
+        step: "moneyforward_refresh",
         metadata: expect.objectContaining({
+          kind: "refresh",
           maxWaitMinutes: 20,
-          remainingCount: 2,
+          remainingAccounts: 2,
           incompleteAccounts: ["Institution A", "Institution B"],
         }),
       },
@@ -115,19 +115,20 @@ describe("scraper progress", () => {
     expect(progress.getState().timeline).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          code: "refresh",
+          step: "moneyforward_refresh",
           status: "warning",
           reason: expect.objectContaining({ code: "refresh_timeout" }),
           metadata: expect.objectContaining({
+            kind: "refresh",
             maxWaitMinutes: 20,
-            remainingCount: 2,
+            remainingAccounts: 2,
             incompleteAccounts: ["Institution A", "Institution B"],
           }),
         }),
         expect.objectContaining({
-          code: "group_data",
-          status: "success",
-          metadata: { groupName: "Group A" },
+          step: "group_data",
+          status: "done",
+          metadata: { kind: "group", groupName: "Group A" },
         }),
       ]),
     );

--- a/apps/crawler/src/scraper-progress.test.ts
+++ b/apps/crawler/src/scraper-progress.test.ts
@@ -77,6 +77,24 @@ afterEach(async () => {
 });
 
 describe("scraper progress", () => {
+  test("group discovery 失敗を全体データ step に記録する", async () => {
+    const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
+      id: "run-a",
+      source: "test",
+      startedAt: "2026-07-01T00:00:00.000Z",
+    });
+    vi.mocked(getAllGroups).mockRejectedValueOnce(new Error("page closed"));
+
+    await expect(
+      scrapeAllGroups({} as Parameters<typeof scrapeAllGroups>[0], progress),
+    ).rejects.toThrow("page closed");
+
+    expect(progress.getState().timeline).toContainEqual(
+      expect.objectContaining({ step: "global_data", status: "failed" }),
+    );
+    expect(switchGroup).not.toHaveBeenCalled();
+  });
+
   test("初期 group 切り替え失敗を全体データ step に記録する", async () => {
     const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
       id: "run-a",

--- a/apps/crawler/src/scraper-progress.test.ts
+++ b/apps/crawler/src/scraper-progress.test.ts
@@ -77,6 +77,27 @@ afterEach(async () => {
 });
 
 describe("scraper progress", () => {
+  test("初期 group 切り替え失敗を全体データ step に記録する", async () => {
+    const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
+      id: "run-a",
+      source: "test",
+      startedAt: "2026-07-01T00:00:00.000Z",
+    });
+    vi.mocked(switchGroup).mockRejectedValueOnce(new Error("selector not found"));
+
+    await expect(
+      scrapeAllGroups({} as Parameters<typeof scrapeAllGroups>[0], progress),
+    ).rejects.toThrow("selector not found");
+
+    expect(progress.getState().timeline).toContainEqual(
+      expect.objectContaining({
+        step: "global_data",
+        status: "failed",
+        reason: expect.objectContaining({ code: "selector_not_found" }),
+      }),
+    );
+  });
+
   test("SKIP_REFRESH の refresh step を skipped にする", async () => {
     const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
       id: "run-a",

--- a/apps/crawler/src/scraper-progress.test.ts
+++ b/apps/crawler/src/scraper-progress.test.ts
@@ -1,0 +1,135 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { createCrawlerProgressReporter } from "./crawler-progress.js";
+import { scrapeAllGroups } from "./scraper.js";
+import { getAssetHistory } from "./scrapers/asset-history.js";
+import { getAssetItems } from "./scrapers/asset-items.js";
+import { getAssetSummary } from "./scrapers/asset-summary.js";
+import { getCashFlow } from "./scrapers/cash-flow.js";
+import { getAllGroups, getCurrentGroup } from "./scrapers/group.js";
+import { getLiabilities } from "./scrapers/liabilities.js";
+import { getPortfolio } from "./scrapers/portfolio.js";
+import { clickRefreshButton } from "./scrapers/refresh.js";
+import { getRegisteredAccounts } from "./scrapers/registered-accounts.js";
+import { getSpendingTargets } from "./scrapers/spending-targets.js";
+
+vi.mock("./scrapers/asset-history.js", () => ({ getAssetHistory: vi.fn<() => void>() }));
+vi.mock("./scrapers/asset-items.js", () => ({ getAssetItems: vi.fn<() => void>() }));
+vi.mock("./scrapers/asset-summary.js", () => ({ getAssetSummary: vi.fn<() => void>() }));
+vi.mock("./scrapers/cash-flow.js", () => ({ getCashFlow: vi.fn<() => void>() }));
+vi.mock("./scrapers/group.js", () => ({
+  NO_GROUP_ID: "0",
+  isNoGroup: (id: string) => id === "0",
+  getAllGroups: vi.fn<() => void>(),
+  getCurrentGroup: vi.fn<() => void>(),
+  switchGroup: vi.fn<() => void>(),
+}));
+vi.mock("./scrapers/liabilities.js", () => ({ getLiabilities: vi.fn<() => void>() }));
+vi.mock("./scrapers/portfolio.js", () => ({ getPortfolio: vi.fn<() => void>() }));
+vi.mock("./scrapers/refresh.js", () => ({
+  clickRefreshButton: vi.fn<() => void>(),
+  getMaxWaitMinutes: () => 20,
+}));
+vi.mock("./scrapers/registered-accounts.js", () => ({
+  getRegisteredAccounts: vi.fn<() => void>(),
+}));
+vi.mock("./scrapers/spending-targets.js", () => ({
+  getSpendingTargets: vi.fn<() => void>(),
+}));
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-scraper-progress-"));
+  vi.mocked(getCurrentGroup).mockResolvedValue(null);
+  vi.mocked(getAllGroups).mockResolvedValue([{ id: "group-a", name: "Group A", isCurrent: false }]);
+  vi.mocked(clickRefreshButton).mockResolvedValue({
+    completed: false,
+    incompleteAccounts: ["Institution A", "Institution B"],
+  });
+  vi.mocked(getRegisteredAccounts).mockResolvedValue({ accounts: [] });
+  vi.mocked(getPortfolio).mockResolvedValue({ items: [], totalAssets: 0 });
+  vi.mocked(getLiabilities).mockResolvedValue({ items: [], totalLiabilities: 0 });
+  vi.mocked(getCashFlow).mockResolvedValue({
+    month: "2026-07",
+    totalIncome: 0,
+    totalExpense: 0,
+    balance: 0,
+    items: [],
+  });
+  vi.mocked(getAssetSummary).mockResolvedValue({
+    totalAssets: "0",
+    dailyChange: "0",
+    dailyChangePercent: "0%",
+    monthlyChange: "0",
+    monthlyChangePercent: "0%",
+  });
+  vi.mocked(getAssetItems).mockResolvedValue([]);
+  vi.mocked(getAssetHistory).mockResolvedValue({ points: [] });
+  vi.mocked(getSpendingTargets).mockResolvedValue({ categories: [] });
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("scraper progress", () => {
+  test("refresh timeout を warning にし、未完了機関と group name を保持する", async () => {
+    const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
+      id: "run-a",
+      pid: 123,
+      source: "test",
+      startedAt: "2026-07-01T00:00:00.000Z",
+    });
+    let waitingState = progress.getState();
+    vi.mocked(clickRefreshButton).mockImplementation(async (_page, options) => {
+      await options?.onWaiting?.({
+        elapsedSeconds: 30,
+        incompleteAccounts: ["Institution A", "Institution B"],
+        maxWaitMinutes: 20,
+        nextCheckSeconds: 30,
+        remainingCount: 2,
+      });
+      waitingState = progress.getState();
+      return {
+        completed: false,
+        incompleteAccounts: ["Institution A", "Institution B"],
+      };
+    });
+
+    await scrapeAllGroups({} as Parameters<typeof scrapeAllGroups>[0], progress);
+
+    expect(waitingState).toMatchObject({
+      waitingFor: "更新中の金融機関が0件になるのを待機",
+      current: {
+        code: "refresh",
+        metadata: expect.objectContaining({
+          maxWaitMinutes: 20,
+          remainingCount: 2,
+          incompleteAccounts: ["Institution A", "Institution B"],
+        }),
+      },
+    });
+    expect(progress.getState().timeline).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "refresh",
+          status: "warning",
+          reason: expect.objectContaining({ code: "refresh_timeout" }),
+          metadata: expect.objectContaining({
+            maxWaitMinutes: 20,
+            remainingCount: 2,
+            incompleteAccounts: ["Institution A", "Institution B"],
+          }),
+        }),
+        expect.objectContaining({
+          code: "group_data",
+          status: "success",
+          metadata: { groupName: "Group A" },
+        }),
+      ]),
+    );
+  });
+});

--- a/apps/crawler/src/scraper-progress.test.ts
+++ b/apps/crawler/src/scraper-progress.test.ts
@@ -8,7 +8,7 @@ import { getAssetHistory } from "./scrapers/asset-history.js";
 import { getAssetItems } from "./scrapers/asset-items.js";
 import { getAssetSummary } from "./scrapers/asset-summary.js";
 import { getCashFlow } from "./scrapers/cash-flow.js";
-import { getAllGroups, getCurrentGroup } from "./scrapers/group.js";
+import { getAllGroups, getCurrentGroup, switchGroup } from "./scrapers/group.js";
 import { getLiabilities } from "./scrapers/liabilities.js";
 import { getPortfolio } from "./scrapers/portfolio.js";
 import { clickRefreshButton } from "./scrapers/refresh.js";
@@ -42,6 +42,7 @@ vi.mock("./scrapers/spending-targets.js", () => ({
 let tempDir: string;
 
 beforeEach(async () => {
+  vi.clearAllMocks();
   tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-scraper-progress-"));
   vi.mocked(getCurrentGroup).mockResolvedValue(null);
   vi.mocked(getAllGroups).mockResolvedValue([{ id: "group-a", name: "Group A", isCurrent: false }]);
@@ -76,6 +77,48 @@ afterEach(async () => {
 });
 
 describe("scraper progress", () => {
+  test("SKIP_REFRESH の refresh step を skipped にする", async () => {
+    const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
+      id: "run-a",
+      source: "test",
+      startedAt: "2026-07-01T00:00:00.000Z",
+    });
+
+    await scrapeAllGroups({} as Parameters<typeof scrapeAllGroups>[0], progress, {
+      skipRefresh: true,
+    });
+
+    expect(progress.getState().timeline).toContainEqual(
+      expect.objectContaining({ step: "moneyforward_refresh", status: "skipped" }),
+    );
+    expect(clickRefreshButton).not.toHaveBeenCalled();
+  });
+
+  test("group 切り替え失敗を対象 group name の failed step にする", async () => {
+    const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
+      id: "run-a",
+      source: "test",
+      startedAt: "2026-07-01T00:00:00.000Z",
+    });
+    vi.mocked(switchGroup)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockRejectedValueOnce(new Error("selector not found"));
+
+    await expect(
+      scrapeAllGroups({} as Parameters<typeof scrapeAllGroups>[0], progress),
+    ).rejects.toThrow("selector not found");
+
+    expect(progress.getState().timeline).toContainEqual(
+      expect.objectContaining({
+        step: "group_data",
+        status: "failed",
+        metadata: { kind: "group", groupName: "Group A" },
+        reason: expect.objectContaining({ code: "selector_not_found" }),
+      }),
+    );
+  });
+
   test("refresh timeout を warning にし、未完了機関と group name を保持する", async () => {
     const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
       id: "run-a",

--- a/apps/crawler/src/scraper-progress.test.ts
+++ b/apps/crawler/src/scraper-progress.test.ts
@@ -96,6 +96,7 @@ describe("scraper progress", () => {
         reason: expect.objectContaining({ code: "selector_not_found" }),
       }),
     );
+    expect(clickRefreshButton).not.toHaveBeenCalled();
   });
 
   test("SKIP_REFRESH の refresh step を skipped にする", async () => {

--- a/apps/crawler/src/scraper.ts
+++ b/apps/crawler/src/scraper.ts
@@ -71,8 +71,16 @@ async function scrapeGlobalData(
   page: Page,
   options: ScrapeOptions,
   progress: CrawlerProgressReporter,
+  globalStep: string,
 ): Promise<GlobalData> {
   const { skipRefresh = false } = options;
+
+  try {
+    await switchGroup(page, NO_GROUP_ID);
+  } catch (error) {
+    await progress.failStep(globalStep, normalizeCrawlerError(error, "global_data_failed"));
+    throw error;
+  }
 
   // Refresh
   let refreshResult = null;
@@ -110,17 +118,15 @@ async function scrapeGlobalData(
       }
     } catch (error) {
       await progress.failStep(refreshStep, normalizeCrawlerError(error, "refresh_failed"));
+      await progress.failStep(globalStep, normalizeCrawlerError(error, "global_data_failed"));
       throw error;
     }
   }
 
-  const globalStep = await progress.startStep(CRAWLER_STEPS.globalData);
   let registeredAccounts: Awaited<ReturnType<typeof getRegisteredAccounts>>;
   let portfolio: Awaited<ReturnType<typeof getPortfolio>>;
   let liabilities: Awaited<ReturnType<typeof getLiabilities>>;
   try {
-    await switchGroup(page, NO_GROUP_ID);
-
     // 全アカウント情報
     registeredAccounts = await getRegisteredAccounts(page);
     log(`Registered accounts: ${registeredAccounts.accounts.length}`);
@@ -272,7 +278,8 @@ export async function scrapeAllGroups(
   const groupsToProcess = buildGroupsToProcess(allGroups);
 
   phase("Scrape: Global Data");
-  const globalData = await scrapeGlobalData(page, options, progress);
+  const globalStep = await progress.startStep(CRAWLER_STEPS.globalData);
+  const globalData = await scrapeGlobalData(page, options, progress, globalStep);
   const groupDataList = await runPhase2(page, groupsToProcess, defaultGroup, progress);
 
   return {

--- a/apps/crawler/src/scraper.ts
+++ b/apps/crawler/src/scraper.ts
@@ -81,7 +81,7 @@ async function scrapeGlobalData(
   });
   if (skipRefresh) {
     log("Skipping refresh (SKIP_REFRESH=true)");
-    await progress.completeStep(refreshStep, { skipped: "true" });
+    await progress.skipStep(refreshStep);
   } else {
     try {
       refreshResult = await clickRefreshButton(page, {
@@ -219,17 +219,16 @@ async function runPhase2(
     const groupId = groupEntry.id;
     const groupName = groupEntry.name;
 
+    const groupStep = await progress.startStep(CRAWLER_STEPS.groupData, { groupName });
     log(`--- ${groupName} ---`);
-    await switchGroup(page, groupId);
-
     const group: Group = {
       id: groupId,
       name: groupName,
       isCurrent: groupId === defaultGroup?.id,
     };
 
-    const groupStep = await progress.startStep(CRAWLER_STEPS.groupData, { groupName });
     try {
+      await switchGroup(page, groupId);
       const groupData = await scrapeGroupData(page, group);
       groupDataList.push(groupData);
       await progress.completeStep(groupStep);

--- a/apps/crawler/src/scraper.ts
+++ b/apps/crawler/src/scraper.ts
@@ -98,6 +98,8 @@ async function scrapeGlobalData(
           {
             code: "refresh_timeout",
             message: "金融機関の一括更新が待機時間を超えました",
+            maxWaitMinutes: getMaxWaitMinutes(),
+            incompleteAccounts: refreshResult.incompleteAccounts,
           },
           {
             maxWaitMinutes: getMaxWaitMinutes(),

--- a/apps/crawler/src/scraper.ts
+++ b/apps/crawler/src/scraper.ts
@@ -267,18 +267,26 @@ export async function scrapeAllGroups(
   progress: CrawlerProgressReporter,
   options: ScrapeOptions = {},
 ): Promise<ScrapeResult> {
-  // 現在のグループを記憶
-  const defaultGroup = await getCurrentGroup(page);
-  log(`Default group: ${defaultGroup?.name ?? "none"}`);
+  const globalStep = await progress.startStep(CRAWLER_STEPS.globalData);
 
-  // 全グループの一覧を取得
-  const allGroups = await getAllGroups(page);
-  log(`Found ${allGroups.length} groups`);
+  // 現在のグループを記憶
+  let defaultGroup: Group | null;
+  let allGroups: Group[];
+  try {
+    defaultGroup = await getCurrentGroup(page);
+    log(`Default group: ${defaultGroup?.name ?? "none"}`);
+
+    // 全グループの一覧を取得
+    allGroups = await getAllGroups(page);
+    log(`Found ${allGroups.length} groups`);
+  } catch (error) {
+    await progress.failStep(globalStep, normalizeCrawlerError(error, "global_data_failed"));
+    throw error;
+  }
 
   const groupsToProcess = buildGroupsToProcess(allGroups);
 
   phase("Scrape: Global Data");
-  const globalStep = await progress.startStep(CRAWLER_STEPS.globalData);
   const globalData = await scrapeGlobalData(page, options, progress, globalStep);
   const groupDataList = await runPhase2(page, groupsToProcess, defaultGroup, progress);
 

--- a/apps/crawler/src/scraper.ts
+++ b/apps/crawler/src/scraper.ts
@@ -1,6 +1,11 @@
-import { formatJstDateTimeForDisplay } from "@mf-dashboard/date-utils";
+import { formatJstDateTimeForDisplay, getJstDateParts } from "@mf-dashboard/date-utils";
 import type { Group, ScrapedData } from "@mf-dashboard/db/types";
 import type { Page } from "playwright";
+import {
+  CRAWLER_STEPS,
+  normalizeCrawlerError,
+  type CrawlerProgressReporter,
+} from "./crawler-progress.js";
 import { log, warn, phase } from "./logger.js";
 import { getAssetHistory } from "./scrapers/asset-history.js";
 import { getAssetItems } from "./scrapers/asset-items.js";
@@ -15,7 +20,7 @@ import {
 } from "./scrapers/group.js";
 import { getLiabilities } from "./scrapers/liabilities.js";
 import { getPortfolio } from "./scrapers/portfolio.js";
-import { clickRefreshButton } from "./scrapers/refresh.js";
+import { clickRefreshButton, getMaxWaitMinutes } from "./scrapers/refresh.js";
 import { getRegisteredAccounts } from "./scrapers/registered-accounts.js";
 import { getSpendingTargets } from "./scrapers/spending-targets.js";
 import type { ScrapeOptions } from "./types.js";
@@ -62,40 +67,87 @@ export interface ScrapeResult {
  * - liabilities
  * - cashFlow
  */
-async function scrapeGlobalData(page: Page, options: ScrapeOptions): Promise<GlobalData> {
+async function scrapeGlobalData(
+  page: Page,
+  options: ScrapeOptions,
+  progress: CrawlerProgressReporter,
+): Promise<GlobalData> {
   const { skipRefresh = false } = options;
 
   // Refresh
   let refreshResult = null;
+  const refreshStep = await progress.startStep(CRAWLER_STEPS.refresh, {
+    maxWaitMinutes: getMaxWaitMinutes(),
+  });
   if (skipRefresh) {
     log("Skipping refresh (SKIP_REFRESH=true)");
+    await progress.completeStep(refreshStep, { skipped: "true" });
   } else {
-    refreshResult = await clickRefreshButton(page);
+    try {
+      refreshResult = await clickRefreshButton(page, {
+        onWaiting: (waiting) =>
+          progress.updateWaiting(refreshStep, "更新中の金融機関が0件になるのを待機", {
+            ...waiting,
+          }),
+      });
+      if (refreshResult.completed) {
+        await progress.completeStep(refreshStep, { remainingCount: 0 });
+      } else {
+        await progress.warnStep(
+          refreshStep,
+          {
+            code: "refresh_timeout",
+            message: "金融機関の一括更新が待機時間を超えました",
+          },
+          {
+            maxWaitMinutes: getMaxWaitMinutes(),
+            remainingCount: refreshResult.remainingCount ?? refreshResult.incompleteAccounts.length,
+            incompleteAccounts: refreshResult.incompleteAccounts,
+          },
+        );
+      }
+    } catch (error) {
+      await progress.failStep(refreshStep, normalizeCrawlerError(error, "refresh_failed"));
+      throw error;
+    }
   }
 
-  // 全アカウント情報
-  const registeredAccounts = await getRegisteredAccounts(page);
-  log(`Registered accounts: ${registeredAccounts.accounts.length}`);
+  const globalStep = await progress.startStep(CRAWLER_STEPS.globalData);
+  let registeredAccounts: Awaited<ReturnType<typeof getRegisteredAccounts>>;
+  let portfolio: Awaited<ReturnType<typeof getPortfolio>>;
+  let liabilities: Awaited<ReturnType<typeof getLiabilities>>;
+  try {
+    // 全アカウント情報
+    registeredAccounts = await getRegisteredAccounts(page);
+    log(`Registered accounts: ${registeredAccounts.accounts.length}`);
 
-  // Portfolio
-  const portfolio = await getPortfolio(page);
-  log(`Portfolio: ${portfolio.items.length} items`);
+    // Portfolio
+    portfolio = await getPortfolio(page);
+    log(`Portfolio: ${portfolio.items.length} items`);
 
-  // Liabilities
-  const liabilities = await getLiabilities(page);
-  log(`Liabilities: ${liabilities.items.length} items`);
+    // Liabilities
+    liabilities = await getLiabilities(page);
+    log(`Liabilities: ${liabilities.items.length} items`);
+    await progress.completeStep(globalStep);
+  } catch (error) {
+    await progress.failStep(globalStep, normalizeCrawlerError(error, "global_data_failed"));
+    throw error;
+  }
 
-  // CashFlow
-  const cashFlow = await getCashFlow(page);
-  log(`CashFlow: ${cashFlow.items.length} items`);
+  const { year, month: monthNumber } = getJstDateParts();
+  const month = `${year}-${String(monthNumber).padStart(2, "0")}`;
+  const cashFlowStep = await progress.startStep(CRAWLER_STEPS.monthlyCashFlow, { month });
+  let cashFlow: Awaited<ReturnType<typeof getCashFlow>>;
+  try {
+    cashFlow = await getCashFlow(page);
+    await progress.completeStep(cashFlowStep, { month: cashFlow.month });
+    log(`CashFlow: ${cashFlow.items.length} items`);
+  } catch (error) {
+    await progress.failStep(cashFlowStep, normalizeCrawlerError(error, "monthly_cash_flow_failed"));
+    throw error;
+  }
 
-  return {
-    registeredAccounts,
-    portfolio,
-    liabilities,
-    cashFlow,
-    refreshResult,
-  };
+  return { registeredAccounts, portfolio, liabilities, cashFlow, refreshResult };
 }
 
 // ============================================================
@@ -152,16 +204,11 @@ function buildGroupsToProcess(allGroups: Group[]): Group[] {
     : [{ id: NO_GROUP_ID, name: "グループ選択なし", isCurrent: false }, ...allGroups];
 }
 
-async function runPhase1(page: Page, options: ScrapeOptions): Promise<GlobalData> {
-  phase("Scrape: Global Data");
-  await switchGroup(page, NO_GROUP_ID);
-  return scrapeGlobalData(page, options);
-}
-
 async function runPhase2(
   page: Page,
   groupsToProcess: Group[],
   defaultGroup: Group | null,
+  progress: CrawlerProgressReporter,
 ): Promise<GroupData[]> {
   phase("Scrape: Group Data");
   const groupDataList: GroupData[] = [];
@@ -179,8 +226,15 @@ async function runPhase2(
       isCurrent: groupId === defaultGroup?.id,
     };
 
-    const groupData = await scrapeGroupData(page, group);
-    groupDataList.push(groupData);
+    const groupStep = await progress.startStep(CRAWLER_STEPS.groupData, { groupName });
+    try {
+      const groupData = await scrapeGroupData(page, group);
+      groupDataList.push(groupData);
+      await progress.completeStep(groupStep);
+    } catch (error) {
+      await progress.failStep(groupStep, normalizeCrawlerError(error, "group_data_failed"));
+      throw error;
+    }
   }
 
   return groupDataList;
@@ -201,6 +255,7 @@ async function runPhase2(
  */
 export async function scrapeAllGroups(
   page: Page,
+  progress: CrawlerProgressReporter,
   options: ScrapeOptions = {},
 ): Promise<ScrapeResult> {
   // 現在のグループを記憶
@@ -213,8 +268,10 @@ export async function scrapeAllGroups(
 
   const groupsToProcess = buildGroupsToProcess(allGroups);
 
-  const globalData = await runPhase1(page, options);
-  const groupDataList = await runPhase2(page, groupsToProcess, defaultGroup);
+  phase("Scrape: Global Data");
+  await switchGroup(page, NO_GROUP_ID);
+  const globalData = await scrapeGlobalData(page, options, progress);
+  const groupDataList = await runPhase2(page, groupsToProcess, defaultGroup, progress);
 
   return {
     globalData,

--- a/apps/crawler/src/scraper.ts
+++ b/apps/crawler/src/scraper.ts
@@ -119,6 +119,8 @@ async function scrapeGlobalData(
   let portfolio: Awaited<ReturnType<typeof getPortfolio>>;
   let liabilities: Awaited<ReturnType<typeof getLiabilities>>;
   try {
+    await switchGroup(page, NO_GROUP_ID);
+
     // 全アカウント情報
     registeredAccounts = await getRegisteredAccounts(page);
     log(`Registered accounts: ${registeredAccounts.accounts.length}`);
@@ -270,7 +272,6 @@ export async function scrapeAllGroups(
   const groupsToProcess = buildGroupsToProcess(allGroups);
 
   phase("Scrape: Global Data");
-  await switchGroup(page, NO_GROUP_ID);
   const globalData = await scrapeGlobalData(page, options, progress);
   const groupDataList = await runPhase2(page, groupsToProcess, defaultGroup, progress);
 

--- a/apps/crawler/src/scrapers/cash-flow-history.test.ts
+++ b/apps/crawler/src/scrapers/cash-flow-history.test.ts
@@ -82,7 +82,7 @@ describe("scrapeCashFlowMonth", () => {
 
   test("前月 navigation の失敗を対象月の callback に通知する", async () => {
     page = await browser.newPage();
-    page.setDefaultTimeout(50);
+    page.setDefaultTimeout(500);
     try {
       await page.route("https://moneyforward.com/cf**", async (route) => {
         await route.fulfill({

--- a/apps/crawler/src/scrapers/cash-flow-history.test.ts
+++ b/apps/crawler/src/scrapers/cash-flow-history.test.ts
@@ -1,6 +1,10 @@
 import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
-import { buildMonthRange, scrapeCashFlowMonth } from "./cash-flow-history.js";
+import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
+import {
+  buildMonthRange,
+  scrapeCashFlowHistory,
+  scrapeCashFlowMonth,
+} from "./cash-flow-history.js";
 
 describe("buildMonthRange", () => {
   test.each([
@@ -71,6 +75,32 @@ describe("scrapeCashFlowMonth", () => {
         balance: 0,
         items: [],
       });
+    } finally {
+      await page.close();
+    }
+  });
+
+  test("前月 navigation の失敗を対象月の callback に通知する", async () => {
+    page = await browser.newPage();
+    page.setDefaultTimeout(50);
+    try {
+      await page.route("https://moneyforward.com/cf**", async (route) => {
+        await route.fulfill({
+          contentType: "text/html",
+          body: `
+            <a href="/cf/csv?year=2026&month=7">CSV</a>
+            <button class="fc-button-prev">前月</button>
+            <table id="monthly_total_table_kakeibo"><tbody><tr>
+              <td>¥0</td><td></td><td>¥0</td><td></td><td>¥0</td>
+            </tr></tbody></table>
+            <table id="cf-detail-table"><tbody><tr><td>placeholder</td></tr></tbody></table>
+          `,
+        });
+      });
+      const onMonthFailure = vi.fn<(month: string, error: unknown) => void>();
+
+      await expect(scrapeCashFlowHistory(page, 2, { onMonthFailure })).rejects.toThrow(/Timeout/);
+      expect(onMonthFailure).toHaveBeenCalledWith("2026-07", expect.any(Error));
     } finally {
       await page.close();
     }

--- a/apps/crawler/src/scrapers/cash-flow-history.ts
+++ b/apps/crawler/src/scrapers/cash-flow-history.ts
@@ -297,35 +297,35 @@ export async function scrapeCashFlowHistory(
   for (let i = 0; i < monthsToScrape; i++) {
     const targetMonth = (await getMonthFromCsvLink(page)) ?? getHistoryMonth(new Date(), i);
     await callbacks.onMonthStart?.(targetMonth);
-    let data: CashFlowSummary;
     try {
-      data = await extractCashFlowFromPage(page);
+      const data = await extractCashFlowFromPage(page);
+      results.push({ month: data.month, data });
+      log(`  ${data.month}: ${data.items.length} transactions`);
+
+      if (i < monthsToScrape - 1) {
+        const currentMonth = await getMonthFromCsvLink(page);
+        const prevButton = page.locator("button.fc-button-prev, span.fc-button-prev").first();
+
+        // 月が変わるまで待機（CSV linkのURLパラメータで判定）
+        // クリックで /cf/fetch が発火するため、取りこぼさないよう先にリスナーを登録し、
+        // レスポンス到着後にCSV linkの月パラメータが変わったかを確認する
+        await Promise.all([
+          page.waitForResponse((res) => res.url().includes("/cf/fetch") && res.status() === 200),
+          prevButton.click(),
+        ]);
+
+        // /cf/fetch 後も月が変わらなければ、これ以上データがないことを意味する
+        const newMonth = await getMonthFromCsvLink(page);
+        if (newMonth === currentMonth) {
+          log(`  No more months available after ${currentMonth}, stopping.`);
+          await callbacks.onMonthComplete?.(targetMonth);
+          break;
+        }
+      }
       await callbacks.onMonthComplete?.(targetMonth);
     } catch (error) {
       await callbacks.onMonthFailure?.(targetMonth, error);
       throw error;
-    }
-    results.push({ month: data.month, data });
-    log(`  ${data.month}: ${data.items.length} transactions`);
-
-    if (i < monthsToScrape - 1) {
-      const currentMonth = await getMonthFromCsvLink(page);
-      const prevButton = page.locator("button.fc-button-prev, span.fc-button-prev").first();
-
-      // 月が変わるまで待機（CSV linkのURLパラメータで判定）
-      // クリックで /cf/fetch が発火するため、取りこぼさないよう先にリスナーを登録し、
-      // レスポンス到着後にCSV linkの月パラメータが変わったかを確認する
-      await Promise.all([
-        page.waitForResponse((res) => res.url().includes("/cf/fetch") && res.status() === 200),
-        prevButton.click(),
-      ]);
-
-      // /cf/fetch 後も月が変わらなければ、これ以上データがないことを意味する
-      const newMonth = await getMonthFromCsvLink(page);
-      if (newMonth === currentMonth) {
-        log(`  No more months available after ${currentMonth}, stopping.`);
-        break;
-      }
     }
   }
 

--- a/apps/crawler/src/scrapers/cash-flow-history.ts
+++ b/apps/crawler/src/scrapers/cash-flow-history.ts
@@ -299,7 +299,7 @@ export async function scrapeCashFlowHistory(
     await callbacks.onMonthStart?.(targetMonth);
     try {
       const data = await extractCashFlowFromPage(page);
-      results.push({ month: data.month, data });
+      results.push({ month: data.month, progressMonth: targetMonth, data });
       log(`  ${data.month}: ${data.items.length} transactions`);
 
       if (i < monthsToScrape - 1) {

--- a/apps/crawler/src/scrapers/cash-flow-history.ts
+++ b/apps/crawler/src/scrapers/cash-flow-history.ts
@@ -2,6 +2,7 @@ import { getJstDateParts } from "@mf-dashboard/date-utils";
 import type { CashFlowSummary, CashFlowItem } from "@mf-dashboard/db/types";
 import { mfUrls } from "@mf-dashboard/meta/urls";
 import type { Locator, Page } from "playwright";
+import { getHistoryMonth } from "../history-months.js";
 import { log, debug } from "../logger.js";
 import { parseJapaneseNumber, convertDateToIso } from "../parsers.js";
 import type { CashFlowHistoryResult } from "../types.js";
@@ -279,6 +280,11 @@ async function getMonthFromCsvLink(page: Page): Promise<string | null> {
 export async function scrapeCashFlowHistory(
   page: Page,
   monthsToScrape: number = 12,
+  callbacks: {
+    onMonthStart?: (month: string) => Promise<void> | void;
+    onMonthComplete?: (month: string) => Promise<void> | void;
+    onMonthFailure?: (month: string, error: unknown) => Promise<void> | void;
+  } = {},
 ): Promise<CashFlowHistoryResult[]> {
   log(`Scraping cash flow history for ${monthsToScrape} months...`);
 
@@ -289,7 +295,16 @@ export async function scrapeCashFlowHistory(
   const results: CashFlowHistoryResult[] = [];
 
   for (let i = 0; i < monthsToScrape; i++) {
-    const data = await extractCashFlowFromPage(page);
+    const targetMonth = (await getMonthFromCsvLink(page)) ?? getHistoryMonth(new Date(), i);
+    await callbacks.onMonthStart?.(targetMonth);
+    let data: CashFlowSummary;
+    try {
+      data = await extractCashFlowFromPage(page);
+      await callbacks.onMonthComplete?.(targetMonth);
+    } catch (error) {
+      await callbacks.onMonthFailure?.(targetMonth, error);
+      throw error;
+    }
     results.push({ month: data.month, data });
     log(`  ${data.month}: ${data.items.length} transactions`);
 

--- a/apps/crawler/src/scrapers/refresh.test.ts
+++ b/apps/crawler/src/scrapers/refresh.test.ts
@@ -1,6 +1,19 @@
 import { chromium, type Browser, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
-import { getRefreshStatus, navigateToAccountsPage } from "./refresh.js";
+import { getMaxWaitMinutes, getRefreshStatus, navigateToAccountsPage } from "./refresh.js";
+
+describe("getMaxWaitMinutes", () => {
+  test.each([undefined, "", "0", "-1", "Infinity", "NaN"])(
+    "invalid MAX_WAIT_MINUTES=%s は default 値を返す",
+    (value) => {
+      expect(getMaxWaitMinutes({ MAX_WAIT_MINUTES: value })).toBe(20);
+    },
+  );
+
+  test("有限の正数を返す", () => {
+    expect(getMaxWaitMinutes({ MAX_WAIT_MINUTES: "12.5" })).toBe(12.5);
+  });
+});
 
 describe("refresh - 更新中セレクタ", () => {
   let browser: Browser;

--- a/apps/crawler/src/scrapers/refresh.test.ts
+++ b/apps/crawler/src/scrapers/refresh.test.ts
@@ -1,6 +1,6 @@
 import { chromium, type Browser, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
-import { navigateToAccountsPage } from "./refresh.js";
+import { getRefreshStatus, navigateToAccountsPage } from "./refresh.js";
 
 describe("refresh - 更新中セレクタ", () => {
   let browser: Browser;
@@ -69,6 +69,21 @@ describe("refresh - 更新中セレクタ", () => {
     }
 
     expect(updatingCount).toBe(2);
+  });
+
+  test("同じ行に非表示の正常セルがあっても更新中として数える", async () => {
+    await page.setContent(`
+      <table id="account-table"><tbody><tr>
+        <td class="service"><a>Institution A</a></td>
+        <td class="account-status">更新中</td>
+        <td class="account-status" hidden>正常</td>
+      </tr></tbody></table>
+    `);
+
+    await expect(getRefreshStatus(page)).resolves.toEqual({
+      incompleteAccounts: ["Institution A"],
+      remainingCount: 1,
+    });
   });
 
   test("更新中のアカウントがない場合は0を返す", async () => {

--- a/apps/crawler/src/scrapers/refresh.ts
+++ b/apps/crawler/src/scrapers/refresh.ts
@@ -72,8 +72,11 @@ interface RefreshOptions {
   onWaiting?: (progress: RefreshWaitProgress) => Promise<void> | void;
 }
 
-export function getMaxWaitMinutes(): number {
-  return Number(process.env.MAX_WAIT_MINUTES) || DEFAULT_MAX_WAIT_MINUTES;
+export function getMaxWaitMinutes(env: NodeJS.ProcessEnv = process.env): number {
+  const configuredValue = Number(env.MAX_WAIT_MINUTES);
+  return Number.isFinite(configuredValue) && configuredValue > 0
+    ? configuredValue
+    : DEFAULT_MAX_WAIT_MINUTES;
 }
 
 export async function clickRefreshButton(

--- a/apps/crawler/src/scrapers/refresh.ts
+++ b/apps/crawler/src/scrapers/refresh.ts
@@ -4,8 +4,6 @@ import type { Page } from "playwright";
 import { debug, info, warn } from "../logger.js";
 
 const DEFAULT_MAX_WAIT_MINUTES = 20;
-const MAX_WAIT_TIME_MS =
-  (Number(process.env.MAX_WAIT_MINUTES) || DEFAULT_MAX_WAIT_MINUTES) * 60 * 1000; // default: 20 minutes
 const POLL_INTERVAL_MS = 30000; // 30 seconds
 const NAVIGATION_RETRY_DELAY_MS = 1000;
 
@@ -34,10 +32,13 @@ export async function navigateToAccountsPage(page: Page): Promise<void> {
   }
 }
 
-async function getUpdatingAccounts(page: Page): Promise<string[]> {
+async function getRefreshStatus(
+  page: Page,
+): Promise<{ incompleteAccounts: string[]; remainingCount: number }> {
   const rows = page.locator("#account-table tr:has(td.account-status)");
   const count = await rows.count();
-  const updatingAccounts: string[] = [];
+  const incompleteAccounts: string[] = [];
+  let remainingCount = 0;
 
   for (let i = 0; i < count; i++) {
     const row = rows.nth(i);
@@ -48,18 +49,43 @@ async function getUpdatingAccounts(page: Page): Promise<string[]> {
 
     // Only count as updating if it exactly matches "更新中"
     if (statusText?.trim() === "更新中") {
+      remainingCount++;
       const nameCell = row.locator("td.service a").first();
       const name = await nameCell.textContent();
       if (name) {
-        updatingAccounts.push(name.trim());
+        incompleteAccounts.push(name.trim());
       }
     }
   }
 
-  return updatingAccounts;
+  return { incompleteAccounts, remainingCount };
 }
 
-export async function clickRefreshButton(page: Page): Promise<RefreshResult> {
+export interface RefreshWaitProgress {
+  elapsedSeconds: number;
+  incompleteAccounts: string[];
+  maxWaitMinutes: number;
+  nextCheckSeconds: number;
+  remainingCount: number;
+}
+
+interface RefreshOptions {
+  maxWaitMinutes?: number;
+  pollIntervalMs?: number;
+  onWaiting?: (progress: RefreshWaitProgress) => Promise<void> | void;
+}
+
+export function getMaxWaitMinutes(): number {
+  return Number(process.env.MAX_WAIT_MINUTES) || DEFAULT_MAX_WAIT_MINUTES;
+}
+
+export async function clickRefreshButton(
+  page: Page,
+  options: RefreshOptions = {},
+): Promise<RefreshResult> {
+  const maxWaitMinutes = options.maxWaitMinutes ?? getMaxWaitMinutes();
+  const maxWaitTimeMs = maxWaitMinutes * 60 * 1000;
+  const pollIntervalMs = options.pollIntervalMs ?? POLL_INTERVAL_MS;
   debug("Looking for refresh button...");
 
   // Navigate to home and click refresh button
@@ -81,40 +107,37 @@ export async function clickRefreshButton(page: Page): Promise<RefreshResult> {
 
   const startTime = Date.now();
 
-  while (Date.now() - startTime < MAX_WAIT_TIME_MS) {
-    // Count accounts with "更新中" status (exclude cells that also have "正常" - hidden text)
-    const statusCells = page.locator("#account-table td.account-status");
-    const cellCount = await statusCells.count();
-    let updatingCount = 0;
-
-    for (let i = 0; i < cellCount; i++) {
-      const text = await statusCells.nth(i).textContent();
-      if (text?.trim() === "更新中") {
-        updatingCount++;
-      }
-    }
-
+  while (Date.now() - startTime < maxWaitTimeMs) {
+    const { incompleteAccounts, remainingCount } = await getRefreshStatus(page);
     const elapsed = Math.round((Date.now() - startTime) / 1000);
-    info(`[${elapsed}s] 残り: ${updatingCount}`);
+    info(`[${elapsed}s] 残り: ${remainingCount}`);
 
-    if (updatingCount === 0) {
+    await options.onWaiting?.({
+      elapsedSeconds: elapsed,
+      incompleteAccounts,
+      maxWaitMinutes,
+      nextCheckSeconds: Math.round(pollIntervalMs / 1000),
+      remainingCount,
+    });
+
+    if (remainingCount === 0) {
       info("All updates completed!");
       return { completed: true, incompleteAccounts: [] };
     }
 
     // Wait and navigate to accounts page again to get fresh status
     // Using goto instead of reload to avoid ERR_ABORTED when frame is detached
-    await page.waitForTimeout(POLL_INTERVAL_MS);
+    await page.waitForTimeout(pollIntervalMs);
     await navigateToAccountsPage(page);
   }
 
   // Timeout: get list of accounts still updating
-  const incompleteAccounts = await getUpdatingAccounts(page);
+  const { incompleteAccounts, remainingCount } = await getRefreshStatus(page);
 
   warn(`Max wait time exceeded. ${incompleteAccounts.length} accounts still updating:`);
   for (const account of incompleteAccounts) {
     warn(`  - ${account}`);
   }
 
-  return { completed: false, incompleteAccounts };
+  return { completed: false, incompleteAccounts, remainingCount };
 }

--- a/apps/crawler/src/scrapers/refresh.ts
+++ b/apps/crawler/src/scrapers/refresh.ts
@@ -32,7 +32,7 @@ export async function navigateToAccountsPage(page: Page): Promise<void> {
   }
 }
 
-async function getRefreshStatus(
+export async function getRefreshStatus(
   page: Page,
 ): Promise<{ incompleteAccounts: string[]; remainingCount: number }> {
   const rows = page.locator("#account-table tr:has(td.account-status)");
@@ -45,10 +45,7 @@ async function getRefreshStatus(
     const statusCells = row.locator("td.account-status");
     // Multiple td.account-status cells may exist in the same row (e.g., info_msg and normal)
     const allTexts = await statusCells.allTextContents();
-    const statusText = allTexts.join(" ");
-
-    // Only count as updating if it exactly matches "更新中"
-    if (statusText?.trim() === "更新中") {
+    if (allTexts.some((text) => text.trim() === "更新中")) {
       remainingCount++;
       const nameCell = row.locator("td.service a").first();
       const name = await nameCell.textContent();

--- a/apps/crawler/src/server.test.ts
+++ b/apps/crawler/src/server.test.ts
@@ -2,7 +2,7 @@ import type { Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { CrawlerAlreadyRunningError, type CrawlerRunState } from "./crawler-run-lock.js";
-import { createCrawlerTriggerServer } from "./server.js";
+import { createCrawlerTriggerServer, recordManualRunFailure } from "./server.js";
 
 const runningState: CrawlerRunState = {
   running: true,
@@ -40,6 +40,15 @@ async function listen(testServer: Server): Promise<string> {
 }
 
 describe("crawler trigger server", () => {
+  test("terminal state の保存失敗を detached run へ再送出しない", async () => {
+    const progress = {
+      finish: vi.fn<() => Promise<void>>().mockRejectedValue(new Error("disk full")),
+    } as unknown as Parameters<typeof recordManualRunFailure>[0];
+
+    await expect(recordManualRunFailure(progress)).resolves.toBeUndefined();
+    expect(progress.finish).toHaveBeenCalledWith("failed");
+  });
+
   test("returns crawler status", async () => {
     const baseUrl = await listen(createCrawlerTriggerServer({ getState: async () => idleState }));
 

--- a/apps/crawler/src/server.ts
+++ b/apps/crawler/src/server.ts
@@ -1,6 +1,11 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { pathToFileURL } from "node:url";
 import {
+  createCrawlerProgressReporter,
+  DEFAULT_CRAWLER_STATE_PATH,
+  normalizeCrawlerError,
+} from "./crawler-progress.js";
+import {
   acquireCrawlerRunLock,
   CrawlerAlreadyRunningError,
   getCrawlerRunState,
@@ -27,25 +32,34 @@ function methodNotAllowed(response: ServerResponse): void {
 
 export async function startCrawlerRun(): Promise<CrawlerRunState> {
   const lock = await acquireCrawlerRunLock("manual");
-  const state: CrawlerRunState = {
-    running: true,
-    pid: lock.record.pid,
-    source: lock.record.source,
-    startedAt: lock.record.startedAt,
-  };
+  let progress: Awaited<ReturnType<typeof createCrawlerProgressReporter>>;
+  try {
+    progress = await createCrawlerProgressReporter(
+      process.env.CRAWLER_STATE_PATH ?? DEFAULT_CRAWLER_STATE_PATH,
+      lock.record,
+    );
+  } catch (err) {
+    await lock.release();
+    throw err;
+  }
 
   void (async () => {
     try {
       const { runCrawler } = await import("./run.js");
-      await runCrawler();
+      await runCrawler(progress);
+      await progress.finish("success");
     } catch (err) {
+      await progress.finish(
+        "failed",
+        progress.getState().reason ?? normalizeCrawlerError(err, "run_failed"),
+      );
       error("Manual crawler run failed:", err);
     } finally {
       await lock.release();
     }
   })();
 
-  return state;
+  return progress.getState();
 }
 
 export function createCrawlerTriggerServer(options: CrawlerTriggerServerOptions = {}): Server {

--- a/apps/crawler/src/server.ts
+++ b/apps/crawler/src/server.ts
@@ -17,6 +17,16 @@ interface CrawlerTriggerServerOptions {
   startRun?: () => Promise<CrawlerRunState>;
 }
 
+type ProgressReporter = Awaited<ReturnType<typeof createCrawlerProgressReporter>>;
+
+export async function recordManualRunFailure(progress: ProgressReporter): Promise<void> {
+  try {
+    await progress.finish("failed");
+  } catch (err) {
+    error("Failed to record manual crawler failure:", err);
+  }
+}
+
 function json(response: ServerResponse, status: number, body: unknown): void {
   response.writeHead(status, { "content-type": "application/json" });
   response.end(JSON.stringify(body));
@@ -46,7 +56,7 @@ export async function startCrawlerRun(): Promise<CrawlerRunState> {
       await runCrawler(progress);
       await progress.finish("success");
     } catch (err) {
-      await progress.finish("failed");
+      await recordManualRunFailure(progress);
       error("Manual crawler run failed:", err);
     } finally {
       await lock.release();

--- a/apps/crawler/src/server.ts
+++ b/apps/crawler/src/server.ts
@@ -1,16 +1,13 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { pathToFileURL } from "node:url";
-import {
-  createCrawlerProgressReporter,
-  DEFAULT_CRAWLER_STATE_PATH,
-  normalizeCrawlerError,
-} from "./crawler-progress.js";
+import { createCrawlerProgressReporter } from "./crawler-progress.js";
 import {
   acquireCrawlerRunLock,
   CrawlerAlreadyRunningError,
   getCrawlerRunState,
   type CrawlerRunState,
 } from "./crawler-run-lock.js";
+import { getCrawlerRunStatePath } from "./crawler-run-state.js";
 import { error, info } from "./logger.js";
 
 const DEFAULT_PORT = 8766;
@@ -35,7 +32,7 @@ export async function startCrawlerRun(): Promise<CrawlerRunState> {
   let progress: Awaited<ReturnType<typeof createCrawlerProgressReporter>>;
   try {
     progress = await createCrawlerProgressReporter(
-      process.env.CRAWLER_STATE_PATH ?? DEFAULT_CRAWLER_STATE_PATH,
+      process.env.CRAWLER_STATE_PATH ?? getCrawlerRunStatePath(),
       lock.record,
     );
   } catch (err) {
@@ -49,17 +46,14 @@ export async function startCrawlerRun(): Promise<CrawlerRunState> {
       await runCrawler(progress);
       await progress.finish("success");
     } catch (err) {
-      await progress.finish(
-        "failed",
-        progress.getState().reason ?? normalizeCrawlerError(err, "run_failed"),
-      );
+      await progress.finish("failed");
       error("Manual crawler run failed:", err);
     } finally {
       await lock.release();
     }
   })();
 
-  return progress.getState();
+  return { ...progress.getState(), running: true, pid: lock.record.pid };
 }
 
 export function createCrawlerTriggerServer(options: CrawlerTriggerServerOptions = {}): Server {

--- a/apps/crawler/src/server.ts
+++ b/apps/crawler/src/server.ts
@@ -61,7 +61,9 @@ export async function startCrawlerRun(): Promise<CrawlerRunState> {
     } finally {
       await lock.release();
     }
-  })();
+  })().catch((err) => {
+    error("Manual crawler run finalization failed:", err);
+  });
 
   return { ...progress.getState(), running: true, pid: lock.record.pid };
 }

--- a/apps/crawler/src/types.ts
+++ b/apps/crawler/src/types.ts
@@ -20,5 +20,6 @@ export interface ScrapeOptions {
 
 export interface CashFlowHistoryResult {
   month: string;
+  progressMonth?: string;
   data: CashFlowSummary;
 }

--- a/apps/crawler/tests/e2e/db-save-groups.test.ts
+++ b/apps/crawler/tests/e2e/db-save-groups.test.ts
@@ -1,9 +1,13 @@
+import { randomUUID } from "node:crypto";
+import { rm } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { getDb, schema } from "@mf-dashboard/db";
 import { saveScrapedData, saveGroupOnlyData } from "@mf-dashboard/db/repository/save-scraped-data";
 import { eq } from "drizzle-orm";
 import type { Browser, BrowserContext } from "playwright";
 import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { createCrawlerProgressReporter } from "../../src/crawler-progress.js";
 import { buildScrapedData, buildGroupOnlyScrapedData } from "../../src/data-builder.js";
 import type { ScrapeResult } from "../../src/scraper.js";
 import { scrapeAllGroups } from "../../src/scraper.js";
@@ -20,6 +24,7 @@ import {
 
 const TEST_DB_DIR = path.resolve(process.cwd(), "tests/e2e");
 const TEST_DB_PATH = path.join(TEST_DB_DIR, "test-groups-moneyforward.db");
+const PROGRESS_STATE_PATH = path.join(os.tmpdir(), `db-save-groups-${randomUUID()}.json`);
 
 let browser: Browser;
 let context: BrowserContext;
@@ -38,7 +43,12 @@ beforeAll(async () => {
     return withErrorScreenshot(page, "db-save-groups-test-error.png", async () => {
       await using _scope = await createGroupScope(page);
 
-      const result = await scrapeAllGroups(page, { skipRefresh: true });
+      const progress = await createCrawlerProgressReporter(PROGRESS_STATE_PATH, {
+        id: randomUUID(),
+        source: "e2e",
+        startedAt: new Date().toISOString(),
+      });
+      const result = await scrapeAllGroups(page, progress, { skipRefresh: true });
 
       // 保存処理（index.ts と同じフロー）
       const db = getDb();
@@ -67,6 +77,7 @@ afterAll(async () => {
   await browser?.close();
   // テスト後にクリーンアップ
   cleanupTestDb(TEST_DB_PATH);
+  await rm(PROGRESS_STATE_PATH, { force: true });
 });
 
 describe("グループ保存（新フロー）", () => {

--- a/apps/crawler/tests/e2e/scrape-all-groups.test.ts
+++ b/apps/crawler/tests/e2e/scrape-all-groups.test.ts
@@ -1,5 +1,10 @@
+import { randomUUID } from "node:crypto";
+import { rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import type { Browser, BrowserContext } from "playwright";
 import { describe, test, expect, beforeAll, afterAll } from "vitest";
+import { createCrawlerProgressReporter } from "../../src/crawler-progress.js";
 import type { ScrapeResult } from "../../src/scraper.js";
 import { scrapeAllGroups } from "../../src/scraper.js";
 import { isNoGroup, createGroupScope } from "../../src/scrapers/group.js";
@@ -14,6 +19,7 @@ import {
 let browser: Browser;
 let context: BrowserContext;
 let result: ScrapeResult;
+const progressStatePath = path.join(os.tmpdir(), `scrape-all-groups-${randomUUID()}.json`);
 
 beforeAll(async () => {
   ({ browser, context } = await launchLoggedInContext());
@@ -23,7 +29,12 @@ beforeAll(async () => {
 
     return withErrorScreenshot(page, "scrape-all-groups-test-error.png", async () => {
       await using _scope = await createGroupScope(page);
-      return scrapeAllGroups(page, { skipRefresh: true });
+      const progress = await createCrawlerProgressReporter(progressStatePath, {
+        id: randomUUID(),
+        source: "e2e",
+        startedAt: new Date().toISOString(),
+      });
+      return scrapeAllGroups(page, progress, { skipRefresh: true });
     });
   });
 }, 300000);
@@ -31,6 +42,7 @@ beforeAll(async () => {
 afterAll(async () => {
   await context?.close();
   await browser?.close();
+  await rm(progressStatePath, { force: true });
 });
 
 describe("scrapeAllGroups", () => {

--- a/apps/web/src/components/layout/action-icons.test.tsx
+++ b/apps/web/src/components/layout/action-icons.test.tsx
@@ -140,6 +140,50 @@ describe("ActionIcons", () => {
     expect(refreshMock).not.toHaveBeenCalled();
   });
 
+  it("shows the current waiting reason while the crawler is running", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({
+        available: true,
+        running: true,
+        runStatus: "running",
+        current: {
+          label: "金融機関データを一括更新",
+          metadata: { remainingCount: 2 },
+        },
+        waitingFor: "更新中の金融機関が0件になるのを待機",
+      }),
+    );
+
+    render(<ActionIcons variant="header" />);
+
+    const refreshButton = screen.getByRole("button", { name: "金融機関データを更新" });
+    await waitFor(() =>
+      expect(refreshButton.getAttribute("title")).toBe(
+        "更新中（更新中の金融機関が0件になるのを待機）",
+      ),
+    );
+  });
+
+  it("shows the latest safe failure reason after the crawler stops", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({
+        available: true,
+        running: false,
+        runStatus: "failed",
+        reason: { code: "auth_failed", message: "処理中にエラーが発生しました" },
+      }),
+    );
+
+    render(<ActionIcons variant="header" />);
+
+    const refreshButton = screen.getByRole("button", { name: "金融機関データを更新" });
+    await waitFor(() =>
+      expect(refreshButton.getAttribute("title")).toBe(
+        "前回の更新に失敗（処理中にエラーが発生しました）",
+      ),
+    );
+  });
+
   it("disables the header refresh button when the crawler service is unavailable", async () => {
     vi.mocked(global.fetch).mockResolvedValueOnce(
       jsonResponse({ available: false, running: false }, 503),

--- a/apps/web/src/components/layout/action-icons.test.tsx
+++ b/apps/web/src/components/layout/action-icons.test.tsx
@@ -79,6 +79,35 @@ describe("ActionIcons", () => {
     expect(refreshMock).not.toHaveBeenCalled();
   });
 
+  it("resets terminal progress while optimistically starting another run", async () => {
+    let resolveStart!: (response: Response) => void;
+    const startResponse = new Promise<Response>((resolve) => {
+      resolveStart = resolve;
+    });
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(
+        jsonResponse({
+          available: true,
+          running: false,
+          runStatus: "success",
+          progress: { completed: 10, total: 10 },
+        }),
+      )
+      .mockReturnValueOnce(startResponse);
+
+    render(<ActionIcons variant="header" />);
+    const refreshButton = screen.getByRole("button", { name: "金融機関データを更新" });
+    await waitFor(() => expect((refreshButton as HTMLButtonElement).disabled).toBe(false));
+
+    fireEvent.click(refreshButton);
+
+    await waitFor(() => expect(screen.getByText("同期中 · 0/10")).not.toBeNull());
+    resolveStart(
+      jsonResponse({ available: true, running: true, progress: { completed: 0, total: 10 } }, 202),
+    );
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(2));
+  });
+
   it("refreshes the dashboard after the crawler run finishes", async () => {
     const intervalCallbacks: Array<() => unknown> = [];
     const setIntervalSpy = vi.spyOn(window, "setInterval").mockImplementation((handler) => {

--- a/apps/web/src/components/layout/action-icons.test.tsx
+++ b/apps/web/src/components/layout/action-icons.test.tsx
@@ -151,6 +151,7 @@ describe("ActionIcons", () => {
           metadata: { remainingCount: 2 },
         },
         waitingFor: "更新中の金融機関が0件になるのを待機",
+        progress: { completed: 3, total: 10 },
       }),
     );
 
@@ -162,6 +163,7 @@ describe("ActionIcons", () => {
         "更新中（更新中の金融機関が0件になるのを待機）",
       ),
     );
+    expect(screen.getByText("同期中 · 3/10")).not.toBeNull();
   });
 
   it("shows the latest safe failure reason after the crawler stops", async () => {

--- a/apps/web/src/components/layout/action-icons.tsx
+++ b/apps/web/src/components/layout/action-icons.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import type {
   CrawlerRunCurrent,
+  CrawlerRunProgress,
   CrawlerRunReason,
   CrawlerRunStatus,
 } from "../../../../crawler/src/crawler-run-state";
@@ -29,6 +30,7 @@ interface CrawlerRefreshStatus {
   current: CrawlerRunCurrent | null;
   waitingFor: string | null;
   reason: CrawlerRunReason | null;
+  progress: CrawlerRunProgress | null;
 }
 
 interface CrawlerRefreshButtonState extends CrawlerRefreshStatus {
@@ -44,6 +46,7 @@ const unavailableStatus: CrawlerRefreshStatus = {
   current: null,
   waitingFor: null,
   reason: null,
+  progress: null,
 };
 
 function parseCrawlerRefreshStatus(
@@ -65,6 +68,12 @@ function parseCrawlerRefreshStatus(
     reason:
       body.reason && typeof body.reason.code === "string" && typeof body.reason.message === "string"
         ? body.reason
+        : null,
+    progress:
+      body.progress &&
+      Number.isInteger(body.progress.completed) &&
+      Number.isInteger(body.progress.total)
+        ? body.progress
         : null,
   };
 }
@@ -196,10 +205,20 @@ function RefreshButton({ iconSize }: { iconSize: string }) {
   const isBusy = state.isPending || state.running;
   const isDisabled = isBusy || !state.available;
   const title = getRefreshTitle(state);
+  const progress = state.progress ?? { completed: 0, total: 10 };
 
   return (
     <IconButton
-      icon={<RefreshCw className={`${iconSize} ${isBusy ? "animate-spin" : ""}`} />}
+      icon={
+        <span className="flex items-center gap-2">
+          <RefreshCw className={`${iconSize} ${isBusy ? "animate-spin" : ""}`} />
+          {state.running && (
+            <span className="whitespace-nowrap text-xs font-medium">
+              同期中 · {progress.completed}/{progress.total}
+            </span>
+          )}
+        </span>
+      }
       onClick={() => void startRefresh()}
       ariaLabel="金融機関データを更新"
       disabled={isDisabled}

--- a/apps/web/src/components/layout/action-icons.tsx
+++ b/apps/web/src/components/layout/action-icons.tsx
@@ -4,6 +4,11 @@ import { mfUrls } from "@mf-dashboard/meta/urls";
 import { Home, HelpCircle, RefreshCw } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState, type ReactNode } from "react";
+import type {
+  CrawlerRunCurrent,
+  CrawlerRunReason,
+  CrawlerRunStatus,
+} from "../../../../crawler/src/crawler-run-state";
 import { formatDateTime } from "../../lib/format";
 import { Dialog, DialogTrigger, DialogContent, DialogTitle, DialogDescription } from "../ui/dialog";
 import { IconButton } from "../ui/icon-button";
@@ -20,13 +25,10 @@ interface CrawlerRefreshStatus {
   running: boolean;
   startedAt: string | null;
   finishedAt: string | null;
-  runStatus: "running" | "success" | "failed" | null;
-  current: {
-    label: string;
-    metadata?: Record<string, string | number | string[]>;
-  } | null;
+  runStatus: CrawlerRunStatus | null;
+  current: CrawlerRunCurrent | null;
   waitingFor: string | null;
-  reason: { code: string; message: string } | null;
+  reason: CrawlerRunReason | null;
 }
 
 interface CrawlerRefreshButtonState extends CrawlerRefreshStatus {
@@ -86,8 +88,13 @@ function getRefreshTitle(state: CrawlerRefreshStatus): string {
     return "更新";
   }
 
-  const metadataTarget = state.current?.metadata?.groupName ?? state.current?.metadata?.month;
-  const currentTarget = typeof metadataTarget === "string" ? metadataTarget : null;
+  const metadata = state.current?.metadata;
+  let currentTarget: string | null = null;
+  if (metadata?.kind === "group") {
+    currentTarget = metadata.groupName;
+  } else if (metadata?.kind === "month") {
+    currentTarget = metadata.month;
+  }
   const current = state.current
     ? `${state.current.label}${currentTarget ? `: ${currentTarget}` : ""}`
     : null;

--- a/apps/web/src/components/layout/action-icons.tsx
+++ b/apps/web/src/components/layout/action-icons.tsx
@@ -177,7 +177,12 @@ function RefreshButton({ iconSize }: { iconSize: string }) {
       return;
     }
 
-    setState((prev) => ({ ...prev, running: true, isPending: true }));
+    setState((prev) => ({
+      ...prev,
+      running: true,
+      isPending: true,
+      progress: { completed: 0, total: 10 },
+    }));
 
     try {
       const res = await fetch("/api/crawler/refresh/", { method: "POST" });

--- a/apps/web/src/components/layout/action-icons.tsx
+++ b/apps/web/src/components/layout/action-icons.tsx
@@ -19,6 +19,14 @@ interface CrawlerRefreshStatus {
   available: boolean;
   running: boolean;
   startedAt: string | null;
+  finishedAt: string | null;
+  runStatus: "running" | "success" | "failed" | null;
+  current: {
+    label: string;
+    metadata?: Record<string, string | number | string[]>;
+  } | null;
+  waitingFor: string | null;
+  reason: { code: string; message: string } | null;
 }
 
 interface CrawlerRefreshButtonState extends CrawlerRefreshStatus {
@@ -29,17 +37,64 @@ const unavailableStatus: CrawlerRefreshStatus = {
   available: false,
   running: false,
   startedAt: null,
+  finishedAt: null,
+  runStatus: null,
+  current: null,
+  waitingFor: null,
+  reason: null,
 };
+
+function parseCrawlerRefreshStatus(
+  body: Partial<CrawlerRefreshStatus>,
+  available: boolean,
+): CrawlerRefreshStatus {
+  const runStatus = body.runStatus;
+  return {
+    available,
+    running: Boolean(body.running),
+    startedAt: typeof body.startedAt === "string" ? body.startedAt : null,
+    finishedAt: typeof body.finishedAt === "string" ? body.finishedAt : null,
+    runStatus:
+      runStatus === "running" || runStatus === "success" || runStatus === "failed"
+        ? runStatus
+        : null,
+    current: body.current && typeof body.current.label === "string" ? body.current : null,
+    waitingFor: typeof body.waitingFor === "string" ? body.waitingFor : null,
+    reason:
+      body.reason && typeof body.reason.code === "string" && typeof body.reason.message === "string"
+        ? body.reason
+        : null,
+  };
+}
 
 async function readCrawlerRefreshStatus(): Promise<CrawlerRefreshStatus> {
   const res = await fetch("/api/crawler/refresh/", { cache: "no-store" });
   const body = (await res.json().catch(() => ({}))) as Partial<CrawlerRefreshStatus>;
 
-  return {
-    available: res.ok && body.available !== false,
-    running: Boolean(body.running),
-    startedAt: typeof body.startedAt === "string" ? body.startedAt : null,
-  };
+  return parseCrawlerRefreshStatus(body, res.ok && body.available !== false);
+}
+
+function getRefreshTitle(state: CrawlerRefreshStatus): string {
+  if (!state.available) return "更新サービス未接続";
+  if (!state.running) {
+    if (state.runStatus === "failed" && state.reason) {
+      return `前回の更新に失敗（${state.reason.message}）`;
+    }
+    if (state.runStatus === "success" && state.finishedAt) {
+      return `前回の更新完了（${formatDateTime(state.finishedAt)}）`;
+    }
+    return "更新";
+  }
+
+  const metadataTarget = state.current?.metadata?.groupName ?? state.current?.metadata?.month;
+  const currentTarget = typeof metadataTarget === "string" ? metadataTarget : null;
+  const current = state.current
+    ? `${state.current.label}${currentTarget ? `: ${currentTarget}` : ""}`
+    : null;
+  const detail = state.waitingFor ?? current;
+  if (detail) return `更新中（${detail}）`;
+  if (state.startedAt) return `更新中（開始: ${formatDateTime(state.startedAt)}）`;
+  return "更新中";
 }
 
 export function ActionIcons({ variant, notifications }: ActionIconsProps) {
@@ -120,9 +175,10 @@ function RefreshButton({ iconSize }: { iconSize: string }) {
       const running = Boolean(body.running ?? true);
       wasRunningRef.current ||= running;
       setState({
-        available: body.available !== false,
-        running,
-        startedAt: typeof body.startedAt === "string" ? body.startedAt : null,
+        ...parseCrawlerRefreshStatus(
+          { ...body, running, runStatus: body.runStatus ?? "running" },
+          body.available !== false,
+        ),
         isPending: false,
       });
     } catch {
@@ -132,10 +188,7 @@ function RefreshButton({ iconSize }: { iconSize: string }) {
 
   const isBusy = state.isPending || state.running;
   const isDisabled = isBusy || !state.available;
-  let title = state.available ? "更新" : "更新サービス未接続";
-  if (state.running) {
-    title = state.startedAt ? `更新中（開始: ${formatDateTime(state.startedAt)}）` : "更新中";
-  }
+  const title = getRefreshTitle(state);
 
   return (
     <IconButton

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -166,6 +166,7 @@ export interface SpendingTargetsData {
 export interface RefreshResult {
   completed: boolean;
   incompleteAccounts: string[];
+  remainingCount?: number;
 }
 
 // --- Scraped Data ---


### PR DESCRIPTION
# Summary

crawler の各ユーザー向けフェーズから、timeline、current、waitingFor、reason を永続 run state へ記録します。MoneyForward 一括更新の待機状況と timeout warning、グループ名、対象月、終了状態を保持し、Web の更新ボタンにも現在の待機理由または安全な失敗理由を表示します。

## Linear Issue

- [HIR-129](https://linear.app/hiroppy/issue/HIR-129/crawler-各フェーズから進捗待機理由失敗理由を記録する)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| 機能適合性 | 全フェーズと metadata が state に欠落なく流れる必要がある | 10種の step、group name、YYYY-MM、refresh 待機情報を検証 |
| 信頼性 | timeout は継続可能な warning、その他の失敗は finished state として残す必要がある | running から success/failed/warning への遷移と永続化を検証 |
| 使用性 | 内部関数名や生の例外ではなく利用者向け文言が必要 | public-facing label と短い安全な reason を検証 |
| セキュリティ | 認証やブラウザ例外の秘密情報を UI state に含めない | 生の error message が state に残らないことを検証 |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| 状態遷移テスト | crawler state が実行中から警告、成功、失敗へ変化する | runStatus、step status、finishedAt、current/reason |
| 決定表テスト | refresh 成功、timeout、認証失敗で期待結果が異なる | done、warning、failed と継続可否 |
| 境界値分析 | MAX_WAIT_MINUTES と polling 境界が timeout 判定を決める | 最大待機分数、残件数、次回確認秒 |
| Error guessing | Playwright timeout と selector 欠落は代表的な scraping failure | 安全な reason code と message |

### Primary Test Conditions

- 通常成功で認証から Web キャッシュ更新まで全 step が done になる
- refresh 待機中に最大待機分数、残件数、未完了機関、waitingFor が更新される
- refresh timeout は run を継続し、step warning と refresh_timeout reason を残す
- 認証失敗は authentication failed、runStatus failed、finishedAt となり、生の例外を残さない
- history mode の各対象月を YYYY-MM metadata として残す
- Web API が latest state を透過し、ヘッダーが待機理由を表示する

### Out-of-Scope Risks

- 実 MoneyForward への scraping は保存済み認証情報と外部サービス状態に依存するため未実施。Playwright 境界は unit test と mock crawler を使った runtime flow で検証。

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [x] Storybook tests
- [ ] E2E tests
- [x] Manual verification

### Commands Executed

    pnpm turbo typecheck — 9 packages passed
    pnpm --filter @mf-dashboard/crawler test — 26 files / 182 tests passed
    pnpm --filter @mf-dashboard/web test:unit — 24 files / 384 tests passed
    pnpm --filter @mf-dashboard/web test:storybook — 74 files / 330 tests passed
    pnpm format:check — 498 files passed
    pnpm exec oxlint --type-aware <changed files> — passed without warnings
    mock crawler + Next.js + Playwright — API 200、更新ボタン disabled、待機理由 title を確認

### Checks Not Run

- Web E2E suite — 変更経路は mock crawler runtime flow と unit/Storybook tests で直接検証し、実 MoneyForward 認証を伴う crawler E2E は対象外。