### PR TITLE
ci: speed up Playwright tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
       - run: docker compose build ${{ matrix.app }}
   e2e-web:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ["1/3", "2/3", "3/3"]
     container:
       image: mcr.microsoft.com/playwright:v1.62.1-noble
     env:
@@ -55,9 +59,30 @@ jobs:
           persist-credentials: false
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: ./.github/actions/setup-node
-      - run: pnpm test:e2e:web
+      - run: pnpm test:e2e:web -- --shard=${{ matrix.shard }}
       - if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7.0.1
+        with:
+          name: playwright-blob-report-${{ strategy.job-index }}
+          path: apps/web/blob-report/
+          retention-days: 7
+
+  merge-e2e-report:
+    if: ${{ !cancelled() }}
+    needs: e2e-web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-node
+      - uses: actions/download-artifact@v8.0.1
+        with:
+          path: all-blob-reports
+          pattern: playwright-blob-report-*
+          merge-multiple: true
+      - run: pnpm --filter @mf-dashboard/web exec playwright merge-reports --reporter html ../../all-blob-reports
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: playwright-report
           path: apps/web/playwright-report/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,11 @@ jobs:
       - run: |
           cp -R apps/web/.next/static apps/web/.next/standalone/apps/web/.next/static
           cp -R apps/web/public apps/web/.next/standalone/apps/web/public
+          tar -czf e2e-web-build.tar.gz -C apps/web/.next/standalone .
       - uses: actions/upload-artifact@v7.0.1
         with:
           name: e2e-web-build
-          path: apps/web/.next/standalone/
-          include-hidden-files: true
+          path: e2e-web-build.tar.gz
           retention-days: 1
   e2e-web:
     needs: build-e2e-web
@@ -82,7 +82,10 @@ jobs:
       - uses: actions/download-artifact@v8.0.1
         with:
           name: e2e-web-build
-          path: apps/web/.next/standalone
+          path: .artifacts
+      - run: |
+          mkdir -p apps/web/.next/standalone
+          tar -xzf .artifacts/e2e-web-build.tar.gz -C apps/web/.next/standalone
       - run: pnpm test:e2e:web -- --shard=${{ matrix.shard }}
       - if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
       - run: docker compose build ${{ matrix.app }}
   build-e2e-web:
     runs-on: ubuntu-latest
+    env:
+      DASHBOARD_URL: http://127.0.0.1:3000
     steps:
       - uses: actions/checkout@v7.0.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,25 @@ jobs:
       - uses: actions/checkout@v7.0.1
       - run: cp .env.example .env
       - run: docker compose build ${{ matrix.app }}
+  build-e2e-web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-node
+      - run: DEMO_MODE=false pnpm --filter @mf-dashboard/web build
+      - run: |
+          cp -R apps/web/.next/static apps/web/.next/standalone/apps/web/.next/static
+          cp -R apps/web/public apps/web/.next/standalone/apps/web/public
+      - uses: actions/upload-artifact@v7.0.1
+        with:
+          name: e2e-web-build
+          path: apps/web/.next/standalone/
+          include-hidden-files: true
+          retention-days: 1
   e2e-web:
+    needs: build-e2e-web
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -59,6 +77,10 @@ jobs:
           persist-credentials: false
       - run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: ./.github/actions/setup-node
+      - uses: actions/download-artifact@v8.0.1
+        with:
+          name: e2e-web-build
+          path: apps/web/.next/standalone
       - run: pnpm test:e2e:web -- --shard=${{ matrix.shard }}
       - if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7.0.1

--- a/apps/web/e2e/a11y.test.ts
+++ b/apps/web/e2e/a11y.test.ts
@@ -6,7 +6,6 @@ test.describe("Accessibility tests", () => {
   for (const { name, path, heading } of pages) {
     test(`${name} (${path}) should have no accessibility violations`, async ({ page }) => {
       await page.goto(path);
-      await page.waitForLoadState("networkidle");
       await expect(page.getByRole("heading", { name: heading, level: 1 })).toBeVisible();
 
       const results = await new AxeBuilder({ page }).exclude("nextjs-portal").analyze();

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 const mockCrawlerUrl = "http://127.0.0.1:18766";
 const mockCrawlerToken = "e2e-refresh-token";
+const webServerCommand = process.env.CI ? "node .next/standalone/apps/web/server.js" : "pnpm dev";
 
 export default defineConfig({
   testDir: "./e2e",
@@ -39,12 +40,14 @@ export default defineConfig({
       reuseExistingServer: false,
     },
     {
-      command: "pnpm dev",
+      command: webServerCommand,
       url: "http://localhost:3000",
       env: {
         CRAWLER_URL: mockCrawlerUrl,
         DB_PATH: "../../data/demo.db",
         DEMO_MODE: "true",
+        HOSTNAME: "127.0.0.1",
+        PORT: "3000",
         REFRESH_TOKEN: mockCrawlerToken,
       },
       reuseExistingServer: false,

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,7 +1,9 @@
+import { resolve } from "node:path";
 import { defineConfig, devices } from "@playwright/test";
 
 const mockCrawlerUrl = "http://127.0.0.1:18766";
 const mockCrawlerToken = "e2e-refresh-token";
+const demoDbPath = resolve(__dirname, "../../data/demo.db");
 const webServerCommand = process.env.CI ? "node .next/standalone/apps/web/server.js" : "pnpm dev";
 
 export default defineConfig({
@@ -44,7 +46,7 @@ export default defineConfig({
       url: "http://localhost:3000",
       env: {
         CRAWLER_URL: mockCrawlerUrl,
-        DB_PATH: "../../data/demo.db",
+        DB_PATH: demoDbPath,
         DEMO_MODE: "true",
         HOSTNAME: "127.0.0.1",
         PORT: "3000",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: 2,
-  reporter: "html",
+  reporter: process.env.CI ? "blob" : "html",
   use: {
     baseURL: "http://localhost:3000",
     trace: "on-first-retry",


### PR DESCRIPTION
# Summary

- build the Next.js standalone server once, package it as a symlink-preserving tar artifact, and reuse it across all Playwright shards
- run CI E2E against `next start`-equivalent standalone output while keeping local E2E on `next dev`
- split the 102 Playwright tests across three GitHub Actions shards with two workers per runner
- upload blob reports per shard and merge them into one HTML report artifact
- remove the discouraged `networkidle` wait from accessibility tests while retaining the explicit heading readiness assertion

The previous sharded CI run still spent 111–187 seconds inside each test step because every runner cold-compiled routes through `next dev`. Against the standalone production build, the complete local suite passed in 43.4 seconds (96 passed, 6 skipped), compared with 1m22.8s against the development server.

## Linear Issue

- N/A

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Performance efficiency | The change targets CI wall-clock time and duplicate route compilation. | Next.js builds once; three shards reuse the same artifact and do not invoke `next dev`. |
| Reliability | Parallel execution and artifact transfer must preserve deterministic startup. | The standalone server starts with the E2E runtime environment and the complete suite passes with two workers. |
| Functional suitability | Production serving, sharding, accessibility checks, and merged reports must retain existing coverage. | All 102 tests are represented, expected skips remain, and blob reports merge into one HTML report. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Equivalence partitioning | Each shard is an independently executable partition of the same suite. | Shards 1/3, 2/3, and 3/3 together cover all 102 tests. |
| Checklist-based testing | The workflow has critical build, artifact, startup, sharding, and reporting integration points. | Standalone build, copied static/public assets, artifact paths, argument forwarding, report merge, lint, types, and YAML syntax are checked. |
| Error guessing | Earlier higher worker counts caused dev-server chunk failures, and standalone output can omit static assets or runtime API behavior. | Workers remain at two; static/public assets are packaged; the full suite includes crawler refresh API coverage. |

### Primary Test Conditions

- `DEMO_MODE=false` produces standalone output with dynamic pages and API routes
- the standalone output includes `.next/static` and `public`
- CI starts `.next/standalone/apps/web/server.js`; local execution still starts `pnpm dev`
- runtime E2E variables retain the absolute demo DB path, demo-mode authentication, crawler URL, and refresh token behavior
- the full 102-test suite passes against the standalone server with the expected six skips
- each of three CI shards consumes the same build artifact and produces a blob report
- blob reports merge into a single HTML report
- failed shards still upload diagnostics and allow report merging unless the workflow is cancelled

### Out-of-Scope Risks

- Accessibility coverage remains enabled for all three browser projects; browser reduction is not part of this PR.
- PR smoke, main full-suite, and nightly tiers remain unchanged.
- Full GitHub Actions schema validation is left to CI because local `actionlint` could not start due to a Go toolchain/standard-library version mismatch.

## Verification

- [ ] Unit tests
- [x] Type checking
- [x] Lint
- [ ] Storybook tests
- [x] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/db build:demo — passed
DEMO_MODE=false pnpm --filter @mf-dashboard/web build — passed; standalone output generated
CI=1 pnpm test:e2e:web — 96 passed, 6 skipped in 43.4s against standalone server
isolated tar extraction + standalone HTTP startup — passed without repository node_modules fallback
CI=1 pnpm test:e2e:web -- --shard=1/3 — 34 passed in 14.3s after absolute DB-path fix
pnpm test:e2e:web -- --list --shard=1/3 — passed; collected 34 tests
CI=1 pnpm --filter @mf-dashboard/web exec playwright test --shard=1/3 — 34 passed in 29.4s
CI=1 pnpm --filter @mf-dashboard/web exec playwright test --shard=2/3 — 31 passed, 3 skipped in 29.0s
CI=1 pnpm --filter @mf-dashboard/web exec playwright test --shard=3/3 — 31 passed, 3 skipped in 32.2s
pnpm --filter @mf-dashboard/web exec playwright merge-reports --reporter html <blob-directory> — passed
pnpm format:check — passed
pnpm lint — passed
pnpm turbo typecheck — passed
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")' — passed
go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/ci.yml — not run successfully; local Go version mismatch
```

### Checks Not Run

- Unit tests — no application logic changed; the complete E2E suite exercises the affected test and server configuration.
- Storybook tests — no component or story changed.

### GitHub Actions Verification

[Run 30703834412](https://github.com/hiroppy/mf-dashboard/actions/runs/30703834412) passed all checks:

- build-e2e-web: 1m18s
- shard 1/3: 34 passed in 41.1s; job 1m52s
- shard 2/3: 31 passed and 3 skipped in 40.3s; job 1m56s
- shard 3/3: 31 passed and 3 skipped in 1.8m; job 3m4s
- merged HTML report: passed; job 51s

The production server removes repeated development-route compilation, but the separate build gate, three runner setups, and report-merge job still dominate total workflow time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved automated end-to-end test execution with parallel test runs.
  * Added consolidated HTML reporting for easier review of test results.
  * Updated accessibility test timing to improve reliability.
  * Standardized test server and environment configuration across local and CI runs.

* **Chores**
  * Improved build archiving and retrieval for automated browser testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->