### PR TITLE
chore(deps): narrow release age exclusions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,40 +10,15 @@ allowBuilds:
   workerd: true
 
 minimumReleaseAgeExclude:
-  - ai
-  - "@cloudflare/workerd-*"
-  - "@csstools/css-color-parser"
-  - "@storybook/addon-a11y"
-  - "@storybook/addon-vitest"
-  - "@storybook/builder-vite"
-  - "@storybook/csf-plugin"
-  - "@storybook/nextjs-vite"
-  - "@storybook/react"
-  - "@storybook/react-dom-shim"
-  - "@storybook/react-vite"
-  - "@turbo/*"
-  - "@types/node"
-  - knip
-  - lucide-react
-  - miniflare
-  - storybook
-  - turbo
-  - workerd
-  - wrangler
-  - "@ai-sdk/gateway@4.0.22"
-  - recharts@3.10.1
-  - "@ai-sdk/anthropic@4.0.21"
-  - "@next/env@16.2.12"
-  - "@next/swc-darwin-arm64@16.2.12"
-  - "@next/swc-darwin-x64@16.2.12"
-  - "@next/swc-linux-arm64-gnu@16.2.12"
-  - "@next/swc-linux-arm64-musl@16.2.12"
-  - "@next/swc-linux-x64-gnu@16.2.12"
-  - "@next/swc-linux-x64-musl@16.2.12"
-  - "@next/swc-win32-arm64-msvc@16.2.12"
-  - "@next/swc-win32-x64-msvc@16.2.12"
-  - "@next/third-parties@16.2.12"
-  - next@16.2.12
+  - "@storybook/addon-a11y@10.5.5"
+  - "@storybook/addon-vitest@10.5.5"
+  - "@storybook/builder-vite@10.5.5"
+  - "@storybook/csf-plugin@10.5.5"
+  - "@storybook/nextjs-vite@10.5.5"
+  - "@storybook/react@10.5.5"
+  - "@storybook/react-dom-shim@10.5.5"
+  - "@storybook/react-vite@10.5.5"
+  - storybook@10.5.5
 
 catalog:
   "@libsql/client": 0.17.4


### PR DESCRIPTION
# Summary

- Remove expired `minimumReleaseAgeExclude` entries.
- Replace broad Storybook exclusions with version-specific exceptions for the still-immature `10.5.5` release.
- Restore pnpm's one-day cooldown for future releases of the previously broad-excluded packages.

## Linear Issue

- N/A

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Security | The exclusions bypass pnpm's dependency cooldown. | Only lockfile versions younger than one day remain excluded. |
| Reliability | Removing a required exclusion could make CI installs fail. | A frozen-lockfile install passes pnpm's supply-chain verification and completes. |
| Maintainability | Broad package-name exclusions silently bypass future checks. | Remaining exceptions are version-specific and temporary. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Decision table testing | Each lockfile entry is either mature or still within the one-day window. | Mature entries are protected by the default policy; immature Storybook entries remain explicitly allowed. |
| Checklist-based testing | This is a package-manager policy-only change. | JSON/YAML formatting, diff integrity, and install behavior are checked. |
| Error guessing | Removing all exclusions first exposes hidden young transitive dependencies. | Confirms the exact set of currently required exceptions. |

### Primary Test Conditions

- Remove all exclusions and observe the packages rejected by pnpm.
- Add exact-version exceptions only for the rejected Storybook 10.5.5 packages.
- Verify the full frozen lockfile passes supply-chain policy validation.
- Verify dependency installation completes.

### Out-of-Scope Risks

- The remaining Storybook 10.5.5 exceptions require a later cleanup after their one-day window; no application behavior changed.

## Verification

- [ ] Unit tests
- [ ] Type checking
- [ ] Lint
- [ ] Storybook tests
- [ ] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm install --frozen-lockfile (without exclusions) — expected failure; identified only nine Storybook 10.5.5 entries inside the one-day window
pnpm install --frozen-lockfile (with exact Storybook exceptions) — passed supply-chain verification and completed
pnpm exec oxfmt --check pnpm-workspace.yaml — passed
git diff --check — passed
```

### Checks Not Run

- Unit, type, lint, Storybook, and E2E checks were not run because this change only narrows pnpm install-policy exceptions and does not modify application code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package release-age exclusions to target specific Storybook 10.5.5 packages.
  * Removed broader exclusions for previously covered packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->