### PR TITLE
fix: preserve cash flow history integrity

### DIFF
--- a/apps/crawler/src/category-decision/categorize-cash-flow.test.ts
+++ b/apps/crawler/src/category-decision/categorize-cash-flow.test.ts
@@ -4,7 +4,6 @@ import type { Page } from "playwright";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { getCsrfToken } from "../hooks/helpers.js";
 import { warn } from "../logger.js";
-import { scrapeCashFlowMonth } from "../scrapers/cash-flow-history.js";
 import { scrapeCategoryCandidates } from "../scrapers/category-candidates.js";
 import { applyCategoryDecisions } from "./apply.js";
 import { categorizeCashFlowMonth } from "./categorize-cash-flow.js";
@@ -25,10 +24,6 @@ vi.mock("../hooks/helpers.js", () => ({
 vi.mock("../logger.js", () => ({
   info: vi.fn<(...args: unknown[]) => void>(),
   warn: vi.fn<(...args: unknown[]) => void>(),
-}));
-
-vi.mock("../scrapers/cash-flow-history.js", () => ({
-  scrapeCashFlowMonth: vi.fn<() => Promise<CashFlowSummary>>(),
 }));
 
 vi.mock("../scrapers/category-candidates.js", () => ({
@@ -72,7 +67,6 @@ function item(mfId: string, description = "Service A"): CashFlowItem {
 describe("categorizeCashFlowMonth", () => {
   beforeEach(() => {
     vi.mocked(findExistingTransactionMfIds).mockReset();
-    vi.mocked(scrapeCashFlowMonth).mockReset();
     vi.mocked(scrapeCategoryCandidates).mockReset();
     vi.mocked(getCsrfToken).mockReset();
     vi.mocked(applyCategoryDecisions).mockReset();
@@ -90,14 +84,10 @@ describe("categorizeCashFlowMonth", () => {
     vi.mocked(getCsrfToken).mockResolvedValue("csrf");
   });
 
-  test("再スクレイプ後の取引でDB既存mfIdを照合し直す", async () => {
+  test("履歴取得済みの取引をそのままカテゴリ判定する", async () => {
     const db = {} as Parameters<typeof categorizeCashFlowMonth>[0]["db"];
-    const initialCashFlow = cashFlow("2026-06", [item("initial-new")]);
-    const latestCashFlow = cashFlow("2026-06", [item("latest-existing"), item("latest-new")]);
-    vi.mocked(findExistingTransactionMfIds)
-      .mockResolvedValueOnce(new Set())
-      .mockResolvedValueOnce(new Set(["latest-existing"]));
-    vi.mocked(scrapeCashFlowMonth).mockResolvedValue(latestCashFlow);
+    const initialCashFlow = cashFlow("2026-06", [item("existing"), item("new")]);
+    vi.mocked(findExistingTransactionMfIds).mockResolvedValue(new Set(["existing"]));
     vi.mocked(applyCategoryDecisions).mockResolvedValue({
       appliedCount: 0,
       appliedDecisions: [],
@@ -111,23 +101,21 @@ describe("categorizeCashFlowMonth", () => {
       usage: { llmCallsUsed: 0 },
     });
 
-    expect(findExistingTransactionMfIds).toHaveBeenNthCalledWith(2, db, [
-      "latest-existing",
-      "latest-new",
-    ]);
+    expect(findExistingTransactionMfIds).toHaveBeenCalledOnce();
+    expect(findExistingTransactionMfIds).toHaveBeenCalledWith(db, ["existing", "new"]);
     expect(vi.mocked(applyCategoryDecisions).mock.calls[0]?.[0].decisions).toHaveLength(1);
     expect(
       vi.mocked(applyCategoryDecisions).mock.calls[0]?.[0].decisions[0]?.transaction.mfId,
-    ).toBe("latest-new");
+    ).toBe("new");
   });
 
-  test("カテゴリ反映後の再スクレイプ失敗時は反映カテゴリをローカル適用して返す", async () => {
-    const initialCashFlow = cashFlow("2026-06", [item("initial-new")]);
-    const latestCashFlow = cashFlow("2026-06", [item("latest-new")]);
+  test("カテゴリ反映後も元の月跨ぎ表示期間と取引集合を保持する", async () => {
+    const initialCashFlow = {
+      ...cashFlow("2026-08", [item("initial-new")]),
+      periodStart: "2026-07-26",
+      periodEnd: "2026-08-25",
+    };
     vi.mocked(findExistingTransactionMfIds).mockResolvedValue(new Set());
-    vi.mocked(scrapeCashFlowMonth)
-      .mockResolvedValueOnce(latestCashFlow)
-      .mockRejectedValueOnce(new Error("final scrape failed"));
     vi.mocked(applyCategoryDecisions).mockImplementation(async ({ decisions }) => ({
       appliedCount: 1,
       appliedDecisions: decisions,
@@ -141,24 +129,41 @@ describe("categorizeCashFlowMonth", () => {
       usage: { llmCallsUsed: 0 },
     });
 
+    expect(result).toEqual({
+      ...initialCashFlow,
+      items: [{ ...initialCashFlow.items[0], category: "食費", subCategory: "食料品" }],
+    });
+  });
+
+  test("一部だけ反映できた場合は成功したカテゴリだけをローカル適用する", async () => {
+    const initialCashFlow = cashFlow("2026-06", [item("applied"), item("not-applied")]);
+    vi.mocked(findExistingTransactionMfIds).mockResolvedValue(new Set());
+    vi.mocked(applyCategoryDecisions).mockImplementation(async ({ decisions }) => ({
+      appliedCount: 1,
+      appliedDecisions: decisions.slice(0, 1),
+    }));
+
+    const result = await categorizeCashFlowMonth({
+      page: {} as Page,
+      db: {} as Parameters<typeof categorizeCashFlowMonth>[0]["db"],
+      cashFlow: initialCashFlow,
+      config,
+      usage: { llmCallsUsed: 0 },
+    });
+
     expect(result.items).toEqual([
       {
-        ...latestCashFlow.items[0],
+        ...initialCashFlow.items[0],
         category: "食費",
         subCategory: "食料品",
       },
+      initialCashFlow.items[1],
     ]);
-    expect(warn).toHaveBeenCalledWith(
-      "Category decision failed for 2026-06; saving locally reflected categories (code: CATEGORY_DECISION_PIPELINE_FAILED).",
-    );
-    expect(JSON.stringify(vi.mocked(warn).mock.calls)).not.toContain("final scrape failed");
   });
 
-  test("再スクレイプ後かつカテゴリ反映前の失敗時は最新取引を返す", async () => {
+  test("カテゴリ反映前の失敗時は履歴取得済みの取引を返す", async () => {
     const initialCashFlow = cashFlow("2026-06", [item("initial-new")]);
-    const latestCashFlow = cashFlow("2026-06", [item("initial-new"), item("latest-new")]);
     vi.mocked(findExistingTransactionMfIds).mockResolvedValue(new Set());
-    vi.mocked(scrapeCashFlowMonth).mockResolvedValue(latestCashFlow);
     vi.mocked(scrapeCategoryCandidates).mockRejectedValue(new Error("candidate scrape failed"));
 
     const result = await categorizeCashFlowMonth({
@@ -169,9 +174,9 @@ describe("categorizeCashFlowMonth", () => {
       usage: { llmCallsUsed: 0 },
     });
 
-    expect(result).toBe(latestCashFlow);
+    expect(result).toBe(initialCashFlow);
     expect(warn).toHaveBeenCalledWith(
-      "Category decision failed for 2026-06; saving latest scraped cash flow (code: CATEGORY_DECISION_PIPELINE_FAILED).",
+      "Category decision failed for 2026-06; saving scraped cash flow (code: CATEGORY_DECISION_PIPELINE_FAILED).",
     );
     expect(JSON.stringify(vi.mocked(warn).mock.calls)).not.toContain("candidate scrape failed");
   });

--- a/apps/crawler/src/category-decision/categorize-cash-flow.ts
+++ b/apps/crawler/src/category-decision/categorize-cash-flow.ts
@@ -5,7 +5,6 @@ import type { CashFlowItem, CashFlowSummary } from "@mf-dashboard/db/types";
 import type { Page } from "playwright";
 import { getCsrfToken } from "../hooks/helpers.js";
 import { info, warn } from "../logger.js";
-import { scrapeCashFlowMonth } from "../scrapers/cash-flow-history.js";
 import { scrapeCategoryCandidates } from "../scrapers/category-candidates.js";
 import { applyCategoryDecisions } from "./apply.js";
 import { CategoryDecisionEngine, selectTransactionsForCategorization } from "./engine.js";
@@ -93,25 +92,15 @@ export async function categorizeCashFlowMonth(options: {
   usage: CategoryDecisionUsage;
 }): Promise<CashFlowSummary> {
   const { page, db, cashFlow, config, usage } = options;
-  let latestCashFlowForFallback = cashFlow;
-  let appliedDecisionsForFallback: ResolvedCategoryDecision[] = [];
 
   try {
-    if ((await findCategorizationTargets(db, cashFlow)).length === 0) {
-      return cashFlow;
-    }
-
-    const latestCashFlow = await scrapeCashFlowMonth(page, cashFlow.month);
-    latestCashFlowForFallback = latestCashFlow;
-    const latestTargets = await findCategorizationTargets(db, latestCashFlow);
-    if (latestTargets.length === 0) {
-      return latestCashFlow;
-    }
+    const targets = await findCategorizationTargets(db, cashFlow);
+    if (targets.length === 0) return cashFlow;
 
     const candidates = await scrapeCategoryCandidates(page);
     if (candidates.length === 0) {
       warn("Skipped category decision because no Money Forward category candidates were found.");
-      return latestCashFlow;
+      return cashFlow;
     }
 
     const engine = new CategoryDecisionEngine({
@@ -125,16 +114,16 @@ export async function categorizeCashFlowMonth(options: {
           candidates: candidateList,
         }),
     });
-    const decisions = await engine.decideMany(latestTargets);
+    const decisions = await engine.decideMany(targets);
 
     if (decisions.length === 0) {
-      return latestCashFlow;
+      return cashFlow;
     }
 
     const csrfToken = await getCsrfToken(page);
     if (!csrfToken) {
       warn("Skipped category update because CSRF token was not found.");
-      return latestCashFlow;
+      return cashFlow;
     }
 
     const { appliedCount, appliedDecisions } = await applyCategoryDecisions({
@@ -142,27 +131,16 @@ export async function categorizeCashFlowMonth(options: {
       csrfToken,
       decisions,
     });
-    appliedDecisionsForFallback = appliedDecisions;
-
     if (appliedCount === 0) {
-      return latestCashFlow;
+      return cashFlow;
     }
 
     info(`Applied category decisions: ${appliedCount}/${decisions.length} for ${cashFlow.month}`);
-    const updatedCashFlow = await scrapeCashFlowMonth(page, cashFlow.month);
-    latestCashFlowForFallback = updatedCashFlow;
-    return updatedCashFlow;
+    return applyDecisionsToCashFlow(cashFlow, appliedDecisions);
   } catch {
-    const categoriesWereApplied = appliedDecisionsForFallback.length > 0;
-    const fallbackMessage = categoriesWereApplied
-      ? "saving locally reflected categories"
-      : "saving latest scraped cash flow";
     warn(
-      `Category decision failed for ${cashFlow.month}; ${fallbackMessage} (code: CATEGORY_DECISION_PIPELINE_FAILED).`,
+      `Category decision failed for ${cashFlow.month}; saving scraped cash flow (code: CATEGORY_DECISION_PIPELINE_FAILED).`,
     );
-    if (categoriesWereApplied) {
-      return applyDecisionsToCashFlow(latestCashFlowForFallback, appliedDecisionsForFallback);
-    }
-    return latestCashFlowForFallback;
+    return cashFlow;
   }
 }

--- a/apps/crawler/src/scrapers/cash-flow-history.test.ts
+++ b/apps/crawler/src/scrapers/cash-flow-history.test.ts
@@ -1,4 +1,3 @@
-import { mfUrls } from "@mf-dashboard/meta/urls";
 import type { Locator, Page } from "playwright";
 import { describe, expect, test, vi } from "vitest";
 import {
@@ -9,7 +8,6 @@ import {
   resolveCashFlowDate,
   resolveCashFlowPeriod,
   scrapeCashFlowHistory,
-  scrapeCashFlowMonth,
 } from "./cash-flow-history.js";
 
 describe("buildMonthRange", () => {
@@ -193,7 +191,67 @@ describe("scrapeCashFlowHistory", () => {
   });
 });
 
-describe("scrapeCashFlowMonth", () => {
+describe("parseDetailRow", () => {
+  test("正常に取得した空の内容欄を保持する", async () => {
+    const missingChild = {
+      count: vi.fn<() => Promise<number>>().mockResolvedValue(0),
+    } as unknown as Locator;
+    const accountCell = {
+      locator: vi.fn<(selector: string) => Locator>().mockReturnValue(missingChild),
+      textContent: vi.fn<Locator["textContent"]>().mockResolvedValue(""),
+    } as unknown as Locator;
+    const texts = new Map([
+      [1, "07/01"],
+      [2, ""],
+      [3, "1,000"],
+      [5, ""],
+      [6, ""],
+    ]);
+    const cells = {
+      nth: vi.fn<(index: number) => Locator>((index) => {
+        if (index === 4) return accountCell;
+        return {
+          textContent: vi.fn<Locator["textContent"]>().mockResolvedValue(texts.get(index) ?? ""),
+        } as unknown as Locator;
+      }),
+    } as unknown as Locator;
+    const row = {
+      getAttribute: vi
+        .fn<Locator["getAttribute"]>()
+        .mockImplementation(async (name) => (name === "id" ? "js-transaction-row-a" : "")),
+      locator: vi.fn<(selector: string) => Locator>().mockReturnValue(cells),
+    } as unknown as Locator;
+
+    await expect(parseDetailRow(row, 2026)).resolves.toMatchObject({ description: "" });
+  });
+
+  test("内容欄の取得に失敗したら月次置換へ進まない", async () => {
+    const texts = new Map([
+      [1, "07/01"],
+      [3, "1,000"],
+    ]);
+    const cells = {
+      nth: vi.fn<(index: number) => Locator>((index) => {
+        return {
+          textContent: vi.fn<Locator["textContent"]>().mockImplementation(async () => {
+            if (index === 2) throw new Error("Detached cell");
+            return texts.get(index) ?? "";
+          }),
+        } as unknown as Locator;
+      }),
+    } as unknown as Locator;
+    const row = {
+      getAttribute: vi
+        .fn<Locator["getAttribute"]>()
+        .mockImplementation(async (name) => (name === "id" ? "js-transaction-row-a" : "")),
+      locator: vi.fn<(selector: string) => Locator>().mockReturnValue(cells),
+    } as unknown as Locator;
+
+    await expect(parseDetailRow(row, 2026)).rejects.toThrow(
+      "Incomplete cash flow transaction row (description)",
+    );
+  });
+
   test("必須セルを取得できない行があれば部分的な月次結果を返さない", async () => {
     const emptyCell = {
       textContent: vi.fn<Locator["textContent"]>().mockResolvedValue(""),
@@ -321,66 +379,60 @@ describe("scrapeCashFlowMonth", () => {
     },
   );
 
-  test("指定月範囲へ遷移し、詳細テーブルを待ってから抽出する", async () => {
-    const waitFor = vi.fn<Locator["waitFor"]>().mockResolvedValue(undefined);
-    const detailTable = { waitFor } as unknown as Locator;
-    let csvLink: Locator;
-    const csvFirst = vi.fn<() => Locator>();
-    csvLink = {
-      count: vi.fn<() => Promise<number>>().mockResolvedValue(1),
-      first: csvFirst,
+  test("行classの取得に失敗したら月次置換へ進まない", async () => {
+    const texts = new Map([
+      [1, "2026/07/01"],
+      [2, "Transaction A"],
+      [3, "1,000"],
+    ]);
+    const cells = {
+      nth: vi.fn<(index: number) => Locator>((index) => {
+        return {
+          textContent: vi.fn<Locator["textContent"]>().mockResolvedValue(texts.get(index) ?? ""),
+        } as unknown as Locator;
+      }),
+    } as unknown as Locator;
+    const row = {
+      getAttribute: vi.fn<Locator["getAttribute"]>().mockImplementation(async (name) => {
+        if (name === "id") return "js-transaction-row-a";
+        throw new Error("Detached row");
+      }),
+      locator: vi.fn<(selector: string) => Locator>().mockReturnValue(cells),
+    } as unknown as Locator;
+
+    await expect(parseDetailRow(row, 2026)).rejects.toThrow("Incomplete cash flow transaction row");
+  });
+
+  test("口座セルの取得に失敗したら月次置換へ進まない", async () => {
+    const missingChild = {
+      count: vi.fn<() => Promise<number>>().mockResolvedValue(0),
+    } as unknown as Locator;
+    const accountCell = {
+      locator: vi.fn<(selector: string) => Locator>().mockReturnValue(missingChild),
+      textContent: vi.fn<Locator["textContent"]>().mockRejectedValue(new Error("Detached cell")),
+    } as unknown as Locator;
+    const texts = new Map([
+      [1, "2026/07/01"],
+      [2, "Transaction A"],
+      [3, "1,000"],
+      [5, "Category A"],
+      [6, "Subcategory A"],
+    ]);
+    const cells = {
+      nth: vi.fn<(index: number) => Locator>((index) => {
+        if (index === 4) return accountCell;
+        return {
+          textContent: vi.fn<Locator["textContent"]>().mockResolvedValue(texts.get(index) ?? ""),
+        } as unknown as Locator;
+      }),
+    } as unknown as Locator;
+    const row = {
       getAttribute: vi
-        .fn<(name: string) => Promise<string | null>>()
-        .mockResolvedValue("/cf/csv?year=2024&month=2"),
-    } as unknown as Locator;
-    csvFirst.mockReturnValue(csvLink);
-
-    let missing: Locator;
-    const missingFirst = vi.fn<() => Locator>();
-    missing = {
-      count: vi.fn<() => Promise<number>>().mockResolvedValue(0),
-      first: missingFirst,
-    } as unknown as Locator;
-    missingFirst.mockReturnValue(missing);
-
-    const amountCell = {
-      textContent: vi.fn<() => Promise<string | null>>().mockResolvedValue("0"),
-    } as unknown as Locator;
-    const summaryCells = {
-      nth: vi.fn<(index: number) => Locator>().mockReturnValue(amountCell),
-    } as unknown as Locator;
-    const summaryRow = {
-      locator: vi.fn<(selector: string) => Locator>().mockReturnValue(summaryCells),
-    } as unknown as Locator;
-    const summary = {
-      first: vi.fn<() => Locator>().mockReturnValue(summaryRow),
-    } as unknown as Locator;
-    const detailRows = {
-      count: vi.fn<() => Promise<number>>().mockResolvedValue(0),
+        .fn<Locator["getAttribute"]>()
+        .mockImplementation(async (name) => (name === "id" ? "js-transaction-row-a" : "")),
+      locator: vi.fn<(selector: string) => Locator>().mockReturnValue(cells),
     } as unknown as Locator;
 
-    const goto = vi.fn<Page["goto"]>().mockResolvedValue(null);
-    const locator = vi.fn<Page["locator"]>((selector: string) => {
-      if (selector === "#cf-detail-table") return detailTable;
-      if (selector === "a[href*='/cf/csv']") return csvLink;
-      if (selector === "#monthly_total_table_kakeibo tbody tr") return summary;
-      if (selector === "#cf-detail-table tbody > tr") return detailRows;
-      return missing;
-    });
-    const page = { goto, locator } as unknown as Page;
-
-    await expect(scrapeCashFlowMonth(page, "2024-02")).resolves.toEqual({
-      month: "2024-02",
-      periodStart: "2024-02-01",
-      periodEnd: "2024-02-29",
-      totalIncome: 0,
-      totalExpense: 0,
-      balance: 0,
-      items: [],
-    });
-    expect(goto).toHaveBeenCalledWith(mfUrls.cashFlowWithRange("2024/02/01", "2024/02/29"), {
-      waitUntil: "domcontentloaded",
-    });
-    expect(waitFor).toHaveBeenCalledWith({ state: "visible", timeout: 10000 });
+    await expect(parseDetailRow(row, 2026)).rejects.toThrow("Incomplete cash flow transaction row");
   });
 });

--- a/apps/crawler/src/scrapers/cash-flow-history.ts
+++ b/apps/crawler/src/scrapers/cash-flow-history.ts
@@ -27,6 +27,10 @@ const CASH_FLOW_AJAX_STATE = "__mfDashboardCashFlowAjax";
 const CASH_FLOW_AMOUNT_PATTERN =
   /^(?:(?:[+\-−▲][¥$]?)|(?:[¥$][+\-−▲]?))?(?:\d{1,3}(?:,\d{3})+|\d+)(?:円)?$/;
 
+function incompleteCashFlowRow(fields: string[]): Error {
+  return new Error(`Incomplete cash flow transaction row (${fields.join(", ")})`);
+}
+
 export function isSupportedCashFlowAmount(value: string): boolean {
   const normalized = value.replace(/\s/g, "").replace(/\(振替\)$/, "");
   return CASH_FLOW_AMOUNT_PATTERN.test(normalized);
@@ -113,7 +117,13 @@ async function parseAccountCell(
   const hasTransferBox = (await transferBox.count()) > 0;
 
   if (hasTransferBox) {
-    const [fullText, toText] = await Promise.all([getText(accountCell), getText(transferBox)]);
+    const [fullText, toText] = await Promise.all([
+      getTextWithFailureSignal(accountCell),
+      getTextWithFailureSignal(transferBox),
+    ]);
+    if (fullText === null || toText === null) {
+      throw incompleteCashFlowRow(["account"]);
+    }
     const accountFrom = fullText.replace(toText, "").trim();
     return {
       hasTransferBox,
@@ -125,8 +135,9 @@ async function parseAccountCell(
   const noformSpan = accountCell.locator("div.noform span");
   const hasNoformSpan = (await noformSpan.count()) > 0;
   const accountFrom = hasNoformSpan
-    ? await getText(noformSpan.first())
-    : await getText(accountCell);
+    ? await getTextWithFailureSignal(noformSpan.first())
+    : await getTextWithFailureSignal(accountCell);
+  if (accountFrom === null) throw incompleteCashFlowRow(["account"]);
 
   return {
     hasTransferBox,
@@ -263,9 +274,9 @@ export async function parseDetailRow(
   // グループ1: 基本情報を並列取得
   const [rowId, rowClass, dateText, description, amountText] = await Promise.all([
     row.getAttribute("id").catch(() => ""),
-    row.getAttribute("class").catch(() => ""),
+    row.getAttribute("class").catch(() => undefined),
     getText(cells.nth(DETAIL_COLUMNS.DATE)),
-    getText(cells.nth(DETAIL_COLUMNS.DESCRIPTION)),
+    getTextWithFailureSignal(cells.nth(DETAIL_COLUMNS.DESCRIPTION)),
     getText(cells.nth(DETAIL_COLUMNS.AMOUNT)),
   ]);
 
@@ -278,9 +289,14 @@ export async function parseDetailRow(
     parsedDate.toISOString().slice(0, 10) === date;
 
   // A monthly replacement is safe only when every rendered transaction row was extracted.
-  if (!mfId || !isValidDate || !description || !isSupportedCashFlowAmount(amountText)) {
-    throw new Error("Incomplete cash flow transaction row");
-  }
+  const incompleteFields = [
+    !mfId ? "id" : null,
+    rowClass === undefined ? "class" : null,
+    !isValidDate ? "date" : null,
+    description === null ? "description" : null,
+    !isSupportedCashFlowAmount(amountText) ? "amount" : null,
+  ].filter((field): field is string => field !== null);
+  if (incompleteFields.length > 0) throw incompleteCashFlowRow(incompleteFields);
 
   // グループ2: カテゴリ情報を並列取得
   const [categoryText, subCategoryText] = await Promise.all([
@@ -289,7 +305,7 @@ export async function parseDetailRow(
   ]);
 
   if (categoryText === null || subCategoryText === null) {
-    throw new Error("Incomplete cash flow transaction row");
+    throw incompleteCashFlowRow(["category"]);
   }
 
   const { accountFrom, accountTo, hasTransferBox } = await parseAccountCell(
@@ -320,7 +336,7 @@ export async function parseDetailRow(
     date,
     category: categoryText || null,
     subCategory: subCategoryText || null,
-    description,
+    description: description ?? "",
     amount: Math.abs(parseJapaneseNumber(amountText)),
     type,
     isTransfer,
@@ -374,17 +390,6 @@ export function buildMonthRange(month: string): { from: string; to: string } {
     from: `${yearText}/${monthText}/01`,
     to: `${yearText}/${monthText}/${String(lastDay).padStart(2, "0")}`,
   };
-}
-
-export async function scrapeCashFlowMonth(page: Page, month: string): Promise<CashFlowSummary> {
-  const range = buildMonthRange(month);
-
-  await page.goto(mfUrls.cashFlowWithRange(range.from, range.to), {
-    waitUntil: "domcontentloaded",
-  });
-  await page.locator("#cf-detail-table").waitFor({ state: "visible", timeout: 10000 });
-
-  return extractCashFlowFromPage(page);
 }
 
 /**

--- a/packages/db/src/repositories/transactions.test.ts
+++ b/packages/db/src/repositories/transactions.test.ts
@@ -650,4 +650,41 @@ describe("saveTransactionsForMonth", () => {
     const result = await db.select().from(schema.transactions).all();
     expect(result.map(({ mfId }) => mfId)).toEqual(["existing-transaction"]);
   });
+
+  test("終了日のtimestampを置換対象に含める", async () => {
+    await saveTransaction(db, {
+      mfId: "stale-end-day-transaction",
+      date: "2026-08-25T08:51:00",
+      category: "Category A",
+      subCategory: null,
+      description: "Stale Transaction",
+      amount: 1_000,
+      type: "expense",
+      isTransfer: false,
+      isExcludedFromCalculation: false,
+    });
+
+    await saveTransactionsForMonth(
+      db,
+      "2026-08",
+      [
+        {
+          mfId: "current-end-day-transaction",
+          date: "2026-08-25T09:00:00",
+          category: "Category B",
+          subCategory: null,
+          description: "Current Transaction",
+          amount: 2_000,
+          type: "expense",
+          isTransfer: false,
+          isExcludedFromCalculation: false,
+        },
+      ],
+      undefined,
+      { from: "2026-07-26", to: "2026-08-25" },
+    );
+
+    const result = await db.select().from(schema.transactions).all();
+    expect(result.map(({ mfId }) => mfId)).toEqual(["current-end-day-transaction"]);
+  });
 });

--- a/packages/db/src/repositories/transactions.ts
+++ b/packages/db/src/repositories/transactions.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, inArray, like, lte, sql } from "drizzle-orm";
+import { and, eq, gte, inArray, like, lt, sql } from "drizzle-orm";
 import type { Db, DbExecutor } from "../index";
 import { schema } from "../index";
 import type { CashFlowItem } from "../types";
@@ -119,11 +119,16 @@ export async function deleteTransactionsForMonth(db: DbExecutor, month: string):
 
 async function deleteTransactionsForDateRange(
   db: DbExecutor,
-  range: TransactionDateRange,
+  range: TransactionDateRange & { toExclusive: string },
 ): Promise<number> {
   const result = await db
     .delete(schema.transactions)
-    .where(and(gte(schema.transactions.date, range.from), lte(schema.transactions.date, range.to)))
+    .where(
+      and(
+        gte(schema.transactions.date, range.from),
+        lt(schema.transactions.date, range.toExclusive),
+      ),
+    )
     .run();
   return result.rowsAffected;
 }
@@ -147,6 +152,12 @@ function resolveTransactionDateRange(
   const [year, monthNumber] = month.split("-").map(Number);
   const lastDay = new Date(year, monthNumber, 0).getDate();
   return { from: `${month}-01`, to: `${month}-${String(lastDay).padStart(2, "0")}` };
+}
+
+function getExclusiveRangeEnd(to: string): string {
+  const nextDay = new Date(`${to}T00:00:00Z`);
+  nextDay.setUTCDate(nextDay.getUTCDate() + 1);
+  return nextDay.toISOString().slice(0, 10);
 }
 
 /**
@@ -230,14 +241,15 @@ export async function replaceTransactionsForMonth(
   const validItems = items.filter((item) => item.mfId && !item.mfId.startsWith("unknown"));
   const currentYear = parseInt(month.slice(0, 4), 10);
   const replacementRange = resolveTransactionDateRange(month, dateRange);
+  const toExclusive = getExclusiveRangeEnd(replacementRange.to);
   const records = validItems.map((item) => prepareTransactionData(item, accountIdMap, currentYear));
 
-  if (records.some(({ date }) => date < replacementRange.from || date > replacementRange.to)) {
+  if (records.some(({ date }) => date < replacementRange.from || date >= toExclusive)) {
     throw new Error("Invalid transactions: item falls outside replacement date range");
   }
 
   // Validate the complete replacement before deleting existing data.
-  const deleted = await deleteTransactionsForDateRange(db, replacementRange);
+  const deleted = await deleteTransactionsForDateRange(db, { ...replacementRange, toExclusive });
   if (deleted > 0) {
     console.log(
       `  Deleted ${deleted} existing transactions for ${replacementRange.from} to ${replacementRange.to}`,

--- a/packages/meta/src/urls.ts
+++ b/packages/meta/src/urls.ts
@@ -34,9 +34,4 @@ export const mfUrls = {
   accountDetail(mfId: string, type: "show" | "show_manual" = "show"): string {
     return `${BASE_URL}/accounts/${type}/${mfId}`;
   },
-
-  /** 指定月の家計簿URL を生成 (from/to は YYYY/MM/DD 形式) */
-  cashFlowWithRange(from: string, to: string): string {
-    return `${BASE_URL}/cf?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`;
-  },
 } as const;


### PR DESCRIPTION
# Summary

- Stop re-scraping monthly cash flow through a range URL that Money Forward ignores and preserve the already authenticated history snapshot during category updates.
- Apply only successfully persisted category decisions to the original transaction set.
- Abort monthly replacement when required row attributes or account extraction fails, while allowing legitimate empty descriptions.
- Include timestamps on the configured period end date in replacement boundaries.
- Remove the ineffective range-navigation helper and its mock-based tests.

This is a stacked follow-up to #310 so the E2E policy change and the crawler data-integrity fix remain reviewable separately. After #310 merges, this PR can target `main`.

## Linear Issue

- N/A

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | Monthly history, amounts, and transfer relationships must match the authenticated service | Every extracted period is saved with the same count; common transaction IDs retain identical amounts, types, transfer flags, and source/target account links |
| Reliability | A partial DOM read must not replace a complete persisted month | Required extraction failures abort the replacement transaction; valid empty descriptions remain accepted |
| Information security | Real-account validation must not expose personal financial data | Tests and PR evidence contain only anonymous fixtures and aggregate comparison counts |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Boundary value analysis | Date-range deletion previously excluded end-day timestamps | Start/end dates and end-day timestamps are replaced; the next day is excluded |
| Decision table testing | Empty values and extraction failures require different outcomes per field | Legitimate empty descriptions succeed; failed class, description, category, and account reads abort |
| State transition testing | Category updates move from scraped state to partially or fully applied state | Original period and transaction set remain stable; only successful decisions alter categories |
| Exploratory/checklist testing | Production-like integrity requires comparison against the authenticated service and an existing DB | Fresh history DB is internally valid and common transactions reconcile without amount or transfer-link mismatches |

### Primary Test Conditions

- A legitimate empty transaction description is preserved.
- Failed row-class, description, category, or account extraction aborts the monthly snapshot.
- A cross-month accounting period preserves its original rows during category decisions.
- Partial category-update success changes only successful transactions.
- A timestamp on the replacement end date is deleted/replaced; the exclusive next-day boundary is retained.
- A fresh authenticated history crawl saves all 20 extracted periods with matching per-period counts.
- Existing and fresh DB common transactions have zero mismatches for date, amount, type, transfer flag, exclusion flag, source account, transfer text, and target account.
- Fresh DB has no duplicate transaction IDs, invalid dates/types, transfer consistency errors, orphan account links, or non-integer amounts.

### Out-of-Scope Risks

- Current account totals and holding valuations can legitimately change between crawls; they were compared for shape, but exact equality is not required.
- The fresh official crawl contained new transactions and current category/description updates not present in the older DB; the older DB was not modified.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [x] Storybook tests
- [x] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm test — passed (crawler 346, DB 392, web 928, analytics 143, meta 9, date-utils 14)
pnpm turbo typecheck — passed (8/8 packages)
pnpm lint — passed
pnpm format:check — passed
pnpm knip — passed (existing configuration hints only)
pnpm --filter @mf-dashboard/crawler test:e2e — passed (74/74, skipped 0)
DB_PATH=<temporary> SCRAPE_MODE=history CLEANUP_GROUPS=false pnpm --filter @mf-dashboard/crawler dev:scrape — passed
fresh crawl reconciliation — 4,957/4,957 extracted/saved, 20/20 periods, per-period mismatches 0
existing DB reconciliation — 4,942 common IDs; amount/type/transfer/source/target mismatches 0
SQLite integrity and transaction invariant checks — passed
```

### Checks Not Run

- N/A — all relevant checks were run.
