### PR TITLE
feat: add chat clear action

### DIFF
--- a/apps/web/src/components/chat/chat-provider.test.tsx
+++ b/apps/web/src/components/chat/chat-provider.test.tsx
@@ -4,7 +4,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatProvider, prepareChatMessagesForRequest, useFinanceChat } from "./chat-provider";
 
 const mocks = vi.hoisted(() => ({
+  clearError: vi.fn<() => void>(),
   sendMessage: vi.fn<(...args: unknown[]) => unknown>(),
+  setMessages: vi.fn<(...args: unknown[]) => void>(),
   useChat: vi.fn<(...args: unknown[]) => unknown>(),
   usePathname: vi.fn<() => string>(),
 }));
@@ -56,8 +58,10 @@ describe("ChatProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.useChat.mockReturnValue({
+      clearError: mocks.clearError,
       messages: [],
       sendMessage: mocks.sendMessage,
+      setMessages: mocks.setMessages,
       status: "ready",
     });
   });
@@ -198,6 +202,34 @@ describe("ChatProvider", () => {
       { text: "最初の質問" },
       { body: { groupId: "group-b" } },
     );
+  });
+
+  it("clears the messages, draft, and error state", () => {
+    function ChatClearer() {
+      const { clear, draft, setDraft } = useFinanceChat();
+
+      return (
+        <>
+          <span>{draft}</span>
+          <button onClick={() => setDraft("入力中")}>下書きを入力</button>
+          <button onClick={clear}>クリア</button>
+        </>
+      );
+    }
+
+    render(
+      <ChatProvider>
+        <ChatClearer />
+      </ChatProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "下書きを入力" }));
+    expect(screen.getByText("入力中")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "クリア" }));
+
+    expect(mocks.setMessages).toHaveBeenCalledWith([]);
+    expect(mocks.clearError).toHaveBeenCalledOnce();
+    expect(screen.queryByText("入力中")).toBeNull();
   });
 
   it("resolves the current group on a top-level route", () => {

--- a/apps/web/src/components/chat/chat-provider.tsx
+++ b/apps/web/src/components/chat/chat-provider.tsx
@@ -24,6 +24,7 @@ interface ChatContextValue {
   isSubmitting: boolean;
   messages: UIMessage[];
   addUserMessage: (text: string) => void;
+  clear: () => void;
   close: () => void;
   open: () => void;
   setDraft: (draft: string) => void;
@@ -124,12 +125,17 @@ function GroupChatProvider({
       }),
     [],
   );
-  const { error, messages, sendMessage, status } = useChat({
+  const { clearError, error, messages, sendMessage, setMessages, status } = useChat({
     id: `finance-chat:${groupId ?? "current"}`,
     messages: initialMessages,
     transport,
   });
   const isSubmitting = status === "submitted" || status === "streaming";
+  const clear = useCallback(() => {
+    setMessages([]);
+    setDraft("");
+    clearError();
+  }, [clearError, setMessages]);
   const close = useCallback(() => setIsOpen(false), [setIsOpen]);
   const open = useCallback(() => setIsOpen(true), [setIsOpen]);
 
@@ -152,6 +158,7 @@ function GroupChatProvider({
         isSubmitting,
         messages,
         addUserMessage,
+        clear,
         close,
         open,
         setDraft,

--- a/apps/web/src/components/chat/chat-shell.stories.tsx
+++ b/apps/web/src/components/chat/chat-shell.stories.tsx
@@ -43,6 +43,25 @@ export const Response: Story = {
   ),
 };
 
+export const ClearHistory: Story = {
+  render: () => (
+    <ChatProvider initialMessages={[response]} initialOpen>
+      <ChatShell />
+    </ChatProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const page = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(canvas.getByRole("button", { name: "チャットをクリア" }));
+    await expect(page.getByRole("dialog")).toBeInTheDocument();
+    await expect(page.getByText("チャットをクリアしますか？")).toBeInTheDocument();
+    await userEvent.click(page.getByRole("button", { name: "クリア" }));
+    await expect(canvas.queryByText(response.parts[0].text)).not.toBeInTheDocument();
+    await expect(canvas.getByText("家計の相談を始めましょう")).toBeInTheDocument();
+  },
+};
+
 export const Interaction: Story = {
   render: () => (
     <ChatProvider>

--- a/apps/web/src/components/chat/chat-shell.test.tsx
+++ b/apps/web/src/components/chat/chat-shell.test.tsx
@@ -43,6 +43,7 @@ describe("ChatShell", () => {
   it("shows an accessible configuration hint when chat fails", () => {
     vi.spyOn(chatProvider, "useFinanceChat").mockReturnValue({
       addUserMessage: vi.fn<(text: string) => void>(),
+      clear: vi.fn<() => void>(),
       close: vi.fn<() => void>(),
       draft: "",
       error: new Error("secret provider response"),
@@ -64,6 +65,7 @@ describe("ChatShell", () => {
   it("shows actionable guidance for a conversation size error", () => {
     vi.spyOn(chatProvider, "useFinanceChat").mockReturnValue({
       addUserMessage: vi.fn<(text: string) => void>(),
+      clear: vi.fn<() => void>(),
       close: vi.fn<() => void>(),
       draft: "",
       error: new Error(JSON.stringify({ error: { code: "REQUEST_TOO_LARGE" } })),
@@ -84,6 +86,7 @@ describe("ChatShell", () => {
   it("shows retry guidance when chat concurrency is full", () => {
     vi.spyOn(chatProvider, "useFinanceChat").mockReturnValue({
       addUserMessage: vi.fn<(text: string) => void>(),
+      clear: vi.fn<() => void>(),
       close: vi.fn<() => void>(),
       draft: "",
       error: new Error(JSON.stringify({ error: { code: "CHAT_BUSY" } })),
@@ -105,6 +108,7 @@ describe("ChatShell", () => {
     const addUserMessage = vi.fn<(text: string) => void>();
     vi.spyOn(chatProvider, "useFinanceChat").mockReturnValue({
       addUserMessage,
+      clear: vi.fn<() => void>(),
       close: vi.fn<() => void>(),
       draft: "重ねて送らない",
       isOpen: true,
@@ -142,6 +146,7 @@ describe("ChatShell", () => {
     });
     const chatState: ReturnType<typeof chatProvider.useFinanceChat> = {
       addUserMessage: vi.fn<(text: string) => void>(),
+      clear: vi.fn<() => void>(),
       close: vi.fn<() => void>(),
       draft: "",
       isOpen: true,
@@ -227,6 +232,7 @@ describe("ChatShell", () => {
     const addUserMessage = vi.fn<(text: string) => void>();
     vi.spyOn(chatProvider, "useFinanceChat").mockReturnValue({
       addUserMessage,
+      clear: vi.fn<() => void>(),
       close: vi.fn<() => void>(),
       draft: "",
       isOpen: true,
@@ -249,6 +255,7 @@ describe("ChatShell", () => {
     const addUserMessage = vi.fn<(text: string) => void>();
     vi.spyOn(chatProvider, "useFinanceChat").mockReturnValue({
       addUserMessage,
+      clear: vi.fn<() => void>(),
       close: vi.fn<() => void>(),
       draft: "",
       isOpen: true,
@@ -290,6 +297,7 @@ describe("ChatShell", () => {
     const setDraft = vi.fn<(draft: string) => void>();
     vi.spyOn(chatProvider, "useFinanceChat").mockReturnValue({
       addUserMessage,
+      clear: vi.fn<() => void>(),
       close: vi.fn<() => void>(),
       draft: "送信するメッセージ",
       isOpen: true,
@@ -318,6 +326,7 @@ describe("ChatShell", () => {
     const setDraft = vi.fn<(draft: string) => void>();
     vi.spyOn(chatProvider, "useFinanceChat").mockReturnValue({
       addUserMessage,
+      clear: vi.fn<() => void>(),
       close: vi.fn<() => void>(),
       draft: "x".repeat(8_001),
       isOpen: true,
@@ -347,6 +356,7 @@ describe("ChatShell", () => {
     const addUserMessage = vi.fn<(text: string) => void>();
     vi.spyOn(chatProvider, "useFinanceChat").mockReturnValue({
       addUserMessage,
+      clear: vi.fn<() => void>(),
       close: vi.fn<() => void>(),
       draft: "変換中",
       isOpen: true,
@@ -470,6 +480,7 @@ describe("ChatShell", () => {
   it("renders the latest response while streaming", () => {
     const chatState = {
       addUserMessage: vi.fn<(text: string) => void>(),
+      clear: vi.fn<() => void>(),
       close: vi.fn<() => void>(),
       draft: "",
       isOpen: true,
@@ -521,6 +532,7 @@ describe("ChatShell", () => {
   it("shows only the latest SQL in the loading indicator", () => {
     vi.spyOn(chatProvider, "useFinanceChat").mockReturnValue({
       addUserMessage: vi.fn<(text: string) => void>(),
+      clear: vi.fn<() => void>(),
       close: vi.fn<() => void>(),
       draft: "",
       isOpen: true,

--- a/apps/web/src/components/chat/chat-shell.tsx
+++ b/apps/web/src/components/chat/chat-shell.tsx
@@ -327,7 +327,7 @@ export function ChatShell({ suggestedPrompts = DEFAULT_CHAT_SUGGESTED_PROMPTS }:
             </header>
 
             <Dialog open={isClearDialogOpen} onOpenChange={setIsClearDialogOpen}>
-              <DialogContent className="w-[calc(100%-2rem)] max-w-sm">
+              <DialogContent backdropBlur={false} className="w-[calc(100%-2rem)] max-w-sm">
                 <DialogTitle>チャットをクリアしますか？</DialogTitle>
                 <DialogDescription>
                   会話履歴と入力中のメッセージが削除されます。この操作は取り消せません。

--- a/apps/web/src/components/chat/chat-shell.tsx
+++ b/apps/web/src/components/chat/chat-shell.tsx
@@ -3,7 +3,7 @@
 import { financeChartSchema, type FinanceChart } from "@mf-dashboard/analytics/chat/chart";
 import { financeChatHrefSchema } from "@mf-dashboard/analytics/chat/navigation";
 import { getToolName, isToolUIPart, type UIMessage } from "ai";
-import { Bot, Send, Sparkles, X } from "lucide-react";
+import { Bot, Send, Sparkles, Trash2, X } from "lucide-react";
 import {
   useCallback,
   useEffect,
@@ -22,6 +22,7 @@ import { CHAT_MESSAGE_MAX_LENGTH } from "../../lib/chat-limits";
 import { cn } from "../../lib/utils";
 import { FinanceChatChart } from "../charts/finance-chat-chart";
 import { Button } from "../ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "../ui/dialog";
 import { ChatMarkdown } from "./chat-markdown";
 import { useFinanceChat } from "./chat-provider";
 
@@ -122,13 +123,24 @@ function getLatestDatabaseQuery(messages: UIMessage[]): string | undefined {
 }
 
 export function ChatShell({ suggestedPrompts = DEFAULT_CHAT_SUGGESTED_PROMPTS }: ChatShellProps) {
-  const { addUserMessage, close, draft, error, isOpen, isSubmitting, messages, open, setDraft } =
-    useFinanceChat();
+  const {
+    addUserMessage,
+    clear,
+    close,
+    draft,
+    error,
+    isOpen,
+    isSubmitting,
+    messages,
+    open,
+    setDraft,
+  } = useFinanceChat();
   const triggerRef = useRef<HTMLButtonElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const messagesRef = useRef<HTMLDivElement>(null);
   const isResizingRef = useRef(false);
   const shouldFollowLatestRef = useRef(true);
+  const [isClearDialogOpen, setIsClearDialogOpen] = useState(false);
   const [panelWidth, setPanelWidth] = useState(DEFAULT_PANEL_WIDTH);
   const latestDatabaseQuery = getLatestDatabaseQuery(messages);
 
@@ -141,6 +153,7 @@ export function ChatShell({ suggestedPrompts = DEFAULT_CHAT_SUGGESTED_PROMPTS }:
     if (!isOpen) return;
 
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (isClearDialogOpen) return;
       if (event.key === "Escape" && !event.isComposing && event.keyCode !== 229) closeChat();
     };
 
@@ -149,7 +162,7 @@ export function ChatShell({ suggestedPrompts = DEFAULT_CHAT_SUGGESTED_PROMPTS }:
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [closeChat, isOpen]);
+  }, [closeChat, isClearDialogOpen, isOpen]);
 
   useEffect(() => {
     if (isOpen) shouldFollowLatestRef.current = true;
@@ -290,16 +303,56 @@ export function ChatShell({ suggestedPrompts = DEFAULT_CHAT_SUGGESTED_PROMPTS }:
                 <Bot aria-hidden="true" className="size-5" />
               </span>
               <h2 className="min-w-0 flex-1 font-semibold">家計AIアシスタント</h2>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                aria-label="家計AIチャットを閉じる"
-                onClick={closeChat}
-              >
-                <X aria-hidden="true" />
-              </Button>
+              <div className="flex items-center gap-0">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="チャットをクリア"
+                  disabled={isSubmitting || (messages.length === 0 && draft.length === 0 && !error)}
+                  onClick={() => setIsClearDialogOpen(true)}
+                >
+                  <Trash2 aria-hidden="true" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="家計AIチャットを閉じる"
+                  onClick={closeChat}
+                >
+                  <X aria-hidden="true" />
+                </Button>
+              </div>
             </header>
+
+            <Dialog open={isClearDialogOpen} onOpenChange={setIsClearDialogOpen}>
+              <DialogContent className="w-[calc(100%-2rem)] max-w-sm">
+                <DialogTitle>チャットをクリアしますか？</DialogTitle>
+                <DialogDescription>
+                  会話履歴と入力中のメッセージが削除されます。この操作は取り消せません。
+                </DialogDescription>
+                <div className="mt-6 flex justify-end gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => setIsClearDialogOpen(false)}
+                  >
+                    キャンセル
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    onClick={() => {
+                      clear();
+                      setIsClearDialogOpen(false);
+                    }}
+                  >
+                    クリア
+                  </Button>
+                </div>
+              </DialogContent>
+            </Dialog>
 
             <div
               ref={messagesRef}

--- a/apps/web/src/components/ui/dialog.stories.tsx
+++ b/apps/web/src/components/ui/dialog.stories.tsx
@@ -63,3 +63,27 @@ export const LongContent: Story = {
     </Dialog>
   ),
 };
+
+export const WithoutBackdropBlur: Story = {
+  args: {
+    children: null,
+  },
+  render: () => (
+    <Dialog>
+      <DialogTrigger>
+        <button
+          type="button"
+          className="px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90"
+        >
+          ダイアログを開く
+        </button>
+      </DialogTrigger>
+      <DialogContent backdropBlur={false}>
+        <DialogTitle>背景ぼかしなし</DialogTitle>
+        <DialogDescription>
+          背景を暗く保ったまま、ぼかしを無効にしたダイアログです。
+        </DialogDescription>
+      </DialogContent>
+    </Dialog>
+  ),
+};

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -33,16 +33,18 @@ function DialogTrigger({ children, className }: DialogTriggerProps) {
 }
 
 interface DialogContentProps {
+  backdropBlur?: boolean;
   children: ReactNode;
   className?: string;
 }
 
-function DialogContent({ children, className }: DialogContentProps) {
+function DialogContent({ backdropBlur = true, children, className }: DialogContentProps) {
   return (
     <BaseDialog.Portal>
       <BaseDialog.Backdrop
         className={cn(
-          "fixed inset-0 z-50 bg-black/40 backdrop-blur-sm",
+          "fixed inset-0 z-50 bg-black/40",
+          backdropBlur && "backdrop-blur-sm",
           "transition-opacity duration-200",
           "data-[ending-style]:opacity-0",
           "data-[starting-style]:opacity-0",


### PR DESCRIPTION
# Summary

- Add an icon-only clear action to the finance AI chat header.
- Clear chat messages, the current draft, and the chat error state through the shared chat provider.
- Require confirmation before clearing and disable the action while a response is in progress or there is nothing to clear.
- Add a reusable `backdropBlur` option to `DialogContent` and disable backdrop blur for the chat confirmation.
- Add Storybook interaction coverage for the confirmation and clear flow, plus unit coverage for chat state reset.

## Linear Issue

- N/A

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | The action must clear all intended transient chat state without affecting unrelated dashboard state. | Confirming clears messages, draft, and chat errors; cancelling preserves them. |
| Interaction capability | Clearing is destructive within the current session and needs clear, predictable controls. | The icon has an accessible label, requires confirmation, supports cancellation, and is disabled during submission or when there is nothing to clear. |
| Accessibility | The icon-only action and modal must remain operable and understandable without visible button text. | The trigger has an accessible name; the dialog exposes a title and description; keyboard dismissal does not also close the chat panel. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Decision table testing | Availability depends on submission state and whether messages, draft, or errors exist. | Clear is enabled only when state can be cleared and no response is in progress. |
| State transition testing | The flow moves from chat content to confirmation, cancellation, or cleared empty state. | Opening the dialog does not clear immediately; confirmation reaches the empty state; cancellation paths leave chat state intact. |
| Branch testing | The provider reset has distinct message, draft, and error reset operations. | Unit coverage verifies all three reset effects are invoked. |
| Checklist-based testing | The change uses established dialog and button primitives with accessibility requirements. | Accessible names, dialog semantics, destructive styling, focus-safe dismissal, responsive width, and optional backdrop blur are checked. |

### Primary Test Conditions

- A populated chat opens a confirmation dialog when the trash icon is selected.
- Confirming clears message history, the current draft, and error state.
- Cancelling, clicking outside, or pressing Escape dismisses the dialog without clearing.
- Escape while the dialog is open does not also close the underlying chat panel.
- The clear action is disabled while a response is being generated and when no clearable state exists.
- After confirmation, the chat returns to its empty state and suggested prompts remain available.
- Dialogs retain backdrop blur by default, while the chat confirmation opts out and keeps the darkened backdrop.

### Out-of-Scope Risks

- Browser persistence and server-side history deletion are out of scope because chat state is intentionally session-local and is not written to browser storage or a persistence API.
- End-to-end browser coverage is omitted because the provider behavior and complete dialog interaction are covered by unit and Storybook tests without requiring backend data.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [x] Storybook tests
- [ ] E2E tests
- [ ] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/web test:unit — passed (32 files, 494 tests)
pnpm --filter @mf-dashboard/web test:storybook — passed (78 files, 346 tests)
pnpm turbo typecheck --filter=@mf-dashboard/web — passed
pnpm format:check — passed
pre-commit lint — passed
pre-commit knip --fix — passed with no remaining worktree changes
git diff --check — passed
```

### Checks Not Run

- E2E tests — not run; the interaction is covered by Storybook and provider unit tests and does not cross a backend boundary.
- Manual verification — not run; automated Storybook interaction coverage validates the rendered confirmation flow.
- Build — not run per repository guidance; no explicit build was requested.
