### PR TITLE
fix(renovate): avoid base branch collisions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
   "rangeStrategy": "pin",
   "labels": ["deps"],
   "baseBranchPatterns": ["new-release"],
+  "additionalBranchPrefix": "{{baseBranch}}-",
   "packageRules": [
     {
       "groupName": "npm patch dependencies",


### PR DESCRIPTION
# Summary

- add `additionalBranchPrefix: "{{baseBranch}}-"` to Renovate configuration
- generate `new-release`-specific Renovate branch names so they do not collide with existing `main`-targeted Renovate PR branches

The existing `baseBranchPatterns` setting correctly selects `new-release`, but Renovate identifies update PRs by branch name. Existing `renovate/*` branches targeting `main` therefore prevent equivalent updates from being created against `new-release`. The added templated prefix makes those branch names unique per base branch.

## Linear Issue

- N/A

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | Renovate must create dependency PR branches for `new-release` without colliding with existing `main` branches. | Generated branch names include the base branch prefix and the configuration validates successfully. |
| Maintainability | The solution should use Renovate's supported templating option without custom automation. | `additionalBranchPrefix` uses the supported `baseBranch` template and the diff remains limited to one configuration line. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Checklist-based testing | This is a declarative configuration-only change with a small set of structural requirements. | Confirms target branch selection, unique prefix configuration, formatting, and intended diff scope. |
| Error guessing | Invalid Renovate options or templates are the primary likely failure mode. | The Renovate validator detects unsupported or malformed configuration. |

### Primary Test Conditions

- `baseBranchPatterns` continues to target `new-release`.
- Renovate branch names receive a `new-release-` additional prefix.
- Existing package rules and dependency grouping remain unchanged.
- The repository remains correctly formatted.

### Out-of-Scope Risks

- A hosted Renovate run is not executed from this PR; actual PR creation will be observed after this configuration is merged and Renovate runs again.
- Existing `main`-targeted Renovate PRs are not closed or modified by this change.

## Verification

- [ ] Unit tests
- [ ] Type checking
- [ ] Lint
- [ ] Storybook tests
- [ ] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --package=renovate dlx renovate-config-validator renovate.json — passed
pnpm format:check — passed
git diff --check — passed
git diff --cached --check — passed
pre-commit format hook — passed
```

### Checks Not Run

- Unit, type, lint, Storybook, and E2E checks were not run because the change only affects Renovate metadata and contains no application or test code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency-update branch naming to include the target base branch as a prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->