### PR TITLE
test(web): モバイルナビゲーションE2Eのタイムアウトを調整

### DIFF
--- a/apps/web/e2e/app-flows.test.ts
+++ b/apps/web/e2e/app-flows.test.ts
@@ -58,6 +58,10 @@ test.describe("App flows", () => {
   });
 
   test("navigates between primary pages from the sidebar", async ({ page }) => {
+    // This scenario compiles and visits six routes. WebKit on CI can exceed
+    // Playwright's 30-second default while the Next.js dev server warms up.
+    test.setTimeout(60_000);
+
     await page.goto("/");
     await expectHeading(page, "ダッシュボード");
 
@@ -80,6 +84,10 @@ test.describe("App flows", () => {
   });
 
   test("keeps navigation in the selected group context", async ({ page }) => {
+    // This scenario performs multiple client-side route transitions and select
+    // animations, which can exceed the default timeout on mobile WebKit in CI.
+    test.setTimeout(60_000);
+
     await page.goto("/cf");
     await expectHeading(page, "収支");
 


### PR DESCRIPTION
## 概要

CIのMobile Safariで、複数ページを遷移するE2EテストがPlaywright既定の30秒を超えて失敗することがあるため、該当する2シナリオだけタイムアウトを60秒へ延長します。

## 背景

- `navigates between primary pages from the sidebar`は、Next.js開発サーバーの初回コンパイルを伴う6ページの遷移を1テスト内で行います
- `keeps navigation in the selected group context`は、グループ選択と複数のクライアントサイド遷移を行います
- CIでは両テストが30秒ちょうどでタイムアウトし、要素自体はPlaywrightから取得できていました
- Chromiumでは再試行により成功し、Mobile Safariでは処理完了前にテスト全体の期限へ到達していました

グローバルタイムアウトは変更せず、処理量の多い2テストだけに適用します。

## QA

### 品質特性

- **信頼性:** CI環境の実行速度差による偽陰性を抑制する
- **保守性:** 例外的に長いシナリオへ設定を局所化し、理由をコメントで残す

### テスト技法・確認内容

- エラー推測: CIの低速なWebKitとNext.js初回コンパイルの組み合わせを確認
- 境界値分析: 失敗した30秒を超えられるよう、対象テストのみ60秒へ変更
- Playwrightによるテスト定義の列挙が成功することを確認
- フォーマット、lint、knipのpre-commitチェックが成功

## 対象外

- アプリケーションのナビゲーション実装は変更しません
- 他のE2Eテストおよびグローバルタイムアウトは変更しません


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased end-to-end test timeouts for sidebar and group-context navigation to improve reliability during slower test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->