### PR TITLE
feat: stream crawler refresh status with SSE

### DIFF
--- a/apps/crawler/src/crawler-run-lock.ts
+++ b/apps/crawler/src/crawler-run-lock.ts
@@ -32,6 +32,10 @@ export interface CrawlerRunState {
   timeline?: CrawlerRunStateSnapshot["timeline"];
 }
 
+export function getCrawlerRunLockPath(): string {
+  return DEFAULT_LOCK_PATH;
+}
+
 interface CrawlerRunLockRecord {
   id: string;
   pid: number;

--- a/apps/crawler/src/server.test.ts
+++ b/apps/crawler/src/server.test.ts
@@ -103,6 +103,36 @@ describe("crawler trigger server", () => {
     await vi.waitFor(() => expect(stopWatching).toHaveBeenCalledTimes(1));
   });
 
+  test("releases a watcher that finishes setup after the client disconnects", async () => {
+    let finishWatching: ((stop: () => void) => void) | undefined;
+    const stopWatching = vi.fn<() => void>();
+    const watcherSetup = new Promise<() => void>((resolve) => {
+      finishWatching = resolve;
+    });
+    let markSetupStarted: (() => void) | undefined;
+    const setupStarted = new Promise<void>((resolve) => {
+      markSetupStarted = resolve;
+    });
+    const baseUrl = await listen(
+      createCrawlerTriggerServer({
+        getState: async () => idleState,
+        watchState: async () => {
+          markSetupStarted?.();
+          return watcherSetup;
+        },
+      }),
+    );
+    const controller = new AbortController();
+
+    const request = fetch(`${baseUrl}/events`, { signal: controller.signal });
+    await setupStarted;
+    controller.abort();
+    await expect(request).rejects.toMatchObject({ name: "AbortError" });
+    finishWatching?.(stopWatching);
+
+    await vi.waitFor(() => expect(stopWatching).toHaveBeenCalledTimes(1));
+  });
+
   test("starts a manual run", async () => {
     const startRun = vi.fn<() => Promise<CrawlerRunState>>(async () => runningState);
     const baseUrl = await listen(createCrawlerTriggerServer({ startRun }));

--- a/apps/crawler/src/server.test.ts
+++ b/apps/crawler/src/server.test.ts
@@ -70,6 +70,39 @@ describe("crawler trigger server", () => {
     await expect(res.json()).resolves.toEqual(idleState);
   });
 
+  test("streams crawler state changes and releases the watcher on disconnect", async () => {
+    let state = idleState;
+    let notifyChange = () => {};
+    const stopWatching = vi.fn<() => void>();
+    const baseUrl = await listen(
+      createCrawlerTriggerServer({
+        getState: async () => state,
+        watchState: async (onChange) => {
+          notifyChange = onChange;
+          return stopWatching;
+        },
+      }),
+    );
+
+    const res = await fetch(`${baseUrl}/events`);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+
+    await expect(reader.read()).resolves.toMatchObject({
+      value: expect.any(Uint8Array),
+      done: false,
+    });
+
+    state = runningState;
+    notifyChange();
+    const update = await reader.read();
+    expect(decoder.decode(update.value)).toContain(JSON.stringify(runningState));
+
+    await reader.cancel();
+    await vi.waitFor(() => expect(stopWatching).toHaveBeenCalledTimes(1));
+  });
+
   test("starts a manual run", async () => {
     const startRun = vi.fn<() => Promise<CrawlerRunState>>(async () => runningState);
     const baseUrl = await listen(createCrawlerTriggerServer({ startRun }));

--- a/apps/crawler/src/server.test.ts
+++ b/apps/crawler/src/server.test.ts
@@ -133,6 +133,27 @@ describe("crawler trigger server", () => {
     await vi.waitFor(() => expect(stopWatching).toHaveBeenCalledTimes(1));
   });
 
+  test("closes the SSE stream when its filesystem watcher fails", async () => {
+    let reportWatcherError: ((err: Error) => void) | undefined;
+    const stopWatching = vi.fn<() => void>();
+    const baseUrl = await listen(
+      createCrawlerTriggerServer({
+        getState: async () => idleState,
+        watchState: async (_onChange, onError) => {
+          reportWatcherError = onError;
+          return stopWatching;
+        },
+      }),
+    );
+
+    const res = await fetch(`${baseUrl}/events`);
+    const reader = res.body!.getReader();
+    await reader.read();
+    reportWatcherError?.(new Error("watch failed"));
+
+    await vi.waitFor(() => expect(stopWatching).toHaveBeenCalledTimes(1));
+  });
+
   test("starts a manual run", async () => {
     const startRun = vi.fn<() => Promise<CrawlerRunState>>(async () => runningState);
     const baseUrl = await listen(createCrawlerTriggerServer({ startRun }));

--- a/apps/crawler/src/server.ts
+++ b/apps/crawler/src/server.ts
@@ -20,7 +20,7 @@ const DEFAULT_HOST = "127.0.0.1";
 interface CrawlerTriggerServerOptions {
   getState?: () => Promise<CrawlerRunState>;
   startRun?: () => Promise<CrawlerRunState>;
-  watchState?: (onChange: () => void) => Promise<() => void>;
+  watchState?: (onChange: () => void, onError: (err: Error) => void) => Promise<() => void>;
 }
 
 type ProgressReporter = Awaited<ReturnType<typeof createCrawlerProgressReporter>>;
@@ -43,9 +43,13 @@ function methodNotAllowed(response: ServerResponse): void {
   response.end();
 }
 
-async function watchCrawlerState(onChange: () => void): Promise<() => void> {
+async function watchCrawlerState(
+  onChange: () => void,
+  onError: (err: Error) => void,
+): Promise<() => void> {
   const statePath = process.env.CRAWLER_STATE_PATH ?? getCrawlerRunStatePath();
-  const watchedPaths = [statePath, getCrawlerRunLockPath()];
+  const lockPath = getCrawlerRunLockPath();
+  const watchedPaths = [statePath, lockPath];
   const targetsByDirectory = new Map<string, string[]>();
   for (const filePath of watchedPaths) {
     const directory = path.dirname(filePath);
@@ -54,27 +58,47 @@ async function watchCrawlerState(onChange: () => void): Promise<() => void> {
   await Promise.all(
     [...targetsByDirectory.keys()].map((directory) => mkdir(directory, { recursive: true })),
   );
-  const watchers = [...targetsByDirectory].map(([directory, targets]) => {
-    const filenames = new Set(targets.map((target) => path.basename(target)));
-    return watch(directory, (_event, filename) => {
-      if (!filename || filenames.has(filename.toString())) {
-        onChange();
-      }
-    });
-  });
-
-  return () => {
+  const watchers: ReturnType<typeof watch>[] = [];
+  const closeWatchers = () => {
     for (const watcher of watchers) {
       watcher.close();
     }
   };
+  const handleError = (err: Error) => {
+    closeWatchers();
+    onError(err);
+  };
+
+  try {
+    for (const [directory, targets] of targetsByDirectory) {
+      const filenames = new Set(targets.map((target) => path.basename(target)));
+      const lockFilename = path.basename(lockPath);
+      const watcher = watch(directory, (_event, filename) => {
+        const changedFilename = filename?.toString();
+        if (
+          !changedFilename ||
+          filenames.has(changedFilename) ||
+          changedFilename.startsWith(`${lockFilename}.mutation-`)
+        ) {
+          onChange();
+        }
+      });
+      watcher.once("error", handleError);
+      watchers.push(watcher);
+    }
+  } catch (err) {
+    closeWatchers();
+    throw err;
+  }
+
+  return closeWatchers;
 }
 
 async function streamCrawlerState(
   request: IncomingMessage,
   response: ServerResponse,
   getState: () => Promise<CrawlerRunState>,
-  watchState: (onChange: () => void) => Promise<() => void>,
+  watchState: (onChange: () => void, onError: (err: Error) => void) => Promise<() => void>,
 ): Promise<void> {
   let closed = false;
   let stopWatching: (() => void) | null = null;
@@ -111,12 +135,18 @@ async function streamCrawlerState(
     }
   }
 
-  const stopWatcher = await watchState(() => {
-    void sendLatestState().catch((err) => {
+  const stopWatcher = await watchState(
+    () => {
+      void sendLatestState().catch((err) => {
+        error("Failed to stream crawler state:", err);
+        response.destroy(err instanceof Error ? err : undefined);
+      });
+    },
+    (err) => {
       error("Failed to stream crawler state:", err);
-      response.destroy(err instanceof Error ? err : undefined);
-    });
-  });
+      response.destroy(err);
+    },
+  );
   if (closed) {
     stopWatcher();
     return;

--- a/apps/crawler/src/server.ts
+++ b/apps/crawler/src/server.ts
@@ -57,7 +57,7 @@ async function watchCrawlerState(onChange: () => void): Promise<() => void> {
   const watchers = [...targetsByDirectory].map(([directory, targets]) => {
     const filenames = new Set(targets.map((target) => path.basename(target)));
     return watch(directory, (_event, filename) => {
-      if (filename && filenames.has(filename.toString())) {
+      if (!filename || filenames.has(filename.toString())) {
         onChange();
       }
     });
@@ -77,9 +77,20 @@ async function streamCrawlerState(
   watchState: (onChange: () => void) => Promise<() => void>,
 ): Promise<void> {
   let closed = false;
+  let stopWatching: (() => void) | null = null;
+  let heartbeat: ReturnType<typeof setInterval> | null = null;
   let requestedVersion = 0;
   let sentVersion = -1;
   let sending = false;
+
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    if (heartbeat) clearInterval(heartbeat);
+    stopWatching?.();
+  };
+  request.once("close", close);
+  response.once("close", close);
 
   async function sendLatestState(): Promise<void> {
     requestedVersion += 1;
@@ -100,31 +111,27 @@ async function streamCrawlerState(
     }
   }
 
-  const stopWatching = await watchState(() => {
+  const stopWatcher = await watchState(() => {
     void sendLatestState().catch((err) => {
       error("Failed to stream crawler state:", err);
       response.destroy(err instanceof Error ? err : undefined);
     });
   });
+  if (closed) {
+    stopWatcher();
+    return;
+  }
+  stopWatching = stopWatcher;
   response.writeHead(200, {
     "cache-control": "no-cache, no-transform",
     connection: "keep-alive",
     "content-type": "text/event-stream",
   });
   response.flushHeaders();
-  const heartbeat = setInterval(() => {
+  heartbeat = setInterval(() => {
     if (!closed) response.write(": heartbeat\n\n");
   }, 15_000);
   heartbeat.unref();
-
-  const close = () => {
-    if (closed) return;
-    closed = true;
-    clearInterval(heartbeat);
-    stopWatching();
-  };
-  request.once("close", close);
-  response.once("close", close);
 
   try {
     await sendLatestState();

--- a/apps/crawler/src/server.ts
+++ b/apps/crawler/src/server.ts
@@ -1,9 +1,13 @@
+import { watch } from "node:fs";
+import { mkdir } from "node:fs/promises";
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { createCrawlerProgressReporter } from "./crawler-progress.js";
 import {
   acquireCrawlerRunLock,
   CrawlerAlreadyRunningError,
+  getCrawlerRunLockPath,
   getCrawlerRunState,
   type CrawlerRunState,
 } from "./crawler-run-lock.js";
@@ -16,6 +20,7 @@ const DEFAULT_HOST = "127.0.0.1";
 interface CrawlerTriggerServerOptions {
   getState?: () => Promise<CrawlerRunState>;
   startRun?: () => Promise<CrawlerRunState>;
+  watchState?: (onChange: () => void) => Promise<() => void>;
 }
 
 type ProgressReporter = Awaited<ReturnType<typeof createCrawlerProgressReporter>>;
@@ -36,6 +41,98 @@ function json(response: ServerResponse, status: number, body: unknown): void {
 function methodNotAllowed(response: ServerResponse): void {
   response.writeHead(405, { allow: "GET, POST" });
   response.end();
+}
+
+async function watchCrawlerState(onChange: () => void): Promise<() => void> {
+  const statePath = process.env.CRAWLER_STATE_PATH ?? getCrawlerRunStatePath();
+  const watchedPaths = [statePath, getCrawlerRunLockPath()];
+  const targetsByDirectory = new Map<string, string[]>();
+  for (const filePath of watchedPaths) {
+    const directory = path.dirname(filePath);
+    targetsByDirectory.set(directory, [...(targetsByDirectory.get(directory) ?? []), filePath]);
+  }
+  await Promise.all(
+    [...targetsByDirectory.keys()].map((directory) => mkdir(directory, { recursive: true })),
+  );
+  const watchers = [...targetsByDirectory].map(([directory, targets]) => {
+    const filenames = new Set(targets.map((target) => path.basename(target)));
+    return watch(directory, (_event, filename) => {
+      if (filename && filenames.has(filename.toString())) {
+        onChange();
+      }
+    });
+  });
+
+  return () => {
+    for (const watcher of watchers) {
+      watcher.close();
+    }
+  };
+}
+
+async function streamCrawlerState(
+  request: IncomingMessage,
+  response: ServerResponse,
+  getState: () => Promise<CrawlerRunState>,
+  watchState: (onChange: () => void) => Promise<() => void>,
+): Promise<void> {
+  let closed = false;
+  let requestedVersion = 0;
+  let sentVersion = -1;
+  let sending = false;
+
+  async function sendLatestState(): Promise<void> {
+    requestedVersion += 1;
+    if (sending) return;
+
+    sending = true;
+    try {
+      while (!closed && sentVersion !== requestedVersion) {
+        const version = requestedVersion;
+        const state = await getState();
+        if (!closed) {
+          response.write(`data: ${JSON.stringify(state)}\n\n`);
+          sentVersion = version;
+        }
+      }
+    } finally {
+      sending = false;
+    }
+  }
+
+  const stopWatching = await watchState(() => {
+    void sendLatestState().catch((err) => {
+      error("Failed to stream crawler state:", err);
+      response.destroy(err instanceof Error ? err : undefined);
+    });
+  });
+  response.writeHead(200, {
+    "cache-control": "no-cache, no-transform",
+    connection: "keep-alive",
+    "content-type": "text/event-stream",
+  });
+  response.flushHeaders();
+  const heartbeat = setInterval(() => {
+    if (!closed) response.write(": heartbeat\n\n");
+  }, 15_000);
+  heartbeat.unref();
+
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    clearInterval(heartbeat);
+    stopWatching();
+  };
+  request.once("close", close);
+  response.once("close", close);
+
+  try {
+    await sendLatestState();
+  } catch (err) {
+    error("Failed to stream initial crawler state:", err);
+    close();
+    response.destroy(err instanceof Error ? err : undefined);
+  }
 }
 
 export async function startCrawlerRun(): Promise<CrawlerRunState> {
@@ -72,6 +169,7 @@ export async function startCrawlerRun(): Promise<CrawlerRunState> {
 export function createCrawlerTriggerServer(options: CrawlerTriggerServerOptions = {}): Server {
   const getState = options.getState ?? getCrawlerRunState;
   const startRun = options.startRun ?? startCrawlerRun;
+  const watchState = options.watchState ?? watchCrawlerState;
 
   return createServer(async (request: IncomingMessage, response: ServerResponse) => {
     try {
@@ -84,6 +182,16 @@ export function createCrawlerTriggerServer(options: CrawlerTriggerServerOptions 
         }
 
         json(response, 200, await getState());
+        return;
+      }
+
+      if (url.pathname === "/events") {
+        if (request.method !== "GET") {
+          methodNotAllowed(response);
+          return;
+        }
+
+        await streamCrawlerState(request, response, getState, watchState);
         return;
       }
 

--- a/apps/web/src/app/api/crawler/refresh/route.test.ts
+++ b/apps/web/src/app/api/crawler/refresh/route.test.ts
@@ -18,6 +18,8 @@ function eventStreamResponse(body: unknown): Response {
   });
 }
 
+const unavailableEvent = `data: ${JSON.stringify(unavailableCrawlerRefreshStatus)}\n\n`;
+
 function sameOriginPostRequest(headers: HeadersInit = {}): Request {
   const requestHeaders = new Headers({
     origin: "https://dashboard.example.com",
@@ -57,8 +59,9 @@ describe("/api/crawler/refresh/", () => {
 
     const res = await GET(sameOriginGetRequest());
 
-    expect(res.status).toBe(503);
-    await expect(res.json()).resolves.toEqual(unavailableCrawlerRefreshStatus);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+    await expect(res.text()).resolves.toBe(unavailableEvent);
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
@@ -88,8 +91,9 @@ describe("/api/crawler/refresh/", () => {
 
     const res = await GET(sameOriginGetRequest());
 
-    expect(res.status).toBe(503);
-    await expect(res.json()).resolves.toEqual(unavailableCrawlerRefreshStatus);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+    await expect(res.text()).resolves.toBe(unavailableEvent);
   });
 
   it("starts a crawler run through the crawler service", async () => {
@@ -160,8 +164,9 @@ describe("/api/crawler/refresh/", () => {
 
     const res = await GET(sameOriginGetRequest());
 
-    expect(res.status).toBe(503);
-    await expect(res.json()).resolves.toEqual(unavailableCrawlerRefreshStatus);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+    await expect(res.text()).resolves.toBe(unavailableEvent);
   });
 
   it("times out when the crawler does not complete the SSE handshake", async () => {
@@ -178,8 +183,9 @@ describe("/api/crawler/refresh/", () => {
       await vi.advanceTimersByTimeAsync(5_000);
       const res = await responsePromise;
 
-      expect(res.status).toBe(503);
-      await expect(res.json()).resolves.toEqual(unavailableCrawlerRefreshStatus);
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toBe("text/event-stream");
+      await expect(res.text()).resolves.toBe(unavailableEvent);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/web/src/app/api/crawler/refresh/route.test.ts
+++ b/apps/web/src/app/api/crawler/refresh/route.test.ts
@@ -12,6 +12,12 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
+function eventStreamResponse(body: unknown): Response {
+  return new Response(`data: ${JSON.stringify(body)}\n\n`, {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
 function sameOriginPostRequest(headers: HeadersInit = {}): Request {
   const requestHeaders = new Headers({
     origin: "https://dashboard.example.com",
@@ -56,211 +62,34 @@ describe("/api/crawler/refresh/", () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it("proxies crawler status", async () => {
+  it("proxies crawler events as an SSE stream", async () => {
     vi.mocked(global.fetch).mockResolvedValueOnce(
-      jsonResponse({ running: true, source: "manual", startedAt: "2026-01-01T00:00:00.000Z" }),
+      eventStreamResponse({ running: true, source: "manual" }),
     );
 
     const res = await GET(sameOriginGetRequest());
 
     expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
     expect(global.fetch).toHaveBeenCalledWith(
-      "http://crawler:8766/status",
-      expect.objectContaining({ cache: "no-store" }),
-    );
-    await expect(res.json()).resolves.toEqual(
+      "http://crawler:8766/events",
       expect.objectContaining({
-        available: true,
-        running: true,
-        source: "manual",
-        startedAt: "2026-01-01T00:00:00.000Z",
-        latestRun: null,
+        cache: "no-store",
+        headers: { accept: "text/event-stream" },
       }),
+    );
+    await expect(res.text()).resolves.toBe(
+      `data: ${JSON.stringify({ running: true, source: "manual" })}\n\n`,
     );
   });
 
-  it("keeps an explicit stopped lock state over a stale running snapshot", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce(
-      jsonResponse({
-        running: false,
-        version: 1,
-        runId: "stale-run",
-        runStatus: "running",
-        source: "manual",
-        startedAt: "2026-01-01T00:00:00.000Z",
-        finishedAt: null,
-        current: null,
-        progress: null,
-        timeline: [],
-        reason: null,
-      }),
-    );
-
-    const res = await GET(sameOriginGetRequest());
-    const body = await res.json();
-
-    expect(body).toEqual(
-      expect.objectContaining({
-        available: true,
-        running: false,
-        latestRun: expect.objectContaining({ runStatus: "running" }),
-      }),
-    );
-  });
-
-  it("returns unavailable for a malformed successful crawler response", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ error: "invalid status" }));
+  it("returns unavailable when the crawler event stream fails", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ error: "failed" }, 500));
 
     const res = await GET(sameOriginGetRequest());
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(503);
     await expect(res.json()).resolves.toEqual(unavailableCrawlerRefreshStatus);
-  });
-
-  it("drops a latest run snapshot with an invalid timestamp", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce(
-      jsonResponse({
-        running: false,
-        version: 1,
-        runId: "corrupt-run",
-        runStatus: "failed",
-        source: "manual",
-        startedAt: "not-a-date",
-        finishedAt: "also-not-a-date",
-        current: null,
-        progress: null,
-        timeline: [],
-        reason: { code: "unknown_error", message: "処理に失敗しました" },
-      }),
-    );
-
-    const res = await GET(sameOriginGetRequest());
-
-    await expect(res.json()).resolves.toEqual({
-      available: true,
-      running: false,
-      source: "manual",
-      startedAt: null,
-      latestRun: null,
-    });
-  });
-
-  it("proxies a typed latest run state", async () => {
-    const latestRun = {
-      version: 1,
-      runId: "run-1",
-      runStatus: "failed",
-      source: "manual",
-      startedAt: "2026-01-01T00:00:00.000Z",
-      finishedAt: "2026-01-01T00:01:00.000Z",
-      current: {
-        timelineItemId: "refresh",
-        label: "金融機関を更新",
-        step: "moneyforward_refresh",
-        metadata: {
-          kind: "refresh",
-          maxWaitMinutes: 0.5,
-          remainingAccounts: 1,
-          incompleteAccounts: ["機関 A"],
-        },
-      },
-      progress: { completed: 2, total: 4 },
-      timeline: [
-        {
-          id: "auth",
-          label: "認証",
-          step: "authentication",
-          metadata: null,
-          status: "done",
-          startedAt: "2026-01-01T00:00:00.000Z",
-          finishedAt: "2026-01-01T00:00:10.000Z",
-          reason: null,
-        },
-        {
-          id: "refresh",
-          label: "金融機関を更新",
-          step: "moneyforward_refresh",
-          metadata: {
-            kind: "refresh",
-            maxWaitMinutes: 0.5,
-            remainingAccounts: 1,
-            incompleteAccounts: ["機関 A"],
-          },
-          status: "failed",
-          startedAt: "2026-01-01T00:00:10.000Z",
-          finishedAt: "2026-01-01T00:01:00.000Z",
-          reason: {
-            code: "moneyforward_timeout",
-            message: "画面を開けませんでした",
-            operation: "refresh",
-            timeoutMs: 0.5,
-          },
-        },
-      ],
-      reason: {
-        code: "moneyforward_timeout",
-        message: "画面を開けませんでした",
-        operation: "refresh",
-        timeoutMs: 0.5,
-      },
-    };
-    vi.mocked(global.fetch).mockResolvedValueOnce(
-      jsonResponse({
-        ...latestRun,
-        running: false,
-        pid: null,
-      }),
-    );
-
-    const res = await GET(sameOriginGetRequest());
-
-    await expect(res.json()).resolves.toEqual({
-      available: true,
-      running: false,
-      source: "manual",
-      startedAt: "2026-01-01T00:00:00.000Z",
-      latestRun,
-    });
-  });
-
-  it("proxies the latest successful run state", async () => {
-    const latestRun = {
-      version: 1,
-      runId: "run-success",
-      runStatus: "success",
-      source: "manual",
-      startedAt: "2026-01-01T00:00:00.000Z",
-      finishedAt: "2026-01-01T00:01:00.000Z",
-      current: null,
-      progress: { completed: 1, total: 1 },
-      timeline: [
-        {
-          id: "auth",
-          label: "認証",
-          step: "authentication",
-          metadata: null,
-          status: "done",
-          startedAt: "2026-01-01T00:00:00.000Z",
-          finishedAt: "2026-01-01T00:01:00.000Z",
-          reason: null,
-        },
-      ],
-      reason: null,
-    };
-    vi.mocked(global.fetch).mockResolvedValueOnce(
-      jsonResponse({ ...latestRun, running: false, pid: null }),
-    );
-
-    const res = await GET(sameOriginGetRequest());
-
-    expect(res.status).toBe(200);
-    await expect(res.json()).resolves.toEqual({
-      available: true,
-      running: false,
-      source: "manual",
-      startedAt: "2026-01-01T00:00:00.000Z",
-      latestRun,
-    });
   });
 
   it("starts a crawler run through the crawler service", async () => {
@@ -304,7 +133,7 @@ describe("/api/crawler/refresh/", () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it("rejects timeline status reads from a cross-site request", async () => {
+  it("rejects event streams from a cross-site request", async () => {
     const res = await GET(
       new Request("https://dashboard.example.com/api/crawler/refresh/", {
         headers: { "sec-fetch-site": "cross-site" },

--- a/apps/web/src/app/api/crawler/refresh/route.test.ts
+++ b/apps/web/src/app/api/crawler/refresh/route.test.ts
@@ -163,4 +163,25 @@ describe("/api/crawler/refresh/", () => {
     expect(res.status).toBe(503);
     await expect(res.json()).resolves.toEqual(unavailableCrawlerRefreshStatus);
   });
+
+  it("times out when the crawler does not complete the SSE handshake", async () => {
+    vi.useFakeTimers();
+    vi.mocked(global.fetch).mockImplementationOnce(
+      (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+        }),
+    );
+
+    try {
+      const responsePromise = GET(sameOriginGetRequest());
+      await vi.advanceTimersByTimeAsync(5_000);
+      const res = await responsePromise;
+
+      expect(res.status).toBe(503);
+      await expect(res.json()).resolves.toEqual(unavailableCrawlerRefreshStatus);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/web/src/app/api/crawler/refresh/route.ts
+++ b/apps/web/src/app/api/crawler/refresh/route.ts
@@ -73,13 +73,20 @@ async function proxyCrawlerEvents(request: Request) {
     return NextResponse.json(unavailableCrawlerRefreshStatus, { status: 503 });
   }
 
+  const controller = new AbortController();
+  const abortUpstream = () => controller.abort(request.signal.reason);
+  request.signal.addEventListener("abort", abortUpstream, { once: true });
+  const handshakeTimeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
   try {
     const response = await fetch(`${crawlerUrl}/events`, {
       cache: "no-store",
       headers: { accept: "text/event-stream" },
-      signal: request.signal,
+      signal: controller.signal,
     });
+    clearTimeout(handshakeTimeout);
     if (!response.ok || !response.body) {
+      request.signal.removeEventListener("abort", abortUpstream);
       return NextResponse.json(unavailableCrawlerRefreshStatus, { status: 503 });
     }
 
@@ -90,6 +97,8 @@ async function proxyCrawlerEvents(request: Request) {
       },
     });
   } catch {
+    clearTimeout(handshakeTimeout);
+    request.signal.removeEventListener("abort", abortUpstream);
     return NextResponse.json(unavailableCrawlerRefreshStatus, { status: 503 });
   }
 }

--- a/apps/web/src/app/api/crawler/refresh/route.ts
+++ b/apps/web/src/app/api/crawler/refresh/route.ts
@@ -45,7 +45,7 @@ function getCrawlerUrl(): string | null {
   return crawlerUrl.replace(/\/+$/, "");
 }
 
-async function proxyCrawlerRequest(path: "/status" | "/runs", init?: RequestInit) {
+async function proxyCrawlerRequest(path: "/runs", init?: RequestInit) {
   const crawlerUrl = getCrawlerUrl();
   if (!crawlerUrl) {
     return NextResponse.json(unavailableCrawlerRefreshStatus, { status: 503 });
@@ -67,12 +67,39 @@ async function proxyCrawlerRequest(path: "/status" | "/runs", init?: RequestInit
   }
 }
 
+async function proxyCrawlerEvents(request: Request) {
+  const crawlerUrl = getCrawlerUrl();
+  if (!crawlerUrl) {
+    return NextResponse.json(unavailableCrawlerRefreshStatus, { status: 503 });
+  }
+
+  try {
+    const response = await fetch(`${crawlerUrl}/events`, {
+      cache: "no-store",
+      headers: { accept: "text/event-stream" },
+      signal: request.signal,
+    });
+    if (!response.ok || !response.body) {
+      return NextResponse.json(unavailableCrawlerRefreshStatus, { status: 503 });
+    }
+
+    return new Response(response.body, {
+      headers: {
+        "cache-control": "no-cache, no-transform",
+        "content-type": "text/event-stream",
+      },
+    });
+  } catch {
+    return NextResponse.json(unavailableCrawlerRefreshStatus, { status: 503 });
+  }
+}
+
 export async function GET(request: Request) {
   if (!isSameOriginRead(request)) {
     return NextResponse.json({ error: "Invalid origin" }, { status: 403 });
   }
 
-  return proxyCrawlerRequest("/status");
+  return proxyCrawlerEvents(request);
 }
 
 export async function POST(request: Request) {

--- a/apps/web/src/app/api/crawler/refresh/route.ts
+++ b/apps/web/src/app/api/crawler/refresh/route.ts
@@ -45,6 +45,15 @@ function getCrawlerUrl(): string | null {
   return crawlerUrl.replace(/\/+$/, "");
 }
 
+function unavailableCrawlerEvents() {
+  return new Response(`data: ${JSON.stringify(unavailableCrawlerRefreshStatus)}\n\n`, {
+    headers: {
+      "cache-control": "no-cache, no-transform",
+      "content-type": "text/event-stream",
+    },
+  });
+}
+
 async function proxyCrawlerRequest(path: "/runs", init?: RequestInit) {
   const crawlerUrl = getCrawlerUrl();
   if (!crawlerUrl) {
@@ -70,7 +79,7 @@ async function proxyCrawlerRequest(path: "/runs", init?: RequestInit) {
 async function proxyCrawlerEvents(request: Request) {
   const crawlerUrl = getCrawlerUrl();
   if (!crawlerUrl) {
-    return NextResponse.json(unavailableCrawlerRefreshStatus, { status: 503 });
+    return unavailableCrawlerEvents();
   }
 
   const controller = new AbortController();
@@ -87,7 +96,7 @@ async function proxyCrawlerEvents(request: Request) {
     clearTimeout(handshakeTimeout);
     if (!response.ok || !response.body) {
       request.signal.removeEventListener("abort", abortUpstream);
-      return NextResponse.json(unavailableCrawlerRefreshStatus, { status: 503 });
+      return unavailableCrawlerEvents();
     }
 
     return new Response(response.body, {
@@ -99,7 +108,7 @@ async function proxyCrawlerEvents(request: Request) {
   } catch {
     clearTimeout(handshakeTimeout);
     request.signal.removeEventListener("abort", abortUpstream);
-    return NextResponse.json(unavailableCrawlerRefreshStatus, { status: 503 });
+    return unavailableCrawlerEvents();
   }
 }
 

--- a/apps/web/src/components/layout/action-icons.stories.tsx
+++ b/apps/web/src/components/layout/action-icons.stories.tsx
@@ -87,14 +87,27 @@ const failedStatus: CrawlerRefreshStatus = {
 };
 
 function mockCrawlerStatus(status: CrawlerRefreshStatus) {
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = (async () =>
-    new Response(JSON.stringify(status), {
-      headers: { "content-type": "application/json" },
-    })) as typeof fetch;
+  const OriginalEventSource = globalThis.EventSource;
+  class StoryEventSource {
+    onerror: ((event: Event) => void) | null = null;
+    onmessage: ((event: MessageEvent<string>) => void) | null = null;
+
+    constructor() {
+      queueMicrotask(() => {
+        this.onmessage?.(
+          new MessageEvent("message", {
+            data: JSON.stringify(status),
+          }),
+        );
+      });
+    }
+
+    close() {}
+  }
+  globalThis.EventSource = StoryEventSource as unknown as typeof EventSource;
 
   return () => {
-    globalThis.fetch = originalFetch;
+    globalThis.EventSource = OriginalEventSource;
   };
 }
 

--- a/apps/web/src/components/layout/action-icons.stories.tsx
+++ b/apps/web/src/components/layout/action-icons.stories.tsx
@@ -89,11 +89,13 @@ const failedStatus: CrawlerRefreshStatus = {
 function mockCrawlerStatus(status: CrawlerRefreshStatus) {
   const OriginalEventSource = globalThis.EventSource;
   class StoryEventSource {
+    private closed = false;
     onerror: ((event: Event) => void) | null = null;
     onmessage: ((event: MessageEvent<string>) => void) | null = null;
 
     constructor() {
       queueMicrotask(() => {
+        if (this.closed) return;
         this.onmessage?.(
           new MessageEvent("message", {
             data: JSON.stringify(status),
@@ -102,7 +104,9 @@ function mockCrawlerStatus(status: CrawlerRefreshStatus) {
       });
     }
 
-    close() {}
+    close() {
+      this.closed = true;
+    }
   }
   globalThis.EventSource = StoryEventSource as unknown as typeof EventSource;
 

--- a/apps/web/src/components/layout/action-icons.test.tsx
+++ b/apps/web/src/components/layout/action-icons.test.tsx
@@ -397,6 +397,19 @@ describe("ActionIcons", () => {
     expect((refreshButton as HTMLButtonElement).disabled).toBe(true);
   });
 
+  it("refreshes after reconnecting when a running crawl finished during an SSE outage", async () => {
+    render(<ActionIcons variant="header" />);
+    await emitStatus({ running: true });
+
+    await act(async () => {
+      EventSourceMock.instances.at(-1)?.onerror?.(new Event("error"));
+    });
+    await emitStatus({ running: false });
+
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "金融機関データを更新" })).toBeTruthy();
+  });
+
   it("does not render the refresh button in the mobile sidebar actions", () => {
     render(<ActionIcons variant="sidebar" />);
 

--- a/apps/web/src/components/layout/action-icons.test.tsx
+++ b/apps/web/src/components/layout/action-icons.test.tsx
@@ -170,6 +170,28 @@ describe("ActionIcons", () => {
     expect(refreshMock).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves buffered running and terminal statuses when the refresh POST fails", async () => {
+    let resolvePost: ((response: Response) => void) | undefined;
+    vi.mocked(global.fetch).mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolvePost = resolve;
+      }),
+    );
+    render(<ActionIcons variant="header" />);
+    await emitStatus({ running: false });
+
+    fireEvent.click(screen.getByRole("button", { name: "金融機関データを更新" }));
+    await emitStatus({ running: true });
+    await emitStatus({ running: false });
+
+    await act(async () => {
+      resolvePost?.(jsonResponse({ error: "upstream response lost" }, 503));
+    });
+
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "金融機関データを更新" })).toBeTruthy();
+  });
+
   it("starts another refresh after the latest run succeeded", async () => {
     vi.mocked(global.fetch).mockResolvedValueOnce(
       jsonResponse({ available: true, running: true }, 202),
@@ -407,6 +429,17 @@ describe("ActionIcons", () => {
     await emitStatus({ running: false });
 
     expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "金融機関データを更新" })).toBeTruthy();
+  });
+
+  it("recovers after an unavailable SSE handshake event", async () => {
+    render(<ActionIcons variant="header" />);
+    await emitStatus({ running: false, available: false });
+
+    expect(screen.getByRole("button", { name: "更新サービス未接続" })).toBeTruthy();
+
+    await emitStatus({ running: false });
+
     expect(screen.getByRole("button", { name: "金融機関データを更新" })).toBeTruthy();
   });
 

--- a/apps/web/src/components/layout/action-icons.test.tsx
+++ b/apps/web/src/components/layout/action-icons.test.tsx
@@ -4,6 +4,7 @@ import { ActionIcons } from "./action-icons";
 
 const originalEnv = { ...process.env };
 const originalFetch = global.fetch;
+const originalEventSource = global.EventSource;
 const { refreshMock, routerMock } = vi.hoisted(() => {
   const refreshMock = vi.fn<() => void>();
   return {
@@ -20,6 +21,29 @@ function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: { "content-type": "application/json" },
+  });
+}
+
+class EventSourceMock {
+  static instances: EventSourceMock[] = [];
+  readonly url: string;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  close = vi.fn<() => void>();
+
+  constructor(url: string | URL) {
+    this.url = String(url);
+    EventSourceMock.instances.push(this);
+  }
+
+  emit(body: unknown) {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(body) }));
+  }
+}
+
+async function emitStatus(body: unknown): Promise<void> {
+  await act(async () => {
+    EventSourceMock.instances.at(-1)?.emit(body);
   });
 }
 
@@ -54,6 +78,8 @@ const failedLatestRun = {
 
 beforeEach(() => {
   refreshMock.mockReset();
+  EventSourceMock.instances = [];
+  global.EventSource = EventSourceMock as unknown as typeof EventSource;
   global.fetch = vi
     .fn<typeof fetch>()
     .mockResolvedValue(jsonResponse({ available: true, running: false }));
@@ -61,6 +87,7 @@ beforeEach(() => {
 
 afterEach(() => {
   process.env = { ...originalEnv };
+  global.EventSource = originalEventSource;
   global.fetch = originalFetch;
 });
 
@@ -90,29 +117,24 @@ describe("ActionIcons", () => {
   });
 
   it("does not show the updating state while loading the initial status", async () => {
-    let resolveStatus: ((response: Response) => void) | undefined;
-    vi.mocked(global.fetch).mockReturnValueOnce(
-      new Promise<Response>((resolve) => {
-        resolveStatus = resolve;
-      }),
-    );
-
-    render(<ActionIcons variant="header" />);
+    const { unmount } = render(<ActionIcons variant="header" />);
 
     const refreshButton = screen.getByRole("button", { name: "更新サービス未接続" });
     expect(refreshButton.querySelector("svg")?.getAttribute("class")).not.toContain("animate-spin");
+    const events = EventSourceMock.instances.at(-1);
+    expect(events?.url).toBe("/api/crawler/refresh/");
 
-    await act(async () => {
-      resolveStatus?.(jsonResponse({ available: true, running: false }));
-    });
+    unmount();
+    expect(events?.close).toHaveBeenCalledTimes(1);
   });
 
   it("starts a crawler refresh from the header refresh button", async () => {
-    vi.mocked(global.fetch)
-      .mockResolvedValueOnce(jsonResponse({ available: true, running: false }))
-      .mockResolvedValueOnce(jsonResponse({ available: true, running: true }, 202));
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ available: true, running: true }, 202),
+    );
 
     render(<ActionIcons variant="header" />);
+    await emitStatus({ running: false });
 
     const refreshButton = await screen.findByRole("button", { name: "金融機関データを更新" });
     expect((refreshButton as HTMLButtonElement).disabled).toBe(false);
@@ -125,71 +147,47 @@ describe("ActionIcons", () => {
     expect(refreshMock).not.toHaveBeenCalled();
   });
 
-  it("ignores an older status response after starting a refresh", async () => {
-    const intervalCallbacks: Array<() => unknown> = [];
-    const setIntervalSpy = vi.spyOn(window, "setInterval").mockImplementation((handler) => {
-      if (typeof handler === "function") {
-        intervalCallbacks.push(handler as () => unknown);
-      }
-      return 1 as unknown as ReturnType<typeof window.setInterval>;
+  it("ignores a status event while starting a refresh", async () => {
+    let resolvePost: ((response: Response) => void) | undefined;
+    vi.mocked(global.fetch).mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolvePost = resolve;
+      }),
+    );
+    render(<ActionIcons variant="header" />);
+    await emitStatus({ running: false });
+
+    fireEvent.click(screen.getByRole("button", { name: "金融機関データを更新" }));
+    await emitStatus({ running: false });
+
+    expect(screen.getByRole("button", { name: "同期タイムラインを表示" })).toBeTruthy();
+
+    await act(async () => {
+      resolvePost?.(jsonResponse({ available: true, running: true }, 202));
     });
-    const clearIntervalSpy = vi.spyOn(window, "clearInterval").mockImplementation(() => undefined);
-    let resolveOldStatus: ((response: Response) => void) | undefined;
-
-    try {
-      vi.mocked(global.fetch)
-        .mockResolvedValueOnce(jsonResponse({ available: true, running: false }))
-        .mockReturnValueOnce(
-          new Promise<Response>((resolve) => {
-            resolveOldStatus = resolve;
-          }),
-        )
-        .mockResolvedValueOnce(jsonResponse({ available: true, running: true }, 202));
-
-      render(<ActionIcons variant="header" />);
-
-      const refreshButton = await screen.findByRole("button", {
-        name: "金融機関データを更新",
-      });
-      void intervalCallbacks[0]?.();
-      fireEvent.click(refreshButton);
-
-      await screen.findByRole("button", { name: "同期タイムラインを表示" });
-
-      await act(async () => {
-        resolveOldStatus?.(jsonResponse({ available: true, running: false }));
-      });
-
-      expect(screen.getByRole("button", { name: "同期タイムラインを表示" })).toBeTruthy();
-    } finally {
-      setIntervalSpy.mockRestore();
-      clearIntervalSpy.mockRestore();
-    }
   });
 
   it("starts another refresh after the latest run succeeded", async () => {
-    vi.mocked(global.fetch)
-      .mockResolvedValueOnce(
-        jsonResponse({
-          available: true,
-          running: false,
-          latestRun: {
-            version: 1,
-            runId: "run-success",
-            runStatus: "success",
-            source: "manual",
-            startedAt: "2026-01-01T00:00:00.000Z",
-            finishedAt: "2026-01-01T00:01:00.000Z",
-            current: null,
-            progress: { completed: 5, total: 5 },
-            timeline: [],
-            reason: null,
-          },
-        }),
-      )
-      .mockResolvedValueOnce(jsonResponse({ available: true, running: true }, 202));
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ available: true, running: true }, 202),
+    );
 
     render(<ActionIcons variant="header" />);
+    await emitStatus({
+      running: false,
+      latestRun: {
+        version: 1,
+        runId: "run-success",
+        runStatus: "success",
+        source: "manual",
+        startedAt: "2026-01-01T00:00:00.000Z",
+        finishedAt: "2026-01-01T00:01:00.000Z",
+        current: null,
+        progress: { completed: 5, total: 5 },
+        timeline: [],
+        reason: null,
+      },
+    });
 
     const refreshButton = await screen.findByRole("button", { name: "金融機関データを更新" });
     fireEvent.click(refreshButton);
@@ -201,96 +199,79 @@ describe("ActionIcons", () => {
   });
 
   it("refreshes the dashboard after the crawler run finishes", async () => {
-    const intervalCallbacks: Array<() => unknown> = [];
-    const setIntervalSpy = vi.spyOn(window, "setInterval").mockImplementation((handler) => {
-      if (typeof handler === "function") {
-        intervalCallbacks.push(handler as () => unknown);
-      }
-      return 1 as unknown as ReturnType<typeof window.setInterval>;
-    });
-    const clearIntervalSpy = vi.spyOn(window, "clearInterval").mockImplementation(() => undefined);
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ available: true, running: true }, 202),
+    );
+    render(<ActionIcons variant="header" />);
+    await emitStatus({ running: false });
 
-    try {
-      vi.mocked(global.fetch)
-        .mockResolvedValueOnce(jsonResponse({ available: true, running: false }))
-        .mockResolvedValueOnce(jsonResponse({ available: true, running: true }, 202))
-        .mockResolvedValueOnce(jsonResponse({ available: true, running: false }));
+    fireEvent.click(screen.getByRole("button", { name: "金融機関データを更新" }));
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith("/api/crawler/refresh/", { method: "POST" }),
+    );
 
-      render(<ActionIcons variant="header" />);
+    await emitStatus({ running: false });
 
-      const refreshButton = await screen.findByRole("button", {
-        name: "金融機関データを更新",
-      });
-      expect((refreshButton as HTMLButtonElement).disabled).toBe(false);
-
-      fireEvent.click(refreshButton);
-
-      await waitFor(() =>
-        expect(global.fetch).toHaveBeenCalledWith("/api/crawler/refresh/", { method: "POST" }),
-      );
-      expect(refreshMock).not.toHaveBeenCalled();
-
-      await act(async () => {
-        await intervalCallbacks[0]?.();
-      });
-
-      await waitFor(() => expect(refreshMock).toHaveBeenCalledTimes(1));
-    } finally {
-      setIntervalSpy.mockRestore();
-      clearIntervalSpy.mockRestore();
-    }
+    expect(refreshMock).toHaveBeenCalledTimes(1);
   });
 
   it("refreshes the dashboard when a crawler run fails after partial updates", async () => {
-    const intervalCallbacks: Array<() => unknown> = [];
-    const setIntervalSpy = vi.spyOn(window, "setInterval").mockImplementation((handler) => {
-      if (typeof handler === "function") {
-        intervalCallbacks.push(handler as () => unknown);
-      }
-      return 1 as unknown as ReturnType<typeof window.setInterval>;
-    });
-    const clearIntervalSpy = vi.spyOn(window, "clearInterval").mockImplementation(() => undefined);
+    render(<ActionIcons variant="header" />);
+    await emitStatus({ running: true });
+    await emitStatus({ running: false, latestRun: failedLatestRun });
 
-    try {
-      vi.mocked(global.fetch)
-        .mockResolvedValueOnce(jsonResponse({ available: true, running: true }))
-        .mockResolvedValueOnce(
-          jsonResponse({ available: true, running: false, latestRun: failedLatestRun }),
-        );
-
-      render(<ActionIcons variant="header" />);
-      await screen.findByRole("button", { name: "同期タイムラインを表示" });
-
-      await act(async () => {
-        await intervalCallbacks[0]?.();
-      });
-
-      await waitFor(() => expect(refreshMock).toHaveBeenCalledTimes(1));
-      expect(screen.getByRole("button", { name: "同期失敗の詳細を表示" })).toBeTruthy();
-    } finally {
-      setIntervalSpy.mockRestore();
-      clearIntervalSpy.mockRestore();
-    }
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "同期失敗の詳細を表示" })).toBeTruthy();
   });
 
   it("opens the latest running timeline without starting another refresh", async () => {
     const startedAt = "2026-01-01T00:00:00.000Z";
-    vi.mocked(global.fetch).mockResolvedValueOnce(
-      jsonResponse({
-        available: true,
-        running: true,
+    const status = {
+      running: true,
+      source: "scheduled",
+      startedAt,
+      latestRun: {
+        version: 1,
+        runId: "run-1",
+        runStatus: "running",
         source: "scheduled",
         startedAt,
-        latestRun: {
-          version: 1,
-          runId: "run-1",
-          runStatus: "running",
-          source: "scheduled",
-          startedAt,
-          finishedAt: null,
-          progress: { completed: 2, total: 5 },
-          current: {
-            timelineItemId: "refresh",
+        finishedAt: null,
+        progress: { completed: 2, total: 5 },
+        current: {
+          timelineItemId: "refresh",
+          label: "金融機関データを一括更新",
+          step: "moneyforward_refresh",
+          metadata: {
+            kind: "refresh",
+            maxWaitMinutes: 10,
+            remainingAccounts: 1,
+            incompleteAccounts: ["金融機関 A"],
+          },
+        },
+        timeline: [
+          {
+            id: "auth",
+            label: "認証",
+            step: "authentication",
+            metadata: null,
+            status: "done",
+            startedAt,
+            finishedAt: "2026-01-01T00:00:10.000Z",
+            reason: null,
+          },
+          {
+            id: "accounts",
+            label: "登録口座を取得",
+            step: "registered_accounts",
+            metadata: null,
+            status: "running",
+            startedAt: "2026-01-01T00:00:10.000Z",
+            finishedAt: null,
+            reason: null,
+          },
+          {
+            id: "refresh",
             label: "金融機関データを一括更新",
             step: "moneyforward_refresh",
             metadata: {
@@ -299,50 +280,18 @@ describe("ActionIcons", () => {
               remainingAccounts: 1,
               incompleteAccounts: ["金融機関 A"],
             },
+            status: "running",
+            startedAt: "2026-01-01T00:00:10.000Z",
+            finishedAt: null,
+            reason: null,
           },
-          timeline: [
-            {
-              id: "auth",
-              label: "認証",
-              step: "authentication",
-              metadata: null,
-              status: "done",
-              startedAt,
-              finishedAt: "2026-01-01T00:00:10.000Z",
-              reason: null,
-            },
-            {
-              id: "accounts",
-              label: "登録口座を取得",
-              step: "registered_accounts",
-              metadata: null,
-              status: "running",
-              startedAt: "2026-01-01T00:00:10.000Z",
-              finishedAt: null,
-              reason: null,
-            },
-            {
-              id: "refresh",
-              label: "金融機関データを一括更新",
-              step: "moneyforward_refresh",
-              metadata: {
-                kind: "refresh",
-                maxWaitMinutes: 10,
-                remainingAccounts: 1,
-                incompleteAccounts: ["金融機関 A"],
-              },
-              status: "running",
-              startedAt: "2026-01-01T00:00:10.000Z",
-              finishedAt: null,
-              reason: null,
-            },
-          ],
-          reason: null,
-        },
-      }),
-    );
+        ],
+        reason: null,
+      },
+    };
 
     render(<ActionIcons variant="header" />);
+    await emitStatus(status);
 
     const refreshButton = await screen.findByRole("button", { name: "同期タイムラインを表示" });
     expect((refreshButton as HTMLButtonElement).disabled).toBe(false);
@@ -371,20 +320,13 @@ describe("ActionIcons", () => {
     expect(
       accountsStep!.compareDocumentPosition(authenticationStep!) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
-    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).not.toHaveBeenCalled();
     expect(refreshMock).not.toHaveBeenCalled();
   });
 
   it("ignores a stale failed snapshot while a new run is active", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce(
-      jsonResponse({
-        available: true,
-        running: true,
-        latestRun: failedLatestRun,
-      }),
-    );
-
     render(<ActionIcons variant="header" />);
+    await emitStatus({ running: true, latestRun: failedLatestRun });
 
     const refreshButton = await screen.findByRole("button", { name: "同期タイムラインを表示" });
     expect(screen.queryByText("同期失敗")).toBeNull();
@@ -401,11 +343,10 @@ describe("ActionIcons", () => {
     const postResponse = new Promise<Response>((resolve) => {
       resolvePost = resolve;
     });
-    vi.mocked(global.fetch)
-      .mockResolvedValueOnce(jsonResponse({ available: true, running: false }))
-      .mockReturnValueOnce(postResponse);
+    vi.mocked(global.fetch).mockReturnValueOnce(postResponse);
 
     render(<ActionIcons variant="header" />);
+    await emitStatus({ running: false });
 
     fireEvent.click(await screen.findByRole("button", { name: "金融機関データを更新" }));
 
@@ -418,17 +359,12 @@ describe("ActionIcons", () => {
   });
 
   it("opens a failed timeline and retries from the popover", async () => {
-    vi.mocked(global.fetch)
-      .mockResolvedValueOnce(
-        jsonResponse({
-          available: true,
-          running: false,
-          latestRun: failedLatestRun,
-        }),
-      )
-      .mockResolvedValueOnce(jsonResponse({ available: true, running: true }, 202));
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ available: true, running: true }, 202),
+    );
 
     render(<ActionIcons variant="header" />);
+    await emitStatus({ running: false, latestRun: failedLatestRun });
 
     const refreshButton = await screen.findByRole("button", { name: "同期失敗の詳細を表示" });
     expect((refreshButton as HTMLButtonElement).disabled).toBe(false);
@@ -448,11 +384,10 @@ describe("ActionIcons", () => {
   });
 
   it("disables the header refresh button when the crawler service is unavailable", async () => {
-    vi.mocked(global.fetch).mockResolvedValueOnce(
-      jsonResponse({ available: false, running: false }, 503),
-    );
-
     render(<ActionIcons variant="header" />);
+    await act(async () => {
+      EventSourceMock.instances.at(-1)?.onerror?.(new Event("error"));
+    });
 
     const refreshButton = await screen.findByRole("button", { name: "更新サービス未接続" });
     expect(refreshButton.getAttribute("title")).toBe("更新サービス未接続");

--- a/apps/web/src/components/layout/action-icons.test.tsx
+++ b/apps/web/src/components/layout/action-icons.test.tsx
@@ -76,6 +76,19 @@ const failedLatestRun = {
   reason: { code: "auth_failed", message: "認証できませんでした" },
 };
 
+const successfulLatestRun = {
+  version: 1,
+  runId: "run-success",
+  runStatus: "success",
+  source: "manual",
+  startedAt: "2026-01-01T00:00:00.000Z",
+  finishedAt: "2026-01-01T00:00:10.000Z",
+  current: null,
+  progress: { completed: 0, total: 0 },
+  timeline: [],
+  reason: null,
+};
+
 beforeEach(() => {
   refreshMock.mockReset();
   EventSourceMock.instances = [];
@@ -158,7 +171,7 @@ describe("ActionIcons", () => {
     await emitStatus({ running: false });
 
     fireEvent.click(screen.getByRole("button", { name: "金融機関データを更新" }));
-    await emitStatus({ running: false });
+    await emitStatus({ running: false, latestRun: successfulLatestRun });
 
     expect(screen.getByRole("button", { name: "同期タイムラインを表示" })).toBeTruthy();
 
@@ -168,6 +181,44 @@ describe("ActionIcons", () => {
 
     expect(screen.getByRole("button", { name: "金融機関データを更新" })).toBeTruthy();
     expect(refreshMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not let a stale idle status override a confirmed running POST response", async () => {
+    let resolvePost: ((response: Response) => void) | undefined;
+    vi.mocked(global.fetch).mockReturnValueOnce(
+      new Promise<Response>((resolve) => {
+        resolvePost = resolve;
+      }),
+    );
+    render(<ActionIcons variant="header" />);
+    await emitStatus({ running: false });
+
+    fireEvent.click(screen.getByRole("button", { name: "金融機関データを更新" }));
+    await emitStatus({ running: false });
+
+    await act(async () => {
+      resolvePost?.(jsonResponse({ available: true, running: true }, 202));
+    });
+
+    expect(screen.getByRole("button", { name: "同期タイムラインを表示" })).toBeTruthy();
+    expect(refreshMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes after an ambiguous POST failure is reconciled by SSE", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      jsonResponse({ error: "upstream response lost" }, 503),
+    );
+    render(<ActionIcons variant="header" />);
+    await emitStatus({ running: false });
+
+    fireEvent.click(screen.getByRole("button", { name: "金融機関データを更新" }));
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith("/api/crawler/refresh/", { method: "POST" }),
+    );
+    await emitStatus({ running: false });
+
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "金融機関データを更新" })).toBeTruthy();
   });
 
   it("preserves buffered running and terminal statuses when the refresh POST fails", async () => {

--- a/apps/web/src/components/layout/action-icons.test.tsx
+++ b/apps/web/src/components/layout/action-icons.test.tsx
@@ -147,7 +147,7 @@ describe("ActionIcons", () => {
     expect(refreshMock).not.toHaveBeenCalled();
   });
 
-  it("ignores a status event while starting a refresh", async () => {
+  it("applies a terminal status received while starting a refresh", async () => {
     let resolvePost: ((response: Response) => void) | undefined;
     vi.mocked(global.fetch).mockReturnValueOnce(
       new Promise<Response>((resolve) => {
@@ -165,6 +165,9 @@ describe("ActionIcons", () => {
     await act(async () => {
       resolvePost?.(jsonResponse({ available: true, running: true }, 202));
     });
+
+    expect(screen.getByRole("button", { name: "金融機関データを更新" })).toBeTruthy();
+    expect(refreshMock).toHaveBeenCalledTimes(1);
   });
 
   it("starts another refresh after the latest run succeeded", async () => {

--- a/apps/web/src/components/layout/action-icons.test.tsx
+++ b/apps/web/src/components/layout/action-icons.test.tsx
@@ -215,6 +215,8 @@ describe("ActionIcons", () => {
     await waitFor(() =>
       expect(global.fetch).toHaveBeenCalledWith("/api/crawler/refresh/", { method: "POST" }),
     );
+    expect(screen.getByRole("button", { name: "金融機関データを更新" })).toBeTruthy();
+
     await emitStatus({ running: false });
 
     expect(refreshMock).toHaveBeenCalledTimes(1);

--- a/apps/web/src/components/layout/action-icons.tsx
+++ b/apps/web/src/components/layout/action-icons.tsx
@@ -98,7 +98,8 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
     };
     events.onerror = () => {
       if (startRefreshInFlightRef.current) return;
-      setUnavailable();
+      setState({ ...unavailableCrawlerRefreshStatus, isPending: false });
+      setPopoverOpen(false);
     };
 
     return () => {

--- a/apps/web/src/components/layout/action-icons.tsx
+++ b/apps/web/src/components/layout/action-icons.tsx
@@ -55,6 +55,7 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
   const wasRunningRef = useRef(false);
   const startRefreshInFlightRef = useRef(false);
   const pendingStatusRef = useRef<CrawlerRefreshStatus | null>(null);
+  const pendingWasRunningRef = useRef(false);
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [state, setState] = useState<CrawlerRefreshButtonState>({
     ...unavailableCrawlerRefreshStatus,
@@ -70,7 +71,9 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
       if (nextStatus.available && wasRunningRef.current && !nextStatus.running) {
         router.refresh();
       }
-      wasRunningRef.current = nextStatus.running;
+      if (nextStatus.available) {
+        wasRunningRef.current = nextStatus.running;
+      }
     },
     [router],
   );
@@ -89,6 +92,7 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
         const nextStatus = parseCrawlerRefreshStatus(JSON.parse(event.data) as unknown, true);
         if (startRefreshInFlightRef.current) {
           pendingStatusRef.current = nextStatus;
+          pendingWasRunningRef.current ||= nextStatus.running;
           return;
         }
         applyStatus(nextStatus);
@@ -114,6 +118,7 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
 
     startRefreshInFlightRef.current = true;
     pendingStatusRef.current = null;
+    pendingWasRunningRef.current = false;
     setPopoverOpen(false);
     setState((prev) => ({
       ...prev,
@@ -143,7 +148,11 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
     } finally {
       startRefreshInFlightRef.current = false;
       const pendingStatus = pendingStatusRef.current;
+      if (pendingWasRunningRef.current) {
+        wasRunningRef.current = true;
+      }
       pendingStatusRef.current = null;
+      pendingWasRunningRef.current = false;
       if (pendingStatus) {
         applyStatus(pendingStatus);
       }

--- a/apps/web/src/components/layout/action-icons.tsx
+++ b/apps/web/src/components/layout/action-icons.tsx
@@ -56,6 +56,7 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
   const startRefreshInFlightRef = useRef(false);
   const pendingStatusRef = useRef<CrawlerRefreshStatus | null>(null);
   const pendingWasRunningRef = useRef(false);
+  const previousRunIdRef = useRef<string | null>(null);
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [state, setState] = useState<CrawlerRefreshButtonState>({
     ...unavailableCrawlerRefreshStatus,
@@ -119,6 +120,8 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
     startRefreshInFlightRef.current = true;
     pendingStatusRef.current = null;
     pendingWasRunningRef.current = false;
+    previousRunIdRef.current = state.latestRun?.runId ?? null;
+    wasRunningRef.current = true;
     setPopoverOpen(false);
     setState((prev) => ({
       ...prev,
@@ -147,13 +150,18 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
       setState({ ...unavailableCrawlerRefreshStatus, isPending: false });
     } finally {
       startRefreshInFlightRef.current = false;
-      const pendingStatus = pendingStatusRef.current;
-      if (pendingWasRunningRef.current) {
-        wasRunningRef.current = true;
-      }
+      const pendingStatus = pendingStatusRef.current as CrawlerRefreshStatus | null;
+      const pendingRun = pendingStatus?.latestRun;
+      const isNewTerminalRun =
+        pendingRun !== null &&
+        pendingRun !== undefined &&
+        pendingRun.runStatus !== "running" &&
+        pendingRun.runId !== previousRunIdRef.current;
+      const shouldApplyPendingStatus = pendingWasRunningRef.current || isNewTerminalRun;
       pendingStatusRef.current = null;
       pendingWasRunningRef.current = false;
-      if (pendingStatus) {
+      previousRunIdRef.current = null;
+      if (pendingStatus && shouldApplyPendingStatus) {
         applyStatus(pendingStatus);
       }
     }

--- a/apps/web/src/components/layout/action-icons.tsx
+++ b/apps/web/src/components/layout/action-icons.tsx
@@ -20,8 +20,6 @@ import { Dialog, DialogTrigger, DialogContent, DialogTitle, DialogDescription } 
 import { IconButton } from "../ui/icon-button";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 
-const STATUS_POLL_INTERVAL_MS = 5_000;
-
 interface ActionIconsProps {
   variant: "header" | "sidebar";
   notifications?: ReactNode;
@@ -29,12 +27,6 @@ interface ActionIconsProps {
 
 interface CrawlerRefreshButtonState extends CrawlerRefreshStatus {
   isPending: boolean;
-}
-
-async function readCrawlerRefreshStatus(): Promise<CrawlerRefreshStatus> {
-  const res = await fetch("/api/crawler/refresh/", { cache: "no-store" });
-  const body: unknown = await res.json().catch(() => null);
-  return parseCrawlerRefreshStatus(body, res.ok);
 }
 
 export function ActionIcons({ variant, notifications }: ActionIconsProps) {
@@ -61,7 +53,6 @@ export function ActionIcons({ variant, notifications }: ActionIconsProps) {
 function RefreshControl({ iconSize }: { iconSize: string }) {
   const router = useRouter();
   const wasRunningRef = useRef(false);
-  const requestSequenceRef = useRef(0);
   const startRefreshInFlightRef = useRef(false);
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [state, setState] = useState<CrawlerRefreshButtonState>({
@@ -70,51 +61,49 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
   });
 
   useEffect(() => {
-    let isMounted = true;
+    const events = new EventSource("/api/crawler/refresh/");
 
-    async function updateStatus() {
+    function setUnavailable() {
+      setState({ ...unavailableCrawlerRefreshStatus, isPending: false });
+      setPopoverOpen(false);
+      wasRunningRef.current = false;
+    }
+
+    events.onmessage = (event) => {
       if (startRefreshInFlightRef.current) {
         return;
       }
-      const requestSequence = ++requestSequenceRef.current;
 
       try {
-        const nextStatus = await readCrawlerRefreshStatus();
-        if (isMounted && requestSequence === requestSequenceRef.current) {
-          setState({ ...nextStatus, isPending: false });
-          if (!nextStatus.running && nextStatus.latestRun?.runStatus !== "failed") {
-            setPopoverOpen(false);
-          }
-          if (nextStatus.available && wasRunningRef.current && !nextStatus.running) {
-            router.refresh();
-          }
-          wasRunningRef.current = nextStatus.running;
-        }
-      } catch {
-        if (isMounted && requestSequence === requestSequenceRef.current) {
-          setState({ ...unavailableCrawlerRefreshStatus, isPending: false });
+        const nextStatus = parseCrawlerRefreshStatus(JSON.parse(event.data) as unknown, true);
+        setState({ ...nextStatus, isPending: false });
+        if (!nextStatus.running && nextStatus.latestRun?.runStatus !== "failed") {
           setPopoverOpen(false);
-          wasRunningRef.current = false;
         }
+        if (nextStatus.available && wasRunningRef.current && !nextStatus.running) {
+          router.refresh();
+        }
+        wasRunningRef.current = nextStatus.running;
+      } catch {
+        setUnavailable();
       }
-    }
-
-    void updateStatus();
-    const intervalId = window.setInterval(updateStatus, STATUS_POLL_INTERVAL_MS);
+    };
+    events.onerror = () => {
+      if (startRefreshInFlightRef.current) return;
+      setUnavailable();
+    };
 
     return () => {
-      isMounted = false;
-      window.clearInterval(intervalId);
+      events.close();
     };
   }, [router]);
 
   async function startRefresh() {
-    if (!state.available || state.isPending) {
+    if (!state.available || state.isPending || startRefreshInFlightRef.current) {
       return;
     }
 
     startRefreshInFlightRef.current = true;
-    const requestSequence = ++requestSequenceRef.current;
     setPopoverOpen(false);
     setState((prev) => ({
       ...prev,
@@ -128,25 +117,19 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
       const body: unknown = await res.json().catch(() => null);
 
       if (!res.ok && res.status !== 409) {
-        if (requestSequence === requestSequenceRef.current) {
-          setState({ ...unavailableCrawlerRefreshStatus, isPending: false });
-        }
+        setState({ ...unavailableCrawlerRefreshStatus, isPending: false });
         return;
       }
 
       const nextStatus = parseCrawlerRefreshStatus(body, true);
       const runningStatus = nextStatus.running ? nextStatus : { ...nextStatus, running: true };
-      if (requestSequence === requestSequenceRef.current) {
-        wasRunningRef.current = true;
-        setState({
-          ...runningStatus,
-          isPending: false,
-        });
-      }
+      wasRunningRef.current = true;
+      setState({
+        ...runningStatus,
+        isPending: false,
+      });
     } catch {
-      if (requestSequence === requestSequenceRef.current) {
-        setState({ ...unavailableCrawlerRefreshStatus, isPending: false });
-      }
+      setState({ ...unavailableCrawlerRefreshStatus, isPending: false });
     } finally {
       startRefreshInFlightRef.current = false;
     }

--- a/apps/web/src/components/layout/action-icons.tsx
+++ b/apps/web/src/components/layout/action-icons.tsx
@@ -3,7 +3,7 @@
 import { mfUrls } from "@mf-dashboard/meta/urls";
 import { Home, HelpCircle, RefreshCw } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import type {
   CrawlerRunStepDetails,
   CrawlerRunStepStatus,
@@ -54,11 +54,26 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
   const router = useRouter();
   const wasRunningRef = useRef(false);
   const startRefreshInFlightRef = useRef(false);
+  const pendingStatusRef = useRef<CrawlerRefreshStatus | null>(null);
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [state, setState] = useState<CrawlerRefreshButtonState>({
     ...unavailableCrawlerRefreshStatus,
     isPending: true,
   });
+
+  const applyStatus = useCallback(
+    (nextStatus: CrawlerRefreshStatus) => {
+      setState({ ...nextStatus, isPending: false });
+      if (!nextStatus.running && nextStatus.latestRun?.runStatus !== "failed") {
+        setPopoverOpen(false);
+      }
+      if (nextStatus.available && wasRunningRef.current && !nextStatus.running) {
+        router.refresh();
+      }
+      wasRunningRef.current = nextStatus.running;
+    },
+    [router],
+  );
 
   useEffect(() => {
     const events = new EventSource("/api/crawler/refresh/");
@@ -70,20 +85,13 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
     }
 
     events.onmessage = (event) => {
-      if (startRefreshInFlightRef.current) {
-        return;
-      }
-
       try {
         const nextStatus = parseCrawlerRefreshStatus(JSON.parse(event.data) as unknown, true);
-        setState({ ...nextStatus, isPending: false });
-        if (!nextStatus.running && nextStatus.latestRun?.runStatus !== "failed") {
-          setPopoverOpen(false);
+        if (startRefreshInFlightRef.current) {
+          pendingStatusRef.current = nextStatus;
+          return;
         }
-        if (nextStatus.available && wasRunningRef.current && !nextStatus.running) {
-          router.refresh();
-        }
-        wasRunningRef.current = nextStatus.running;
+        applyStatus(nextStatus);
       } catch {
         setUnavailable();
       }
@@ -96,7 +104,7 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
     return () => {
       events.close();
     };
-  }, [router]);
+  }, [applyStatus]);
 
   async function startRefresh() {
     if (!state.available || state.isPending || startRefreshInFlightRef.current) {
@@ -104,6 +112,7 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
     }
 
     startRefreshInFlightRef.current = true;
+    pendingStatusRef.current = null;
     setPopoverOpen(false);
     setState((prev) => ({
       ...prev,
@@ -132,6 +141,11 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
       setState({ ...unavailableCrawlerRefreshStatus, isPending: false });
     } finally {
       startRefreshInFlightRef.current = false;
+      const pendingStatus = pendingStatusRef.current;
+      pendingStatusRef.current = null;
+      if (pendingStatus) {
+        applyStatus(pendingStatus);
+      }
     }
   }
 

--- a/apps/web/src/components/layout/action-icons.tsx
+++ b/apps/web/src/components/layout/action-icons.tsx
@@ -117,6 +117,7 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
       return;
     }
 
+    const statusBeforeRefresh = state;
     startRefreshInFlightRef.current = true;
     pendingStatusRef.current = null;
     pendingWasRunningRef.current = false;
@@ -135,7 +136,7 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
       const body: unknown = await res.json().catch(() => null);
 
       if (!res.ok && res.status !== 409) {
-        setState({ ...unavailableCrawlerRefreshStatus, isPending: false });
+        setState({ ...statusBeforeRefresh, isPending: false });
         return;
       }
 
@@ -147,7 +148,7 @@ function RefreshControl({ iconSize }: { iconSize: string }) {
         isPending: false,
       });
     } catch {
-      setState({ ...unavailableCrawlerRefreshStatus, isPending: false });
+      setState({ ...statusBeforeRefresh, isPending: false });
     } finally {
       startRefreshInFlightRef.current = false;
       const pendingStatus = pendingStatusRef.current as CrawlerRefreshStatus | null;


### PR DESCRIPTION
# Summary

- replace browser-side status polling with an `EventSource` connection
- stream crawler state changes from filesystem events, including initial state and heartbeat frames
- proxy the SSE body through the Next.js route and release watchers, timers, and connections on disconnect
- refactor refresh state handling and cover stream, transition, error, and cleanup behavior

## Linear Issue

- [HIR-134](https://linear.app/hiroppy/issue/HIR-134/更新状態の取得をsseへ変更してリファクタリング)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | Status delivery changed from polling to SSE across crawler, proxy, and UI | Idle, running, success, and failure states reach the existing UI without polling |
| Reliability | Long-lived streams must survive normal operation and clean up on disconnect | Watchers, heartbeat timers, upstream streams, and `EventSource` connections are released |
| Performance efficiency | The ticket removes fixed-interval requests | Only filesystem state changes produce status events; unrelated database writes are ignored |
| Security | The status route remains browser-accessible only from the dashboard origin | Existing same-origin checks reject cross-site stream requests and run triggers |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| State transition testing | Refresh behavior is driven by idle/running/terminal transitions | Initial state, start, success, failure, ambiguous starts, and dashboard refresh behavior |
| Branch testing | Route behavior depends on origin, upstream response, conflicts, and disconnects | Accepted/rejected requests, 409 handling, upstream failure, and resource cleanup |
| Error guessing | SSE introduces malformed payload and disconnect risks | Invalid events, connection errors, stale buffered events, and client/server cleanup paths |
| Checklist-based testing | The end-to-end stream crosses three processes | Crawler stream, Next.js proxy, browser EventSource, button state, and final refresh |

### Primary Test Conditions

- initial SSE state enables the refresh action when the crawler is idle
- POST transitions the control to running and a terminal SSE event refreshes the dashboard
- failed POST responses preserve stream-derived availability and remain reconcilable by later SSE events
- failed runs preserve the existing failure details UI and retry action
- crawler file and lock events emit status updates while unrelated files do not
- client disconnect closes filesystem watchers and heartbeat timers
- cross-site stream and run requests remain rejected

### Out-of-Scope Risks

- Reverse-proxy-specific buffering was not exercised against a deployed environment; the stream sends no-transform headers and heartbeat frames to mitigate buffering.
- A real Money Forward crawl was not started during QA; the browser flow used a deterministic local crawler service to avoid external account mutation.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [x] Storybook tests
- [x] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/crawler test — 26 files / 237 tests passed
pnpm --filter @mf-dashboard/web test:unit — 24 files / 404 tests passed
pnpm --filter @mf-dashboard/web test:storybook — 74 files / 333 tests passed
pnpm turbo typecheck — 9 packages passed
pnpm lint — passed without warnings
pnpm format:check — 499 files passed
GitHub CI — test, build-demo, crawler/web Docker builds, and e2e-web passed
Playwright local runtime walkthrough — SSE GET 200, refresh POST 202, running state and terminal refresh confirmed
curl against crawler and Next.js streams — both returned text/event-stream with initial state
```

### Checks Not Run

- Real Money Forward crawl — intentionally excluded to avoid external account mutation; deterministic local SSE runtime validation covered the changed interaction path.
