### PR TITLE
feat(web): add cash flow category drilldown

### DIFF
--- a/apps/web/src/components/charts/pie-chart.tsx
+++ b/apps/web/src/components/charts/pie-chart.tsx
@@ -16,6 +16,8 @@ interface PieChartProps {
   data: Array<{ name: string; value: number }>;
   height?: number;
   useCustomColors?: boolean;
+  selectedName?: string;
+  onSelect?: (name: string) => void;
 }
 
 // Minimum percentage to show label (hide labels for small slices)
@@ -27,6 +29,8 @@ export function PieChart({
   data,
   height = 300,
   useCustomColors = true,
+  selectedName,
+  onSelect,
 }: PieChartProps) {
   const total = data.reduce((sum, item) => sum + item.value, 0);
   const colors = useCustomColors
@@ -60,9 +64,20 @@ export function PieChart({
                   : ""
               }
               labelLine={false}
+              isAnimationActive={false}
+              onClick={(entry) => {
+                if (entry.name) onSelect?.(entry.name);
+              }}
+              className={onSelect ? "cursor-pointer" : undefined}
             >
-              {data.map((_, index) => (
-                <Cell key={`cell-${index}`} fill={colors[index]} />
+              {data.map((item, index) => (
+                <Cell
+                  key={`cell-${index}`}
+                  fill={colors[index]}
+                  opacity={selectedName && selectedName !== item.name ? 0.35 : 1}
+                  stroke={selectedName === item.name ? "var(--foreground)" : undefined}
+                  strokeWidth={selectedName === item.name ? 2 : undefined}
+                />
               ))}
             </Pie>
             <Tooltip
@@ -74,7 +89,14 @@ export function PieChart({
         {/* Legend for all items */}
         <div className="mt-4 flex flex-wrap justify-center gap-x-4 gap-y-1 text-sm">
           {data.map((item, index) => (
-            <div key={item.name} className="flex items-center gap-1.5">
+            <button
+              key={item.name}
+              type="button"
+              className="flex items-center gap-1.5 rounded-md px-1 py-0.5 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none"
+              aria-pressed={onSelect ? selectedName === item.name : undefined}
+              onClick={() => onSelect?.(item.name)}
+              disabled={!onSelect}
+            >
               <div
                 className="w-2.5 h-2.5 rounded-full shrink-0"
                 style={{ backgroundColor: colors[index] }}
@@ -85,7 +107,7 @@ export function PieChart({
                   {((item.value / total) * 100).toFixed(0)}%
                 </span>
               </span>
-            </div>
+            </button>
           ))}
         </div>
         <div className="text-center mt-2">

--- a/apps/web/src/components/info/transaction-stats-utils.test.ts
+++ b/apps/web/src/components/info/transaction-stats-utils.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { calculateCompositionPercentage, createBreakdowns } from "./transaction-stats-utils";
+
+const transaction = {
+  date: "2026-01-01",
+  description: null,
+  accountName: null,
+  category: null,
+  subCategory: null,
+} as const;
+
+describe("createBreakdowns", () => {
+  it("matches income by subcategory and expense by category", () => {
+    const transactions = [
+      {
+        ...transaction,
+        id: 1,
+        amount: 200,
+        type: "income" as const,
+        category: "収入",
+        subCategory: "給与",
+      },
+      {
+        ...transaction,
+        id: 2,
+        amount: 100,
+        type: "expense" as const,
+        category: "食費",
+        subCategory: "外食",
+      },
+    ];
+
+    expect(createBreakdowns([{ name: "給与", value: 200 }], "income", transactions)).toMatchObject([
+      { name: "給与", transactions: [{ id: 1, category: "給与" }] },
+    ]);
+    expect(createBreakdowns([{ name: "食費", value: 100 }], "expense", transactions)).toMatchObject(
+      [{ name: "食費", transactions: [{ id: 2, category: "食費" }] }],
+    );
+  });
+
+  it("uses その他 for missing categories", () => {
+    const transactions = [
+      { ...transaction, id: 1, amount: 100, type: "income" as const },
+      { ...transaction, id: 2, amount: 50, type: "expense" as const },
+    ];
+
+    expect(
+      createBreakdowns([{ name: "その他", value: 100 }], "income", transactions),
+    ).toMatchObject([
+      { name: "その他", categories: ["その他"], transactions: [{ id: 1, category: "その他" }] },
+    ]);
+    expect(
+      createBreakdowns([{ name: "その他", value: 50 }], "expense", transactions),
+    ).toMatchObject([
+      { name: "その他", categories: ["その他"], transactions: [{ id: 2, category: "その他" }] },
+    ]);
+  });
+
+  it("consolidates the sixth category into その他 with its transactions", () => {
+    const categories = ["A", "B", "C", "D", "E", "F"].map((name, index) => ({
+      name,
+      value: 60 - index * 10,
+    }));
+    const transactions = categories.map((category, index) => ({
+      ...transaction,
+      id: index + 1,
+      amount: category.value,
+      type: "expense" as const,
+      category: category.name,
+    }));
+
+    const result = createBreakdowns(categories, "expense", transactions);
+
+    expect(result).toHaveLength(6);
+    expect(result.at(-1)).toMatchObject({
+      name: "その他",
+      value: 10,
+      categories: ["F"],
+      transactions: [{ id: 6, category: "F" }],
+    });
+  });
+});
+
+describe("calculateCompositionPercentage", () => {
+  it("returns zero when the total is zero", () => {
+    expect(calculateCompositionPercentage(0, 0)).toBe(0);
+  });
+
+  it("calculates a percentage for a positive total", () => {
+    expect(calculateCompositionPercentage(25, 100)).toBe(25);
+  });
+});

--- a/apps/web/src/components/info/transaction-stats-utils.ts
+++ b/apps/web/src/components/info/transaction-stats-utils.ts
@@ -1,0 +1,72 @@
+import { consolidateCategories } from "../../lib/aggregation";
+import type { CategoryBreakdown, CategoryTransaction } from "./transaction-stats.client";
+
+interface BreakdownTransaction {
+  id: number;
+  date: string;
+  description: string | null;
+  amount: number;
+  accountName: string | null;
+  category: string | null;
+  subCategory: string | null;
+  type: string;
+}
+
+interface NamedValue {
+  name: string;
+  value: number;
+}
+
+export function createBreakdowns(
+  categories: NamedValue[],
+  type: "income" | "expense",
+  transactions: BreakdownTransaction[],
+): CategoryBreakdown[] {
+  const consolidated = consolidateCategories(categories);
+  const visibleNames = new Set(
+    consolidated.filter((category) => category.name !== "その他").map((category) => category.name),
+  );
+
+  return consolidated.map((category) => {
+    const memberNames =
+      category.name === "その他"
+        ? categories
+            .filter((item) => item.name === "その他" || !visibleNames.has(item.name))
+            .map((item) => item.name)
+        : [category.name];
+    const memberNameSet = new Set(memberNames);
+    const matchingTransactions = transactions
+      .filter((transaction) => {
+        if (transaction.type !== type) return false;
+        const transactionCategory =
+          type === "income"
+            ? (transaction.subCategory ?? "その他")
+            : (transaction.category ?? "その他");
+        return memberNameSet.has(transactionCategory);
+      })
+      .map(
+        (transaction): CategoryTransaction => ({
+          id: transaction.id,
+          date: transaction.date,
+          description: transaction.description,
+          amount: transaction.amount,
+          accountName: transaction.accountName,
+          category:
+            type === "income"
+              ? (transaction.subCategory ?? "その他")
+              : (transaction.category ?? "その他"),
+        }),
+      )
+      .sort((a, b) => b.amount - a.amount);
+
+    return {
+      ...category,
+      categories: memberNames,
+      transactions: matchingTransactions,
+    };
+  });
+}
+
+export function calculateCompositionPercentage(value: number, total: number): number {
+  return total === 0 ? 0 : (value / total) * 100;
+}

--- a/apps/web/src/components/info/transaction-stats.client.tsx
+++ b/apps/web/src/components/info/transaction-stats.client.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { X } from "lucide-react";
+import { useState } from "react";
+import { getCategoryColor } from "../../lib/colors";
+import { formatCurrency, formatDate } from "../../lib/format";
+import { PieChart } from "../charts/pie-chart";
+import { AmountDisplay } from "../ui/amount-display";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "../ui/dialog";
+
+export interface CategoryTransaction {
+  id: number;
+  date: string;
+  description: string | null;
+  amount: number;
+  accountName: string | null;
+  category: string;
+}
+
+export interface CategoryBreakdown {
+  name: string;
+  value: number;
+  categories: string[];
+  transactions: CategoryTransaction[];
+}
+
+interface TransactionStatsClientProps {
+  year: string;
+  income: CategoryBreakdown[];
+  expense: CategoryBreakdown[];
+}
+
+export function TransactionStatsClient({ year, income, expense }: TransactionStatsClientProps) {
+  const [selection, setSelection] = useState<{ type: "income" | "expense"; name: string } | null>(
+    null,
+  );
+
+  const selectedBreakdown = selection
+    ? (selection.type === "income" ? income : expense).find(
+        (breakdown) => breakdown.name === selection.name,
+      )
+    : undefined;
+  const selectedTotal = selection
+    ? (selection.type === "income" ? income : expense).reduce(
+        (sum, breakdown) => sum + breakdown.value,
+        0,
+      )
+    : 0;
+  const selectedTransactions = selectedBreakdown
+    ? [...selectedBreakdown.transactions].sort((a, b) => b.amount - a.amount)
+    : [];
+
+  const select = (type: "income" | "expense", name: string) => {
+    setSelection((current) =>
+      current?.type === type && current.name === name ? null : { type, name },
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-6 grid-cols-1 md:grid-cols-2">
+        {income.length > 0 && (
+          <PieChart
+            title="収入カテゴリ別内訳"
+            data={income}
+            height={280}
+            useCustomColors={false}
+            selectedName={selection?.type === "income" ? selection.name : undefined}
+            onSelect={(name) => select("income", name)}
+          />
+        )}
+        {expense.length > 0 && (
+          <PieChart
+            title="支出カテゴリ別内訳"
+            data={expense}
+            height={280}
+            selectedName={selection?.type === "expense" ? selection.name : undefined}
+            onSelect={(name) => select("expense", name)}
+          />
+        )}
+      </div>
+
+      <Dialog
+        open={Boolean(selection && selectedBreakdown)}
+        onOpenChange={(open) => {
+          if (!open) setSelection(null);
+        }}
+      >
+        {selection && selectedBreakdown && (
+          <DialogContent className="flex max-h-[85vh] w-[calc(100%-2rem)] max-w-3xl flex-col overflow-hidden p-0">
+            <div className="flex items-center justify-between gap-4 border-b px-5 py-4 sm:px-6">
+              <div>
+                <DialogTitle className="leading-tight">
+                  {year}年 {selectedBreakdown.name}の明細
+                </DialogTitle>
+                <DialogDescription className="sr-only">
+                  {selectedBreakdown.name}カテゴリに含まれる年間取引の詳細
+                </DialogDescription>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="shrink-0"
+                aria-label="明細を閉じる"
+                onClick={() => setSelection(null)}
+              >
+                <X aria-hidden="true" />
+              </Button>
+            </div>
+
+            <div className="grid shrink-0 grid-cols-2 gap-4 border-b px-5 py-4 sm:grid-cols-3 sm:px-6">
+              <div>
+                <p className="text-sm text-muted-foreground">年間合計</p>
+                <AmountDisplay
+                  amount={selectedBreakdown.value}
+                  type={selection.type}
+                  size="xl"
+                  weight="bold"
+                />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">構成比</p>
+                <p className="text-xl font-bold">
+                  {((selectedBreakdown.value / selectedTotal) * 100).toFixed(1)}%
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">取引件数</p>
+                <p className="text-xl font-bold">{selectedBreakdown.transactions.length}件</p>
+              </div>
+            </div>
+
+            <div className="min-h-0 space-y-5 overflow-y-auto p-5 sm:p-6">
+              {selectedBreakdown.categories.length > 1 && (
+                <div>
+                  <p className="mb-2 text-sm font-medium">含まれるカテゴリ</p>
+                  <div className="flex flex-wrap gap-2">
+                    {selectedBreakdown.categories.map((category) => (
+                      <Badge
+                        key={category}
+                        className="border text-foreground"
+                        style={{
+                          backgroundColor: `color-mix(in srgb, ${getCategoryColor(category)} 15%, transparent)`,
+                          borderColor: getCategoryColor(category),
+                        }}
+                      >
+                        {category}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <div className="divide-y divide-border rounded-lg border">
+                {selectedTransactions.map((transaction) => (
+                  <div key={transaction.id} className="flex items-center justify-between gap-3 p-3">
+                    <div className="min-w-0">
+                      <p className="truncate font-medium">
+                        {transaction.description || "内容なし"}
+                      </p>
+                      <p className="text-sm text-muted-foreground">
+                        {formatDate(transaction.date)}
+                        {transaction.accountName ? ` / ${transaction.accountName}` : ""}
+                        {selectedBreakdown.categories.length > 1
+                          ? ` / ${transaction.category}`
+                          : ""}
+                      </p>
+                    </div>
+                    <span
+                      className={
+                        selection.type === "income"
+                          ? "shrink-0 font-semibold text-income"
+                          : "shrink-0 font-semibold text-expense"
+                      }
+                    >
+                      {formatCurrency(transaction.amount)}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </DialogContent>
+        )}
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/components/info/transaction-stats.client.tsx
+++ b/apps/web/src/components/info/transaction-stats.client.tsx
@@ -9,6 +9,7 @@ import { AmountDisplay } from "../ui/amount-display";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "../ui/dialog";
+import { calculateCompositionPercentage } from "./transaction-stats-utils";
 
 export interface CategoryTransaction {
   id: number;
@@ -124,7 +125,10 @@ export function TransactionStatsClient({ year, income, expense }: TransactionSta
               <div>
                 <p className="text-sm text-muted-foreground">構成比</p>
                 <p className="text-xl font-bold">
-                  {((selectedBreakdown.value / selectedTotal) * 100).toFixed(1)}%
+                  {calculateCompositionPercentage(selectedBreakdown.value, selectedTotal).toFixed(
+                    1,
+                  )}
+                  %
                 </p>
               </div>
               <div>
@@ -134,7 +138,8 @@ export function TransactionStatsClient({ year, income, expense }: TransactionSta
             </div>
 
             <div className="min-h-0 space-y-5 overflow-y-auto p-5 sm:p-6">
-              {selectedBreakdown.categories.length > 1 && (
+              {(selectedBreakdown.categories.length > 1 ||
+                selectedBreakdown.categories[0] !== selectedBreakdown.name) && (
                 <div>
                   <p className="mb-2 text-sm font-medium">含まれるカテゴリ</p>
                   <div className="flex flex-wrap gap-2">
@@ -164,7 +169,8 @@ export function TransactionStatsClient({ year, income, expense }: TransactionSta
                       <p className="text-sm text-muted-foreground">
                         {formatDate(transaction.date)}
                         {transaction.accountName ? ` / ${transaction.accountName}` : ""}
-                        {selectedBreakdown.categories.length > 1
+                        {selectedBreakdown.categories.length > 1 ||
+                        selectedBreakdown.categories[0] !== selectedBreakdown.name
                           ? ` / ${transaction.category}`
                           : ""}
                       </p>

--- a/apps/web/src/components/info/transaction-stats.stories.tsx
+++ b/apps/web/src/components/info/transaction-stats.stories.tsx
@@ -1,69 +1,109 @@
-import { getTransactions } from "@mf-dashboard/db";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-import { mocked } from "storybook/test";
-import { TransactionStats } from "./transaction-stats";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+import { TransactionStatsClient } from "./transaction-stats.client";
 
 const meta = {
   title: "Info/TransactionStats",
-  component: TransactionStats,
+  component: TransactionStatsClient,
   tags: ["autodocs"],
-} satisfies Meta<typeof TransactionStats>;
+} satisfies Meta<typeof TransactionStatsClient>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const makeTransaction = (
-  id: number,
-  overrides: Partial<{
-    date: string;
-    category: string;
-    description: string;
-    amount: number;
-    type: string;
-    isTransfer: boolean;
-    transferTargetAccountId: number | null;
-  }>,
-) => ({
-  id,
-  mfId: `mf-${id}`,
-  date: overrides.date ?? "2025-04-15",
-  category: overrides.category ?? "食費",
-  subCategory: null,
-  description: overrides.description ?? "取引",
-  amount: overrides.amount ?? -3000,
-  type: overrides.type ?? "expense",
-  isTransfer: overrides.isTransfer ?? false,
-  isExcludedFromCalculation: false,
-  accountId: 1,
-  accountName: "サンプル銀行",
-  transferTargetAccountId: overrides.transferTargetAccountId ?? null,
-});
-
 export const Default: Story = {
   args: {
-    year: "2025",
+    year: "2026",
+    income: [
+      {
+        name: "給与",
+        value: 4800000,
+        categories: ["給与"],
+        transactions: [
+          {
+            id: 1,
+            date: "2026-06-25",
+            description: "給与",
+            amount: 400000,
+            accountName: "口座 A",
+            category: "給与",
+          },
+        ],
+      },
+      {
+        name: "その他",
+        value: 120000,
+        categories: ["還付金", "臨時収入"],
+        transactions: [
+          {
+            id: 2,
+            date: "2026-05-10",
+            description: "還付金",
+            amount: 120000,
+            accountName: "口座 A",
+            category: "還付金",
+          },
+        ],
+      },
+    ],
+    expense: [
+      {
+        name: "食費",
+        value: 720000,
+        categories: ["食費"],
+        transactions: [
+          {
+            id: 3,
+            date: "2026-06-12",
+            description: "店舗 A",
+            amount: 4500,
+            accountName: "カード A",
+            category: "食費",
+          },
+          {
+            id: 5,
+            date: "2026-06-20",
+            description: "店舗 B",
+            amount: 8000,
+            accountName: "カード A",
+            category: "食費",
+          },
+        ],
+      },
+      {
+        name: "住宅",
+        value: 1440000,
+        categories: ["住宅"],
+        transactions: [
+          {
+            id: 4,
+            date: "2026-06-01",
+            description: "住居費",
+            amount: 120000,
+            accountName: "口座 A",
+            category: "住宅",
+          },
+        ],
+      },
+    ],
   },
-  beforeEach() {
-    mocked(getTransactions).mockResolvedValue([
-      makeTransaction(1, { category: "食費", amount: 50000 }),
-      makeTransaction(2, { category: "住宅", amount: 120000 }),
-      makeTransaction(3, { category: "水道・光熱費", amount: 20000 }),
-      makeTransaction(4, { category: "通信費", amount: 15000 }),
-      makeTransaction(5, { category: "交通費", amount: 10000 }),
-      makeTransaction(6, { category: "趣味・娯楽", amount: 30000 }),
-      makeTransaction(7, { category: "日用品", amount: 8000 }),
-      makeTransaction(8, { category: "収入", amount: 350000, type: "income" }),
-      makeTransaction(9, { category: "収入", amount: 50000, type: "income" }),
-      makeTransaction(10, { category: "収入", amount: 20000, type: "income" }),
-    ]);
-  },
-};
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const screen = within(canvasElement.ownerDocument.body);
 
-export const Empty: Story = {
-  args: {
-    year: "2025",
-  },
-  beforeEach() {
-    mocked(getTransactions).mockResolvedValue([]);
+    await userEvent.click(canvas.getByRole("button", { name: /食費/ }));
+
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeVisible());
+    await expect(screen.getByText("2026年 食費の明細")).toBeVisible();
+    await expect(screen.getByText("店舗 A")).toBeVisible();
+    await expect(screen.getByText("2件")).toBeVisible();
+
+    const descriptions = screen.getAllByText(/店舗 [AB]/);
+    await expect(descriptions[0]).toHaveTextContent("店舗 B");
+    await expect(descriptions[1]).toHaveTextContent("店舗 A");
+
+    await userEvent.click(screen.getByRole("button", { name: "明細を閉じる" }));
+
+    await expect(screen.queryByText("2026年 食費の明細")).toBeNull();
   },
 };

--- a/apps/web/src/components/info/transaction-stats.tsx
+++ b/apps/web/src/components/info/transaction-stats.tsx
@@ -1,12 +1,8 @@
 import { getTransactions } from "@mf-dashboard/db";
 import { PieChart as PieChartIcon } from "lucide-react";
-import { consolidateCategories } from "../../lib/aggregation";
 import { EmptyState } from "../ui/empty-state";
-import {
-  type CategoryBreakdown,
-  type CategoryTransaction,
-  TransactionStatsClient,
-} from "./transaction-stats.client";
+import { createBreakdowns } from "./transaction-stats-utils";
+import { TransactionStatsClient } from "./transaction-stats.client";
 
 interface TransactionStatsProps {
   year: string;
@@ -52,62 +48,11 @@ export async function TransactionStats({ year, groupId }: TransactionStatsProps)
     .map(([name, value]) => ({ name, value }))
     .sort((a, b) => b.value - a.value);
 
-  const createBreakdowns = (
-    categories: Array<{ name: string; value: number }>,
-    type: "income" | "expense",
-  ): CategoryBreakdown[] => {
-    const consolidated = consolidateCategories(categories);
-    const visibleNames = new Set(
-      consolidated
-        .filter((category) => category.name !== "その他")
-        .map((category) => category.name),
-    );
-
-    return consolidated.map((category) => {
-      const memberNames =
-        category.name === "その他"
-          ? categories
-              .filter((item) => item.name === "その他" || !visibleNames.has(item.name))
-              .map((item) => item.name)
-          : [category.name];
-      const memberNameSet = new Set(memberNames);
-      const matchingTransactions = validTransactions
-        .filter((transaction) => {
-          if (transaction.type !== type) return false;
-          const transactionCategory =
-            type === "income"
-              ? (transaction.subCategory ?? "その他")
-              : (transaction.category ?? "その他");
-          return memberNameSet.has(transactionCategory);
-        })
-        .map(
-          (transaction): CategoryTransaction => ({
-            id: transaction.id,
-            date: transaction.date,
-            description: transaction.description,
-            amount: transaction.amount,
-            accountName: transaction.accountName,
-            category:
-              type === "income"
-                ? (transaction.subCategory ?? "その他")
-                : (transaction.category ?? "その他"),
-          }),
-        )
-        .sort((a, b) => b.amount - a.amount);
-
-      return {
-        ...category,
-        categories: memberNames,
-        transactions: matchingTransactions,
-      };
-    });
-  };
-
   return (
     <TransactionStatsClient
       year={year}
-      income={createBreakdowns(incomeCategories, "income")}
-      expense={createBreakdowns(expenseCategories, "expense")}
+      income={createBreakdowns(incomeCategories, "income", validTransactions)}
+      expense={createBreakdowns(expenseCategories, "expense", validTransactions)}
     />
   );
 }

--- a/apps/web/src/components/info/transaction-stats.tsx
+++ b/apps/web/src/components/info/transaction-stats.tsx
@@ -1,8 +1,12 @@
 import { getTransactions } from "@mf-dashboard/db";
 import { PieChart as PieChartIcon } from "lucide-react";
 import { consolidateCategories } from "../../lib/aggregation";
-import { PieChart } from "../charts/pie-chart";
 import { EmptyState } from "../ui/empty-state";
+import {
+  type CategoryBreakdown,
+  type CategoryTransaction,
+  TransactionStatsClient,
+} from "./transaction-stats.client";
 
 interface TransactionStatsProps {
   year: string;
@@ -40,31 +44,70 @@ export async function TransactionStats({ year, groupId }: TransactionStatsProps)
     }
   }
 
-  const expenseByCategory = consolidateCategories(
-    Array.from(expenseCategoryMap.entries())
-      .map(([name, value]) => ({ name, value }))
-      .sort((a, b) => b.value - a.value),
-  );
+  const expenseCategories = Array.from(expenseCategoryMap.entries())
+    .map(([name, value]) => ({ name, value }))
+    .sort((a, b) => b.value - a.value);
 
-  const incomeBySubCategory = consolidateCategories(
-    Array.from(incomeSubCategoryMap.entries())
-      .map(([name, value]) => ({ name, value }))
-      .sort((a, b) => b.value - a.value),
-  );
+  const incomeCategories = Array.from(incomeSubCategoryMap.entries())
+    .map(([name, value]) => ({ name, value }))
+    .sort((a, b) => b.value - a.value);
+
+  const createBreakdowns = (
+    categories: Array<{ name: string; value: number }>,
+    type: "income" | "expense",
+  ): CategoryBreakdown[] => {
+    const consolidated = consolidateCategories(categories);
+    const visibleNames = new Set(
+      consolidated
+        .filter((category) => category.name !== "その他")
+        .map((category) => category.name),
+    );
+
+    return consolidated.map((category) => {
+      const memberNames =
+        category.name === "その他"
+          ? categories
+              .filter((item) => item.name === "その他" || !visibleNames.has(item.name))
+              .map((item) => item.name)
+          : [category.name];
+      const memberNameSet = new Set(memberNames);
+      const matchingTransactions = validTransactions
+        .filter((transaction) => {
+          if (transaction.type !== type) return false;
+          const transactionCategory =
+            type === "income"
+              ? (transaction.subCategory ?? "その他")
+              : (transaction.category ?? "その他");
+          return memberNameSet.has(transactionCategory);
+        })
+        .map(
+          (transaction): CategoryTransaction => ({
+            id: transaction.id,
+            date: transaction.date,
+            description: transaction.description,
+            amount: transaction.amount,
+            accountName: transaction.accountName,
+            category:
+              type === "income"
+                ? (transaction.subCategory ?? "その他")
+                : (transaction.category ?? "その他"),
+          }),
+        )
+        .sort((a, b) => b.amount - a.amount);
+
+      return {
+        ...category,
+        categories: memberNames,
+        transactions: matchingTransactions,
+      };
+    });
+  };
 
   return (
-    <div className="grid gap-6 grid-cols-1 md:grid-cols-2">
-      {incomeBySubCategory.length > 0 && (
-        <PieChart
-          title="収入カテゴリ別内訳"
-          data={incomeBySubCategory}
-          height={280}
-          useCustomColors={false}
-        />
-      )}
-      {expenseByCategory.length > 0 && (
-        <PieChart title="支出カテゴリ別内訳" data={expenseByCategory} height={280} />
-      )}
-    </div>
+    <TransactionStatsClient
+      year={year}
+      income={createBreakdowns(incomeCategories, "income")}
+      expense={createBreakdowns(expenseCategories, "expense")}
+    />
   );
 }


### PR DESCRIPTION
# Summary

- make annual income and expense pie slices and legends selectable
- show category totals, share, transaction count, grouped categories, and amount-descending transactions in a dialog
- preserve category colors and keyboard-accessible legend controls
- disable pie re-animation so labels remain visible after closing the dialog
- split server-side aggregation from the interactive client component and add a Storybook interaction test

This lets users inspect the transactions behind annual category totals without scrolling away from the charts.

## Linear Issue

- N/A

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | The drilldown must show transactions belonging to the selected annual category with correct totals and ordering. | Selecting a category opens its detail dialog, reports the correct count and amount, and lists transactions from highest to lowest amount. |
| Interaction capability | The change adds selection, modal navigation, and responsive transaction rows. | Pie legends are keyboard-operable, the dialog opens and closes predictably, and mobile rows keep the amount opposite the title. |
| Accessibility | Category selection and modal content must remain usable with assistive technology. | Legend controls expose pressed state, the dialog has an accessible title and description, focus behavior is supplied by the shared dialog primitive, and Storybook accessibility checks pass. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| State transition testing | The primary interaction moves between unselected, selected/dialog-open, and closed states. | Category selection opens the dialog and the close action restores the chart state. |
| Equivalence partitioning | Income and expense categories share the same drilldown path while using different category keys and semantic monetary colors. | Server aggregation handles both transaction types through the same typed breakdown builder. |
| Boundary value and error guessing | Small categories may be consolidated into `その他`, and chart rerenders previously caused labels to disappear temporarily. | Consolidated categories retain their member names and transactions; disabling pie animation keeps labels stable across dialog transitions. |

### Primary Test Conditions

- Selecting an expense category from the legend opens a dialog for that category.
- The dialog shows annual total, composition ratio, transaction count, and transaction details.
- Transactions are ordered from highest to lowest amount.
- Closing the dialog removes the detail view and restores the unselected chart state.
- Consolidated `その他` breakdowns retain and display their member categories with category colors.
- Pie labels remain visible after selection and dialog closure.

### Out-of-Scope Risks

- Full-page E2E coverage and cross-browser mobile visual regression are out of scope; the interaction is covered at Storybook component level and uses the existing shared dialog primitive.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [x] Storybook tests
- [ ] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/web test:unit — 518 tests passed
pnpm --filter @mf-dashboard/web typecheck — passed
pnpm lint — passed
pnpm --filter @mf-dashboard/web test:storybook — 344 tests passed
pnpm format — passed
pnpm format:check / git diff --check — formatting and whitespace checks passed
```

### Checks Not Run

- Web E2E tests — not run because this change is isolated to an existing component interaction and is covered by Storybook interaction and accessibility tests.
