### PR TITLE
fix(crawler): ignore blank refreshing account names

### DIFF
--- a/apps/crawler/src/scrapers/refresh.test.ts
+++ b/apps/crawler/src/scrapers/refresh.test.ts
@@ -62,6 +62,11 @@ describe("summarizeRefreshRows", () => {
       rows: [{ name: null, statuses: [" 更新中 "] }],
       expected: { incompleteAccounts: [], remainingCount: 1 },
     },
+    {
+      name: "空白のみの名称は除外し更新中行を件数には含める",
+      rows: [{ name: " \t ", statuses: ["更新中"] }],
+      expected: { incompleteAccounts: [], remainingCount: 1 },
+    },
   ])("$name", ({ rows, expected }) => {
     expect(summarizeRefreshRows(rows)).toEqual(expected);
   });

--- a/apps/crawler/src/scrapers/refresh.ts
+++ b/apps/crawler/src/scrapers/refresh.ts
@@ -72,8 +72,9 @@ export function summarizeRefreshRows(rows: readonly RefreshStatusRow[]): {
     }
 
     remainingCount++;
-    if (row.name) {
-      incompleteAccounts.push(row.name.trim());
+    const accountName = row.name?.trim();
+    if (accountName) {
+      incompleteAccounts.push(accountName);
     }
   }
 


### PR DESCRIPTION
# Summary

Trim refreshing account names before collecting them and omit names that become empty, while continuing to count every refreshing row.

## Linear Issue

- [HIR-150](https://linear.app/hiroppy/issue/HIR-150/更新中アカウントの空白名称を除外する)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | Refresh progress must report valid account names without undercounting active rows. | Whitespace-only names are omitted and the row remains in remainingCount. |
| Maintainability | Name normalization and row counting must remain independently understandable. | The DOM-independent summarizer directly tests the boundary behavior. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Equivalence partitioning | Separate normal, missing, and whitespace-only account names. | Valid names remain; null and blank names are omitted. |
| Boundary value analysis | Trimming whitespace produces a zero-length boundary. | A tab/space-only name is excluded after trim. |

### Primary Test Conditions

- A refreshing row with a regular anonymous name is returned and counted.
- A refreshing row with a whitespace-only name is not returned but is counted.
- Non-refreshing rows remain excluded from both outputs.

### Out-of-Scope Risks

- Authenticated Money Forward DOM selector behavior is unchanged and therefore not exercised by this DOM-independent logic fix.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [ ] Storybook tests
- [ ] E2E tests
- [ ] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/crawler test — 29 files / 291 tests passed
pnpm --filter @mf-dashboard/crawler typecheck — passed
pnpm lint — passed
git diff --check — passed
```

### Checks Not Run

- Storybook/E2E/manual verification — no web UI or DOM integration behavior changed; the affected pure summarization logic is covered by crawler unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded blank or whitespace-only account names from incomplete account results.
  * Continued counting in-progress refreshes toward the remaining total.
* **Tests**
  * Added coverage to verify correct handling of whitespace-only account names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->