### PR TITLE
fix(renovate): enforce dependency cooldown

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,12 @@
   "additionalBranchPrefix": "{{baseBranch}}-",
   "packageRules": [
     {
+      "description": "Match pnpm's one-day dependency cooldown",
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "1 day",
+      "internalChecksFilter": "strict"
+    },
+    {
       "groupName": "npm patch dependencies",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
# Summary

- Apply a one-day `minimumReleaseAge` to npm dependencies managed by Renovate.
- Use strict internal checks so immature releases remain pending instead of being selected for update PRs.
- Match Renovate's update policy with pnpm's existing one-day dependency cooldown.

The setting previously existed only as an unmerged commit on #273, so Renovate continued creating PRs for packages published less than one day earlier.

## Linear Issue

- N/A

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Security | Delaying newly published dependencies reduces exposure to supply-chain attacks. | npm releases younger than one day are not selected for Renovate updates. |
| Reliability | Renovate and pnpm should enforce the same dependency maturity policy. | Renovate's configured minimum age matches pnpm's one-day cooldown. |
| Maintainability | The policy should be explicit and scoped to the relevant datasource. | A single documented npm package rule defines the cooldown. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Boundary value analysis | The behavior changes at the one-day release-age boundary. | Releases below one day remain pending; releases at or above one day become eligible. |
| Checklist-based testing | This is a declarative configuration-only change. | JSON syntax, formatting, datasource scope, strict filtering, and diff integrity are checked. |

### Primary Test Conditions

- npm releases younger than one day are held by Renovate internal checks.
- npm releases at least one day old remain eligible for update PRs.
- Non-npm datasources are unaffected.

### Out-of-Scope Risks

- Existing Renovate PRs are not automatically closed by this configuration change.
- End-to-end Renovate execution depends on the hosted Renovate app and is verified after merge.

## Verification

- [ ] Unit tests
- [ ] Type checking
- [ ] Lint
- [ ] Storybook tests
- [ ] E2E tests
- [x] Manual verification

### Commands Executed

```text
JSON.parse(renovate.json) — passed
pnpm exec oxfmt --check renovate.json (pre-commit hook) — passed
git diff --check — passed
```

### Checks Not Run

- Unit, type, lint, Storybook, and E2E tests were not run because this change only affects hosted Renovate configuration and does not modify application behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a one-day waiting period for newly released npm dependencies.
  * Dependency updates now use stricter release-age checks, aligning behavior with pnpm’s cooldown policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->