### PR TITLE
fix(web): resolve dashboard runtime and display bugs

### DIFF
--- a/apps/web/e2e/app-flows.test.ts
+++ b/apps/web/e2e/app-flows.test.ts
@@ -250,6 +250,16 @@ test.describe("App flows", () => {
   });
 
   test("handles invalid dynamic routes", async ({ page }) => {
+    const lcpWarnings: string[] = [];
+    page.on("console", (message) => {
+      if (
+        message.type() === "warning" &&
+        message.text().includes("detected as the Largest Contentful Paint")
+      ) {
+        lcpWarnings.push(message.text());
+      }
+    });
+
     const invalidPaths = [
       "/unknown-group",
       "/accounts/unknown-account",
@@ -271,5 +281,7 @@ test.describe("App flows", () => {
         await expect(page.getByText("データがありません").first()).toBeVisible();
       });
     }
+
+    expect(lcpWarnings).toEqual([]);
   });
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "predev": "test -s ../../data/demo.db || pnpm --filter @mf-dashboard/db build:demo",
     "dev": "DB_PATH=../../data/demo.db DEMO_MODE=true next dev",
     "dev:prod": "DB_PATH=../../data/moneyforward.db CRAWLER_URL=http://127.0.0.1:8766 ALLOW_LOCAL_AUTH_BYPASS=true next dev --hostname 127.0.0.1",
     "build": "next build",
@@ -13,7 +12,7 @@
     "test:unit": "vitest run --project unit",
     "test:storybook": "vitest run --project storybook",
     "test:watch": "vitest",
-    "pretest:e2e": "(test -s ../../data/demo.db || pnpm --filter @mf-dashboard/db build:demo) && playwright install chromium webkit",
+    "pretest:e2e": "playwright install chromium webkit",
     "test:e2e": "playwright test",
     "test:e2e:ui": "pnpm pretest:e2e && playwright test --ui",
     "typecheck": "next typegen && tsc --noEmit",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
     "test:unit": "vitest run --project unit",
     "test:storybook": "vitest run --project storybook",
     "test:watch": "vitest",
-    "pretest:e2e": "pnpm --filter @mf-dashboard/db build:demo && playwright install chromium webkit",
+    "pretest:e2e": "(test -s ../../data/demo.db || pnpm --filter @mf-dashboard/db build:demo) && playwright install chromium webkit",
     "test:e2e": "playwright test",
     "test:e2e:ui": "pnpm pretest:e2e && playwright test --ui",
     "typecheck": "next typegen && tsc --noEmit",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
+    "predev": "test -s ../../data/demo.db || pnpm --filter @mf-dashboard/db build:demo",
     "dev": "DB_PATH=../../data/demo.db DEMO_MODE=true next dev",
     "dev:prod": "DB_PATH=../../data/moneyforward.db CRAWLER_URL=http://127.0.0.1:8766 ALLOW_LOCAL_AUTH_BYPASS=true next dev --hostname 127.0.0.1",
     "build": "next build",
@@ -12,7 +13,7 @@
     "test:unit": "vitest run --project unit",
     "test:storybook": "vitest run --project storybook",
     "test:watch": "vitest",
-    "pretest:e2e": "playwright install chromium webkit",
+    "pretest:e2e": "pnpm --filter @mf-dashboard/db build:demo && playwright install chromium webkit",
     "test:e2e": "playwright test",
     "test:e2e:ui": "pnpm pretest:e2e && playwright test --ui",
     "typecheck": "next typegen && tsc --noEmit",

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -19,6 +19,7 @@ export default function Error({
             alt="エラーが発生しました"
             width={120}
             height={120}
+            loading="eager"
             className="mx-auto mb-4 rounded-full"
           />
           <h1 className="text-2xl font-bold text-foreground">エラーが発生しました</h1>

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -13,6 +13,7 @@ export default function NotFound() {
             alt="ページが見つかりません"
             width={120}
             height={120}
+            loading="eager"
             className="mx-auto mb-4 rounded-full"
           />
           <h1 className="text-2xl font-bold text-foreground">ページが見つかりません</h1>

--- a/apps/web/src/components/charts/chart-tooltip.test.ts
+++ b/apps/web/src/components/charts/chart-tooltip.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { formatChartLabel } from "./chart-tooltip";
+
+describe("formatChartLabel", () => {
+  it.each([
+    ["2026年7月", "2026年7月"],
+    [2026, "2026"],
+  ])("formats primitive label %j", (label, expected) => {
+    expect(formatChartLabel(label)).toBe(expected);
+  });
+
+  it.each([null, undefined, { month: "7月" }, ["7月"]])(
+    "does not expose object stringification for %j",
+    (label) => {
+      expect(formatChartLabel(label)).toBe("");
+    },
+  );
+});

--- a/apps/web/src/components/charts/chart-tooltip.tsx
+++ b/apps/web/src/components/charts/chart-tooltip.tsx
@@ -13,6 +13,10 @@ export const chartTooltipStyle: CSSProperties = {
   boxShadow: "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
 };
 
+export function formatChartLabel(label: unknown): string {
+  return typeof label === "string" || typeof label === "number" ? String(label) : "";
+}
+
 /**
  * カスタム Tooltip の外枠。Recharts / Nivo の content prop で使う。
  */

--- a/apps/web/src/components/charts/chart-tooltip.tsx
+++ b/apps/web/src/components/charts/chart-tooltip.tsx
@@ -13,6 +13,7 @@ export const chartTooltipStyle: CSSProperties = {
   boxShadow: "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
 };
 
+/** Formats Recharts labels without falling back to object stringification. */
 export function formatChartLabel(label: unknown): string {
   return typeof label === "string" || typeof label === "number" ? String(label) : "";
 }

--- a/apps/web/src/components/charts/compound-simulator/projection-chart.test.ts
+++ b/apps/web/src/components/charts/compound-simulator/projection-chart.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { formatProjectionLabel } from "./projection-chart";
+
+const projections = [
+  { year: 0 },
+  { year: 1, isContributing: true },
+  { year: 2, isWithdrawing: true },
+  { year: 3, isContributing: true, isWithdrawing: true },
+];
+
+describe("formatProjectionLabel", () => {
+  it.each([
+    [0, undefined, "0年後"],
+    [1, 35, "36歳（1年後）"],
+    [2, undefined, "2年後（切り崩し）"],
+    [3, 35, "38歳（3年後・積立+切り崩し）"],
+  ])("formats year %d with age %j", (label, currentAge, expected) => {
+    expect(formatProjectionLabel(label, projections, currentAge)).toBe(expected);
+  });
+
+  it.each([null, undefined, Number.NaN, "2", { year: 2 }])(
+    "returns an empty label for invalid input %j",
+    (label) => {
+      expect(formatProjectionLabel(label, projections, 35)).toBe("");
+    },
+  );
+});

--- a/apps/web/src/components/charts/compound-simulator/projection-chart.tsx
+++ b/apps/web/src/components/charts/compound-simulator/projection-chart.tsx
@@ -29,6 +29,29 @@ export interface ProjectionChartProps {
   currentTotalAssets?: number;
 }
 
+export function formatProjectionLabel(
+  label: unknown,
+  projections: ReadonlyArray<{
+    year: number;
+    isContributing?: boolean;
+    isWithdrawing?: boolean;
+  }>,
+  currentAge?: number,
+): string {
+  if (typeof label !== "number" || !Number.isFinite(label)) return "";
+
+  const entry = projections.find((projection) => projection.year === label);
+  let phase = "";
+  if (entry?.isContributing && entry.isWithdrawing) phase = "積立+切り崩し";
+  else if (entry?.isWithdrawing) phase = "切り崩し";
+
+  const phaseSuffix = phase ? `（${phase}）` : "";
+  if (currentAge != null) {
+    return `${currentAge + label}歳（${label}年後${phase ? `・${phase}` : ""}）`;
+  }
+  return `${label}年後${phaseSuffix}`;
+}
+
 export function ProjectionChart({
   projections,
   taxFree,
@@ -67,15 +90,7 @@ export function ProjectionChart({
               formatCurrency(value as number),
               labelMap[name as string] ?? name,
             ]}
-            labelFormatter={(label) => {
-              const entry = projections.find((p) => p.year === label);
-              let phase = "";
-              if (entry?.isContributing && entry?.isWithdrawing) phase = "・積立+切り崩し";
-              else if (entry?.isWithdrawing) phase = "・切り崩し";
-              if (currentAge != null)
-                return `${currentAge + (label as number)}歳（${label}年後${phase}）`;
-              return `${label}年後${phase ? `（${phase.slice(1)}）` : ""}`;
-            }}
+            labelFormatter={(label) => formatProjectionLabel(label, projections, currentAge)}
             contentStyle={chartTooltipStyle}
           />
           <Legend formatter={(value) => labelMap[value] ?? value} />

--- a/apps/web/src/components/charts/compound-simulator/projection-chart.tsx
+++ b/apps/web/src/components/charts/compound-simulator/projection-chart.tsx
@@ -29,6 +29,7 @@ export interface ProjectionChartProps {
   currentTotalAssets?: number;
 }
 
+/** Formats a projection year while rejecting unexpected Recharts label values. */
 export function formatProjectionLabel(
   label: unknown,
   projections: ReadonlyArray<{

--- a/apps/web/src/components/charts/line-chart.tsx
+++ b/apps/web/src/components/charts/line-chart.tsx
@@ -15,7 +15,7 @@ import {
 import { CHART_INITIAL_DIMENSION } from "../../lib/chart";
 import { formatCurrency } from "../../lib/format";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
-import { chartTooltipStyle } from "./chart-tooltip";
+import { chartTooltipStyle, formatChartLabel } from "./chart-tooltip";
 
 interface LineChartProps {
   title: string;
@@ -53,7 +53,7 @@ export function LineChart({ title, icon, data, lines, xAxisKey, height = 300 }: 
             />
             <Tooltip
               formatter={(value) => formatCurrency(value as number)}
-              labelFormatter={(label) => `${label}`}
+              labelFormatter={formatChartLabel}
               contentStyle={chartTooltipStyle}
             />
             <Legend />


### PR DESCRIPTION
# Summary

- guard Recharts tooltip labels so unsupported objects never render as `[object Object]`
- prepare the demo database for direct web development and E2E commands
- eagerly load above-the-fold error artwork and regress the LCP warning

## Linear Issue

- [HIR-151](https://linear.app/hiroppy/issue/HIR-151)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | Tooltip labels and documented launch commands must produce usable results | Primitive labels keep their text, invalid labels are suppressed, and a clean demo launch succeeds |
| Reliability | Missing local demo state previously crashed every web route | Development and E2E scripts provision a valid demo database deterministically |
| Performance efficiency | The above-the-fold error image emitted an LCP loading warning | Invalid routes render without the Next.js LCP warning |
| Maintainability | Label handling was implicit and untested | Small explicit formatters have unit coverage for valid and invalid partitions |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Equivalence partitioning | Recharts labels divide into supported primitives and unsupported values | string/number output and object/null suppression |
| Boundary value analysis | Projection labels vary at year zero and around optional age/phase data | zero year, missing age, withdrawal, and combined phases |
| Error guessing | Clean workspaces and invalid routes exposed failures not covered by happy paths | empty demo DB startup and LCP warnings on 404 pages |
| State transition testing | Navigation crosses global/group and valid/invalid route states | desktop and mobile route transitions remain correct |

### Primary Test Conditions

- Empty demo database is seeded before direct development startup.
- Direct E2E execution regenerates deterministic demo data.
- Chart tooltip labels preserve supported values and hide unsafe object stringification.
- Invalid routes display the not-found state without LCP warnings.
- Primary dashboard, cash-flow, balance-sheet, account, insight, and simulator flows work across configured browsers.

### Out-of-Scope Risks

- Authenticated Money Forward crawler E2E was not exercised because the changes are isolated to the demo web application.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [x] Storybook tests
- [x] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm lint — passed, zero warnings
pnpm turbo typecheck — 8 packages passed
pnpm test — 1,738 tests passed (including 915 web unit/Storybook tests)
pnpm knip — passed; existing configuration hint only
pnpm format:check — passed
pnpm --filter @mf-dashboard/db exec vitest run src/demo-data.test.ts — 17 passed
pnpm --filter @mf-dashboard/web test:e2e — 84 passed across Chromium, mobile Chrome, and mobile Safari
pnpm --filter @mf-dashboard/web exec playwright test e2e/app-flows.test.ts --grep "handles invalid dynamic routes" — 3 passed
```

### Checks Not Run

- N/A — all relevant checks were run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chart tooltip label formatting for months, years, and projection phases for more consistent display.
  - Updated the error and “Page Not Found” pages so their images load immediately.
- **Chores**
  - Automatically generates demo database data before starting development and before running end-to-end tests.
- **Tests**
  - Added unit tests for chart/projection label formatting and strengthened end-to-end coverage by checking for unwanted LCP-related console warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->