### PR TITLE
fix(db): include unmatched holdings in group views

### DIFF
--- a/packages/analytics/src/chat/database-query-tool.test.ts
+++ b/packages/analytics/src/chat/database-query-tool.test.ts
@@ -44,6 +44,11 @@ describe("createDatabaseQueryTool", () => {
     expect(description).toContain("no-group（group_id = '0'）の最新完了snapshot 1件");
     expect(description).toContain("最新snapshotが空なら過去の保有情報は含まれない");
     expect(description).toContain("daily_snapshots.group_idは選択中グループへ匿名化投影済み");
+    expect(description).toContain(
+      "金融機関を特定できない保有資産はholdings.account_id = NULLで含まれる",
+    );
+    expect(description).toContain("group_accountsで再度絞り込まない");
+    expect(description).not.toContain("holdings.account_idをgroup_accounts経由で絞る");
     expect(description).toContain("mf_idは匿名化のため常にNULL");
     expect(description).toContain("transactions.is_internal_transfer = 1");
     expect(description).not.toContain("transactionsRelations");

--- a/packages/db/src/queries/asset.test.ts
+++ b/packages/db/src/queries/asset.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { schema } from "../index";
+import { GLOBAL_SNAPSHOT_GROUP_ID } from "../shared/group-filter";
 import {
   createTestDb,
   resetTestDb,
@@ -36,6 +37,14 @@ afterAll(() => {
 beforeEach(async () => {
   await resetTestDb(db);
   await createTestGroup(db);
+  const now = new Date().toISOString();
+  await db.insert(schema.groups).values({
+    id: GLOBAL_SNAPSHOT_GROUP_ID,
+    name: "All Accounts",
+    isCurrent: false,
+    createdAt: now,
+    updatedAt: now,
+  });
 });
 
 async function createAssetHistory(data: { date: string; totalAssets: number }): Promise<number> {
@@ -104,7 +113,7 @@ async function createSnapshot(): Promise<number> {
   const snapshot = await db
     .insert(schema.dailySnapshots)
     .values({
-      groupId: TEST_GROUP_ID,
+      groupId: GLOBAL_SNAPSHOT_GROUP_ID,
       date: "2025-04-15",
       createdAt: now,
       updatedAt: now,

--- a/packages/db/src/queries/holding.test.ts
+++ b/packages/db/src/queries/holding.test.ts
@@ -1,6 +1,7 @@
 import { eq } from "drizzle-orm";
 import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { schema } from "../index";
+import { GLOBAL_SNAPSHOT_GROUP_ID } from "../shared/group-filter";
 import {
   createTestDb,
   resetTestDb,
@@ -31,6 +32,14 @@ afterAll(() => {
 beforeEach(async () => {
   await resetTestDb(db);
   await createTestGroup(db);
+  const now = new Date().toISOString();
+  await db.insert(schema.groups).values({
+    id: GLOBAL_SNAPSHOT_GROUP_ID,
+    name: "All Accounts",
+    isCurrent: false,
+    createdAt: now,
+    updatedAt: now,
+  });
 });
 
 async function createTestAccount(name: string): Promise<number> {
@@ -60,12 +69,12 @@ async function createTestAccount(name: string): Promise<number> {
   return account.id;
 }
 
-async function createSnapshot(): Promise<number> {
+async function createSnapshot(groupId = GLOBAL_SNAPSHOT_GROUP_ID): Promise<number> {
   const now = new Date().toISOString();
   const snapshot = await db
     .insert(schema.dailySnapshots)
     .values({
-      groupId: TEST_GROUP_ID,
+      groupId,
       date: "2025-04-15",
       createdAt: now,
       updatedAt: now,
@@ -192,7 +201,7 @@ describe("getLatestSnapshot", () => {
     await db
       .insert(schema.dailySnapshots)
       .values({
-        groupId: TEST_GROUP_ID,
+        groupId: GLOBAL_SNAPSHOT_GROUP_ID,
         date: "2025-04-14",
         createdAt: now,
         updatedAt: now,
@@ -201,7 +210,7 @@ describe("getLatestSnapshot", () => {
     await db
       .insert(schema.dailySnapshots)
       .values({
-        groupId: TEST_GROUP_ID,
+        groupId: GLOBAL_SNAPSHOT_GROUP_ID,
         date: "2025-04-15",
         createdAt: now,
         updatedAt: now,
@@ -211,6 +220,43 @@ describe("getLatestSnapshot", () => {
     const result = await getLatestSnapshot(db);
 
     expect(result!.date).toBe("2025-04-15");
+  });
+
+  it("別グループの新しいスナップショットを除外する", async () => {
+    await createSnapshot();
+    const now = new Date().toISOString();
+    await db.insert(schema.dailySnapshots).values({
+      groupId: TEST_GROUP_ID,
+      date: "2025-04-16",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await getLatestSnapshot(db);
+
+    expect(result).toMatchObject({
+      groupId: GLOBAL_SNAPSHOT_GROUP_ID,
+      date: "2025-04-15",
+    });
+  });
+
+  it("更新未完了の新しいglobalスナップショットを除外する", async () => {
+    await createSnapshot();
+    const now = new Date().toISOString();
+    await db.insert(schema.dailySnapshots).values({
+      groupId: GLOBAL_SNAPSHOT_GROUP_ID,
+      date: "2025-04-16",
+      refreshCompleted: false,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const result = await getLatestSnapshot(db);
+
+    expect(result).toMatchObject({
+      date: "2025-04-15",
+      refreshCompleted: true,
+    });
   });
 
   it("スナップショットがない場合はundefinedを返す", async () => {
@@ -283,6 +329,14 @@ describe("getHoldingsWithLatestValues", () => {
     const snapshotId = await createSnapshot();
     const categoryId = await createAssetCategory("保険");
     const now = new Date().toISOString();
+    const otherGroupId = "test_group_002";
+    await db.insert(schema.groups).values({
+      id: otherGroupId,
+      name: "Other Group",
+      isCurrent: false,
+      createdAt: now,
+      updatedAt: now,
+    });
     const unknownAccount = await db
       .insert(schema.accounts)
       .values({
@@ -300,6 +354,17 @@ describe("getHoldingsWithLatestValues", () => {
       categoryId,
     });
     await createHoldingValue({ holdingId, snapshotId, amount: 100000 });
+    const externalHoldingId = await createHolding({
+      accountId: unknownAccount.id,
+      name: "External Insurance",
+      categoryId,
+    });
+    const externalSnapshotId = await createSnapshot(otherGroupId);
+    await createHoldingValue({
+      holdingId: externalHoldingId,
+      snapshotId: externalSnapshotId,
+      amount: 200000,
+    });
 
     const result = await getHoldingsWithLatestValues(undefined, db);
 

--- a/packages/db/src/queries/holding.test.ts
+++ b/packages/db/src/queries/holding.test.ts
@@ -278,6 +278,37 @@ describe("getHoldingsWithLatestValues", () => {
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe("Holding A");
   });
+
+  it("金融機関を特定できない保有資産はグループ絞り込み後も返す", async () => {
+    const snapshotId = await createSnapshot();
+    const categoryId = await createAssetCategory("保険");
+    const now = new Date().toISOString();
+    const unknownAccount = await db
+      .insert(schema.accounts)
+      .values({
+        mfId: "unknown",
+        name: "-",
+        type: "手動",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+      .get();
+    const holdingId = await createHolding({
+      accountId: unknownAccount.id,
+      name: "Insurance A",
+      categoryId,
+    });
+    await createHoldingValue({ holdingId, snapshotId, amount: 100000 });
+
+    const result = await getHoldingsWithLatestValues(undefined, db);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      name: "Insurance A",
+      categoryName: "保険",
+    });
+  });
 });
 
 describe("getHoldingsByAccountId", () => {

--- a/packages/db/src/queries/holding.ts
+++ b/packages/db/src/queries/holding.ts
@@ -3,6 +3,22 @@ import { getDb, type Db, schema } from "../index";
 import { resolveGroupId, getAccountIdsForGroup } from "../shared/group-filter";
 
 const INVESTMENT_CATEGORIES = ["株式(現物)", "投資信託"];
+const UNKNOWN_ACCOUNT_MF_ID = "unknown";
+
+async function getHoldingAccountIdsForGroup(db: Db, groupId: string): Promise<number[]> {
+  const accountIds = await getAccountIdsForGroup(db, groupId);
+  const unknownAccount = await db
+    .select({ id: schema.accounts.id })
+    .from(schema.accounts)
+    .where(eq(schema.accounts.mfId, UNKNOWN_ACCOUNT_MF_ID))
+    .get();
+
+  if (!unknownAccount || accountIds.includes(unknownAccount.id)) {
+    return accountIds;
+  }
+
+  return [...accountIds, unknownAccount.id];
+}
 
 /**
  * 最新のスナップショットを取得
@@ -54,7 +70,7 @@ export async function getHoldingsWithLatestValues(groupIdParam?: string, db: Db 
   }
 
   const groupId = await resolveGroupId(db, groupIdParam);
-  const accountIds = groupId ? await getAccountIdsForGroup(db, groupId) : [];
+  const accountIds = groupId ? await getHoldingAccountIdsForGroup(db, groupId) : [];
 
   const whereCondition = buildHoldingWhereCondition(latestSnapshot.id, accountIds);
 
@@ -160,7 +176,7 @@ export async function getHoldingsWithDailyChange(
   }
 
   const groupId = await resolveGroupId(db, groupIdParam);
-  const accountIds = groupId ? await getAccountIdsForGroup(db, groupId) : [];
+  const accountIds = groupId ? await getHoldingAccountIdsForGroup(db, groupId) : [];
 
   const whereCondition = buildHoldingWhereCondition(
     latestSnapshot.id,

--- a/packages/db/src/queries/holding.ts
+++ b/packages/db/src/queries/holding.ts
@@ -1,6 +1,10 @@
 import { desc, eq, and, isNotNull, inArray } from "drizzle-orm";
 import { getDb, type Db, schema } from "../index";
-import { resolveGroupId, getAccountIdsForGroup } from "../shared/group-filter";
+import {
+  GLOBAL_SNAPSHOT_GROUP_ID,
+  resolveGroupId,
+  getAccountIdsForGroup,
+} from "../shared/group-filter";
 
 const INVESTMENT_CATEGORIES = ["株式(現物)", "投資信託"];
 const UNKNOWN_ACCOUNT_MF_ID = "unknown";
@@ -21,14 +25,19 @@ async function getHoldingAccountIdsForGroup(db: Db, groupId: string): Promise<nu
 }
 
 /**
- * 最新のスナップショットを取得
- * スナップショットは全アカウント共通で1つ作成される
+ * 全アカウント共通で取得した、最新の更新完了スナップショットを取得
  */
 export async function getLatestSnapshot(db: Db = getDb()) {
   return await db
     .select()
     .from(schema.dailySnapshots)
-    .orderBy(desc(schema.dailySnapshots.id))
+    .where(
+      and(
+        eq(schema.dailySnapshots.groupId, GLOBAL_SNAPSHOT_GROUP_ID),
+        eq(schema.dailySnapshots.refreshCompleted, true),
+      ),
+    )
+    .orderBy(desc(schema.dailySnapshots.date), desc(schema.dailySnapshots.id))
     .limit(1)
     .get();
 }

--- a/packages/db/src/queries/read-only-query.test.ts
+++ b/packages/db/src/queries/read-only-query.test.ts
@@ -640,9 +640,7 @@ describe("executeReadOnlyQuery", () => {
         db,
         `SELECT h.name, hv.amount
          FROM holdings h
-         JOIN holding_values hv ON hv.holding_id = h.id
-         JOIN group_accounts ga ON ga.account_id = h.account_id
-         WHERE ga.group_id = :groupId`,
+         JOIN holding_values hv ON hv.holding_id = h.id`,
         "0",
         databasePath,
       ),
@@ -698,16 +696,27 @@ describe("executeReadOnlyQuery", () => {
     await expect(
       executeReadOnlyQuery(
         db,
-        `SELECT h.name, hv.amount
+        `SELECT
+           h.name,
+           hv.amount,
+           h.account_id,
+           (SELECT COUNT(*) FROM accounts) AS account_count,
+           (SELECT COUNT(*) FROM group_accounts) AS group_account_count
          FROM holdings h
-         JOIN holding_values hv ON hv.holding_id = h.id
-         JOIN group_accounts ga ON ga.account_id = h.account_id
-         WHERE ga.group_id = :groupId`,
+         JOIN holding_values hv ON hv.holding_id = h.id`,
         "group-a",
         databasePath,
       ),
     ).resolves.toMatchObject({
-      rows: [{ name: "Unmatched Group Asset", amount: 12_345 }],
+      rows: [
+        {
+          name: "Unmatched Group Asset",
+          amount: 12_345,
+          account_id: null,
+          account_count: 1,
+          group_account_count: 1,
+        },
+      ],
       rowCount: 1,
     });
   });

--- a/packages/db/src/queries/read-only-query.test.ts
+++ b/packages/db/src/queries/read-only-query.test.ts
@@ -675,6 +675,22 @@ describe("executeReadOnlyQuery", () => {
       })
       .returning()
       .get();
+    await db.insert(schema.accountStatuses).values({
+      accountId: fallbackAccount.id,
+      status: "error",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.insert(schema.transactions).values({
+      mfId: "fallback-account-transaction",
+      date: "2026-07-12",
+      accountId: fallbackAccount.id,
+      description: "Fallback account transaction",
+      amount: 1_000,
+      type: "expense",
+      createdAt: now,
+      updatedAt: now,
+    });
     const snapshot = await db
       .insert(schema.dailySnapshots)
       .values({
@@ -701,7 +717,13 @@ describe("executeReadOnlyQuery", () => {
            hv.amount,
            h.account_id,
            (SELECT COUNT(*) FROM accounts) AS account_count,
-           (SELECT COUNT(*) FROM group_accounts) AS group_account_count
+           (SELECT COUNT(*) FROM group_accounts) AS group_account_count,
+           (SELECT COUNT(*) FROM account_statuses) AS account_status_count,
+           (
+             SELECT COUNT(*)
+             FROM transactions
+             WHERE description = 'Fallback account transaction'
+           ) AS fallback_transaction_count
          FROM holdings h
          JOIN holding_values hv ON hv.holding_id = h.id`,
         "group-a",
@@ -715,6 +737,8 @@ describe("executeReadOnlyQuery", () => {
           account_id: null,
           account_count: 1,
           group_account_count: 1,
+          account_status_count: 0,
+          fallback_transaction_count: 0,
         },
       ],
       rowCount: 1,

--- a/packages/db/src/queries/read-only-query.test.ts
+++ b/packages/db/src/queries/read-only-query.test.ts
@@ -652,6 +652,66 @@ describe("executeReadOnlyQuery", () => {
     });
   });
 
+  it("選択groupでもfallback accountの未照合holdingを保持する", async () => {
+    const now = new Date().toISOString();
+    const fallbackAccount = await db
+      .insert(schema.accounts)
+      .values({
+        mfId: "unknown",
+        name: "-",
+        type: "manual",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+      .get();
+    const holding = await db
+      .insert(schema.holdings)
+      .values({
+        mfId: "unmatched-group-holding",
+        accountId: fallbackAccount.id,
+        name: "Unmatched Group Asset",
+        type: "asset",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+      .get();
+    const snapshot = await db
+      .insert(schema.dailySnapshots)
+      .values({
+        groupId: "0",
+        date: "2026-07-12",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+      .get();
+    await db.insert(schema.holdingValues).values({
+      holdingId: holding.id,
+      snapshotId: snapshot.id,
+      amount: 12_345,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await expect(
+      executeReadOnlyQuery(
+        db,
+        `SELECT h.name, hv.amount
+         FROM holdings h
+         JOIN holding_values hv ON hv.holding_id = h.id
+         JOIN group_accounts ga ON ga.account_id = h.account_id
+         WHERE ga.group_id = :groupId`,
+        "group-a",
+        databasePath,
+      ),
+    ).resolves.toMatchObject({
+      rows: [{ name: "Unmatched Group Asset", amount: 12_345 }],
+      rowCount: 1,
+    });
+  });
+
   it("refreshとのversionを保証できないanalytics reportをsandboxへ公開しない", async () => {
     const now = new Date().toISOString();
     await db.insert(schema.analyticsReports).values({

--- a/packages/db/src/queries/read-only-query.ts
+++ b/packages/db/src/queries/read-only-query.ts
@@ -397,10 +397,15 @@ function createScopedDatabaseSql(databasePath: string, groupId: string): string 
   const globalSnapshotGroup = quoteSqlText(GLOBAL_SNAPSHOT_GROUP_ID);
   const accountIds = `
     SELECT account_id FROM source.group_accounts WHERE group_id = ${selectedGroup}
+  `;
+  const holdingAccountIds = `
+    ${accountIds}
     UNION
     SELECT id FROM source.accounts WHERE mf_id = 'unknown'
   `;
-  const groupHoldingIds = `SELECT id FROM source.holdings WHERE account_id IN (${accountIds})`;
+  const groupHoldingIds = `
+    SELECT id FROM source.holdings WHERE account_id IN (${holdingAccountIds})
+  `;
   const latestHoldingSnapshotId = `
     SELECT id
     FROM source.daily_snapshots
@@ -417,19 +422,7 @@ function createScopedDatabaseSql(databasePath: string, groupId: string): string 
     CREATE TABLE groups AS
       SELECT * FROM source.groups WHERE id = ${selectedGroup};
     CREATE TABLE group_accounts AS
-      SELECT * FROM source.group_accounts WHERE group_id = ${selectedGroup}
-      UNION ALL
-      SELECT
-        -1 AS id,
-        ${selectedGroup} AS group_id,
-        id AS account_id,
-        created_at,
-        updated_at
-      FROM source.accounts
-      WHERE mf_id = 'unknown'
-        AND id NOT IN (
-          SELECT account_id FROM source.group_accounts WHERE group_id = ${selectedGroup}
-        );
+      SELECT * FROM source.group_accounts WHERE group_id = ${selectedGroup};
     CREATE TABLE institution_categories AS
       SELECT * FROM source.institution_categories;
     CREATE TABLE accounts AS
@@ -459,7 +452,7 @@ function createScopedDatabaseSql(databasePath: string, groupId: string): string 
       SELECT
         id,
         NULL AS mf_id,
-        account_id,
+        CASE WHEN account_id IN (${accountIds}) THEN account_id END AS account_id,
         category_id,
         name,
         code,

--- a/packages/db/src/queries/read-only-query.ts
+++ b/packages/db/src/queries/read-only-query.ts
@@ -3,6 +3,7 @@ import { getTableColumns, getTableName, isTable } from "drizzle-orm";
 import { getDbPath } from "../db-path";
 import type { Db } from "../index";
 import * as schema from "../schema/schema";
+import { GLOBAL_SNAPSHOT_GROUP_ID } from "../shared/group-filter";
 
 export const READ_ONLY_QUERY_MAX_ROWS = 200;
 export const READ_ONLY_QUERY_MAX_BYTES = 64 * 1024;
@@ -14,8 +15,6 @@ export const READ_ONLY_QUERY_MAX_SQLITE_HEAP_BYTES = 64 * 1024 * 1024;
 const MAX_RESULT_COLUMNS = 32;
 const MAX_JOIN_COUNT = 8;
 const MAX_UNION_COUNT = 8;
-const GLOBAL_SNAPSHOT_GROUP_ID = "0";
-
 const WRITE_KEYWORDS =
   /\b(?:alter|analyze|attach|create|delete|detach|drop|insert|pragma|reindex|release|rollback|savepoint|update|vacuum)\b/i;
 const WRITE_REPLACE_STATEMENT = /\breplace\b(?!\s*\()/i;
@@ -399,8 +398,7 @@ function createScopedDatabaseSql(databasePath: string, groupId: string): string 
   const accountIds = `
     SELECT account_id FROM source.group_accounts WHERE group_id = ${selectedGroup}
     UNION
-    SELECT id FROM source.accounts
-    WHERE mf_id = 'unknown' AND ${selectedGroup} = ${globalSnapshotGroup}
+    SELECT id FROM source.accounts WHERE mf_id = 'unknown'
   `;
   const groupHoldingIds = `SELECT id FROM source.holdings WHERE account_id IN (${accountIds})`;
   const latestHoldingSnapshotId = `
@@ -423,15 +421,14 @@ function createScopedDatabaseSql(databasePath: string, groupId: string): string 
       UNION ALL
       SELECT
         -1 AS id,
-        ${globalSnapshotGroup} AS group_id,
+        ${selectedGroup} AS group_id,
         id AS account_id,
         created_at,
         updated_at
       FROM source.accounts
       WHERE mf_id = 'unknown'
-        AND ${selectedGroup} = ${globalSnapshotGroup}
         AND id NOT IN (
-          SELECT account_id FROM source.group_accounts WHERE group_id = ${globalSnapshotGroup}
+          SELECT account_id FROM source.group_accounts WHERE group_id = ${selectedGroup}
         );
     CREATE TABLE institution_categories AS
       SELECT * FROM source.institution_categories;

--- a/packages/db/src/queries/read-only-query.ts
+++ b/packages/db/src/queries/read-only-query.ts
@@ -161,7 +161,7 @@ export function describeDatabaseSchema(): string {
 - 月はsubstr(${transactions}.${schema.transactions.date.name}, 1, 7)でYYYY-MMとして取得できる
 - ${schema.transactions.category.name}が大カテゴリ、${schema.transactions.subCategory.name}が中カテゴリ、${schema.transactions.description.name}が個別明細の内容
 - chat query sandboxの${transactions}は現在グループの振替元または振替先口座に関係する行へ限定済み。明示的に絞る場合は${schema.transactions.accountId.name}または${schema.transactions.transferTargetAccountId.name}のいずれかを${groupAccounts}.${schema.groupAccounts.accountId.name}と照合し、${groupAccounts}.${schema.groupAccounts.groupId.name} = :groupIdを使用する
-- 現在グループの保有資産も${holdings}.${schema.holdings.accountId.name}を${groupAccounts}経由で絞る
+- chat query sandboxの${holdings}・${holdingValues}は現在グループ向けに限定済み。金融機関を特定できない保有資産は${holdings}.${schema.holdings.accountId.name} = NULLで含まれるため、${groupAccounts}をJOINして再度group scopeしてはいけない
 - 現在グループの総資産は${assetHistory}.${schema.assetHistory.groupId.name} = :groupIdで絞り、${schema.assetHistory.date.name}が最新の行の${schema.assetHistory.totalAssets.name}を使用する。保有銘柄の件数や評価額から総資産を推測・再計算しない
 - 総資産のカテゴリ内訳は最新の${assetHistory}を${assetHistoryCategories}.${schema.assetHistoryCategories.assetHistoryId.name} = ${assetHistory}.${schema.assetHistory.id.name}でJOINし、${schema.assetHistoryCategories.categoryName.name}と${schema.assetHistoryCategories.amount.name}を使用する
 - 銘柄名や資産・負債の区分は${holdings}、評価額・数量・単価・前日比・含み損益は${holdingValues}にある。${holdingValues}.${schema.holdingValues.holdingId.name} = ${holdings}.${schema.holdings.id.name}でJOINする
@@ -169,8 +169,8 @@ export function describeDatabaseSchema(): string {
 - 資産・負債・投資の現在金額には${holdingValues}.${schema.holdingValues.amount.name}を使用する。件数を明示的に求められていない限りCOUNTではなく金額の合計と内訳を取得する
 - 負債は${holdings}.${schema.holdings.type.name} = 'liability'で判定する。負債の総額は${holdingValues}.${schema.holdingValues.amount.name}のSUM、内訳は${holdings}.${schema.holdings.liabilityCategory.name}ごとのSUMとして取得し、件数や登録状況へ読み替えない
 - 資産カテゴリは${holdings}.${schema.holdings.categoryId.name} = ${assetCategories}.${schema.assetCategories.id.name}でJOINする。投資情報には主に「株式(現物)」「投資信託」「債券」「FX」「先物」「暗号資産・FX・貴金属」のカテゴリを使用し、「預金・現金」「暗号資産」「電子マネー・プリペイド」は含めない
-- chat query sandboxの${dailySnapshots}は全口座を取得するno-group（group_id = '0'）の最新完了snapshot 1件、${holdings}・${holdingValues}はそのsnapshot内かつ現在グループ口座の行だけへ限定済み。最新snapshotが空なら過去の保有情報は含まれない。銘柄・負債・投資の現在値は${holdingValues}.${schema.holdingValues.snapshotId.name} = ${dailySnapshots}.${schema.dailySnapshots.id.name}でJOINして使用する
-- chat query sandboxの${dailySnapshots}.${schema.dailySnapshots.groupId.name}は選択中グループへ匿名化投影済み。保有情報のgroup scopeは${holdings}から${groupAccounts}を経由して確認する
+- chat query sandboxの${dailySnapshots}は全口座を取得するno-group（group_id = '0'）の最新完了snapshot 1件、${holdings}・${holdingValues}はそのsnapshot内かつ現在グループ口座の行と金融機関を特定できない保有資産だけへ限定済み。最新snapshotが空なら過去の保有情報は含まれない。銘柄・負債・投資の現在値は${holdingValues}.${schema.holdingValues.snapshotId.name} = ${dailySnapshots}.${schema.dailySnapshots.id.name}でJOINして使用する
+- chat query sandboxの${dailySnapshots}.${schema.dailySnapshots.groupId.name}は選択中グループへ匿名化投影済み。保有情報は既にgroup scope済みなので、${groupAccounts}で再度絞り込まない
 - ${directlyGroupedTables}は${schema.assetHistory.groupId.name} = :groupIdで直接絞る`;
 }
 

--- a/packages/db/src/shared/group-filter.ts
+++ b/packages/db/src/shared/group-filter.ts
@@ -2,6 +2,8 @@ import { eq } from "drizzle-orm";
 import type { Db } from "../index";
 import { schema } from "../index";
 
+export const GLOBAL_SNAPSHOT_GROUP_ID = "0";
+
 /** 現在のグループID（isCurrent=true）を取得 */
 export async function getDefaultGroupId(db: Db): Promise<string | null> {
   const currentGroup = await db


### PR DESCRIPTION
# Summary

金融機関を特定できず `mf_id = "unknown"` のアカウントへ保存された保有資産を、グループ絞り込み後の保有資産クエリにも含めます。

保険・年金などは最新スナップショットへ正常に保存されていましたが、`unknown` アカウントが `group_accounts` に属していないため、選択中グループの画面から欠落していました。アカウント一覧へ疑似アカウントを混入させず、保有資産クエリに限って `unknown` アカウントIDを対象へ追加します。

## Linear Issue

- N/A

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability — functional correctness | 保存済みの保険・年金などがグループ表示から欠落していたため | グループ所属アカウントの保有資産に加え、`unknown` アカウントの保有資産も返す |
| Reliability — data integrity | グループ外の通常アカウントを誤って含めず、欠落のみを解消する必要があるため | 通常のグループ絞り込みを維持し、未特定アカウントのみ追加する |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Decision table testing | アカウントが「グループ内」「グループ外」「未特定」の各状態で結果が変わるため | グループ内は表示、グループ外は非表示、未特定は表示を確認する |
| Regression testing | 既存の保有資産取得・日次変動取得へ共通の対象ID解決を適用するため | DBクエリ全テストと型チェックで既存動作を確認する |

### Primary Test Conditions

- グループに直接所属しない `unknown` アカウントの保険が最新保有資産として返る
- グループ内の通常アカウントは従来どおり返る
- グループ外の通常アカウントは従来どおり除外される
- web/crawlerのDockerイメージが変更後のソースからbuildできる

### Out-of-Scope Risks

- Money Forwardのポートフォリオ表に金融機関情報がない項目を、特定のユーザー定義グループへ厳密に帰属させることは対象外です。現状のデータでは帰属先を判定できないため、未特定の保有資産は各グループの保有資産表示に含まれます。

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [ ] Storybook tests
- [ ] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/db test — 23 files / 367 tests passed
pnpm --filter @mf-dashboard/db typecheck — passed
pnpm exec oxlint --type-aware packages/db/src/queries/holding.ts packages/db/src/queries/holding.test.ts — passed
pnpm exec oxfmt --check packages/db/src/queries/holding.ts packages/db/src/queries/holding.test.ts — passed
docker compose build — web and crawler images built successfully
sqlite3 -readonly data/moneyforward.db <category-count query> — latest snapshot contains 保険 2件・年金 3件; both were excluded by current-group membership before this fix
```

### Checks Not Run

- Storybook tests — DBクエリのみの変更で、コンポーネントやStorybook storyに変更がないため
- E2E tests — 対象の分岐はDBユニットテストで直接検証し、アプリのproduction buildは `docker compose build` で確認したため

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved holdings/asset filtering when a selected group is applied, including correct handling of unidentified (fallback) accounts.
  * Ensured “latest” and “daily change” calculations use only the most recent completed snapshot for the global snapshot set.
  * Prevented holdings from being influenced by snapshots belonging to other groups.
* **Tests**
  * Added/updated coverage to verify group-scoped behavior with unidentified accounts and to confirm unfinished global snapshots are excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->