### PR TITLE
fix(web): initialize demo simulator investment amount

### DIFF
--- a/apps/web/src/app/simulator/page.test.tsx
+++ b/apps/web/src/app/simulator/page.test.tsx
@@ -1,0 +1,48 @@
+import { getHoldingsWithLatestValues } from "@mf-dashboard/db";
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SimulatorContent } from "./page";
+
+vi.mock("@mf-dashboard/db", () => ({
+  getHoldingsWithLatestValues: vi.fn<typeof getHoldingsWithLatestValues>(),
+}));
+
+vi.mock("../../components/charts/compound-simulator/compound-simulator", () => ({
+  CompoundSimulator: ({ defaultInitialAmount }: { defaultInitialAmount: number }) => (
+    <div>初期投資額: {defaultInitialAmount}</div>
+  ),
+}));
+
+const mockedGetHoldings = vi.mocked(getHoldingsWithLatestValues);
+
+describe("SimulatorContent", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it("demo 環境でも投資信託の合計を初期投資額に設定する", async () => {
+    vi.stubEnv("DEMO_MODE", "true");
+    mockedGetHoldings.mockResolvedValue([
+      { categoryName: "投資信託", amount: 1_200_000 },
+      { categoryName: "投資信託", amount: 799_859 },
+      { categoryName: "預金・現金", amount: 500_000 },
+    ] as Awaited<ReturnType<typeof getHoldingsWithLatestValues>>);
+
+    render(await SimulatorContent({}));
+
+    expect(screen.getByText("初期投資額: 1999859")).toBeTruthy();
+  });
+
+  it("通常環境でも投資信託の合計を初期投資額に設定する", async () => {
+    vi.stubEnv("DEMO_MODE", "false");
+    mockedGetHoldings.mockResolvedValue([
+      { categoryName: "投資信託", amount: 2_000_000 },
+      { categoryName: "株式(現物)", amount: 1_000_000 },
+    ] as Awaited<ReturnType<typeof getHoldingsWithLatestValues>>);
+
+    render(await SimulatorContent({}));
+
+    expect(screen.getByText("初期投資額: 2000000")).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/simulator/page.tsx
+++ b/apps/web/src/app/simulator/page.tsx
@@ -19,7 +19,7 @@ export async function SimulatorContent({ groupId }: { groupId?: string }) {
   return (
     <PageLayout title="シミュレーター">
       <CompoundSimulator
-        defaultInitialAmount={isDemo ? 0 : totalInvestment}
+        defaultInitialAmount={totalInvestment}
         portfolioContext={
           isDemo
             ? undefined


### PR DESCRIPTION
# Summary

Use the demo database investment-fund total as the compound simulator initial investment instead of replacing it with zero. Add page-level regression coverage for both demo and regular environments.

## Linear Issue

- [HIR-143](https://linear.app/hiroppy/issue/HIR-143)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | The simulator must initialize from the selected environment data | Demo and regular environments both pass the investment-fund total to the simulator |
| Reliability | Removing the demo branch must not regress the regular environment | Page-level tests cover both environment partitions |
| Interaction capability | The initialized value must remain editable and recalculate projections | Runtime walkthrough confirms the increment control updates the input and summary |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Equivalence partitioning | Environment mode determines the prior faulty branch | Demo and regular modes return the expected initial investment |
| State transition testing | The UI transitions from initialized data to a user-edited value | Initial display and increment-triggered recalculation are verified |
| Error guessing | Non-investment holdings could be accidentally included | Regression fixtures include an unrelated asset category |

### Primary Test Conditions

- Demo mode with multiple investment-fund holdings and an unrelated holding.
- Regular mode with investment-fund and equity holdings.
- Demo runtime initial display of ¥1,999,859, followed by increment to ¥2,009,859 and summary recalculation.

### Out-of-Scope Risks

- Investment category matching rules are unchanged; this fix only removes the demo-only zero override.
- Monte Carlo numerical correctness is covered by the existing unit suite and is not changed here.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [ ] Storybook tests
- [ ] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/web test:unit — passed (40 files, 547 tests)
pnpm turbo typecheck — passed (8 packages)
pnpm lint — passed (6 pre-existing chart warnings, none in changed files)
pnpm format:check — passed
pnpm --filter @mf-dashboard/web dev + Playwright runtime walkthrough — passed
```

### Checks Not Run

- Storybook tests — no component or story behavior changed.
- Formal E2E suite — targeted Playwright runtime walkthrough covered the changed path.