### PR TITLE
feat(analytics): add LLM forecast assistance

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -10,6 +10,7 @@
     "./chat/tools": "./src/chat/tools.ts",
     "./config": "./src/config.ts",
     "./categorization": "./src/categorization.ts",
+    "./forecast-assistance": "./src/forecast-assistance.ts",
     "./types": "./src/types.ts"
   },
   "scripts": {

--- a/packages/analytics/src/forecast-assistance.test.ts
+++ b/packages/analytics/src/forecast-assistance.test.ts
@@ -96,6 +96,36 @@ describe("assistForecastCandidate", () => {
     );
   });
 
+  test("LLMが給与へ補強した場合は休日ズレ候補を再計算する", async () => {
+    const unclassifiedCandidate = {
+      ...salaryCandidate,
+      matchedSignals: [],
+    };
+    const llmDecider = vi.fn<ForecastLLMDecider>().mockResolvedValue({
+      candidateId: "candidate-a",
+      classification: "salary",
+      confidence: 0.8,
+      reason: "出現日と金額帯から給与候補と判断しました。",
+      dateAdjustment: "next_business_day",
+    });
+
+    const result = await assistForecastCandidate(unclassifiedCandidate, llmDecider);
+
+    expect(llmDecider).toHaveBeenCalledWith(
+      unclassifiedCandidate,
+      expect.arrayContaining([
+        { date: "2026-10-23", adjustment: "previous_business_day" },
+        { date: "2026-10-26", adjustment: "next_business_day" },
+      ]),
+    );
+    expect(result.classification).toMatchObject({ label: "salary", source: "llm" });
+    expect(result.dateCandidates).toEqual([
+      { date: "2026-10-23", adjustment: "previous_business_day" },
+      { date: "2026-10-26", adjustment: "next_business_day" },
+    ]);
+    expect(result.suggestedDateAdjustment).toBe("next_business_day");
+  });
+
   test("直近1回のみの新規大口入金を要確認として説明する", async () => {
     const result = await assistForecastCandidate(
       {

--- a/packages/analytics/src/forecast-assistance.test.ts
+++ b/packages/analytics/src/forecast-assistance.test.ts
@@ -1,5 +1,5 @@
 import { generateText } from "ai";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { isLLMEnabled } from "./config.js";
 import {
   assistForecastCandidate,
@@ -30,6 +30,10 @@ const salaryCandidate: ForecastCandidateFeatures = {
   nominalDate: "2026-10-25",
   matchedSignals: ["salary"],
 };
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("getBusinessDayShiftCandidates", () => {
   test("25日が休日の場合は前営業日と翌営業日を候補にする", () => {
@@ -81,6 +85,10 @@ describe("assistForecastCandidate", () => {
 
     const result = await assistForecastCandidate(salaryCandidate, llmDecider);
 
+    expect(llmDecider).toHaveBeenCalledWith(
+      salaryCandidate,
+      expect.arrayContaining([{ date: "2026-10-25", adjustment: "none" }]),
+    );
     expect(result.classification).toEqual({
       label: "salary",
       confidence: 0.82,
@@ -167,6 +175,36 @@ describe("assistForecastCandidate", () => {
     expect(invalidResult.classification.source).toBe("rule");
     expect(ambiguousResult.classification.source).toBe("rule");
   });
+
+  test("収支方向と矛盾するルールとLLM分類を無視する", async () => {
+    const expenseCandidate = {
+      ...salaryCandidate,
+      direction: "expense" as const,
+    };
+
+    const result = await assistForecastCandidate(expenseCandidate, async () => ({
+      candidateId: "candidate-a",
+      classification: "salary",
+      confidence: 0.9,
+      reason: "incompatible direction",
+      dateAdjustment: "previous_business_day",
+    }));
+
+    expect(result.classification).toMatchObject({ label: "other", source: "rule" });
+    expect(result.dateCandidates).toEqual([{ date: "2026-10-25", adjustment: "none" }]);
+  });
+
+  test("LLMがtimeoutした場合はルール結果を返す", async () => {
+    vi.useFakeTimers();
+    const stalledDecider = vi.fn<ForecastLLMDecider>(() => new Promise(() => {}));
+
+    const resultPromise = assistForecastCandidate(salaryCandidate, stalledDecider, 100);
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(resultPromise).resolves.toMatchObject({
+      classification: { label: "salary", source: "rule" },
+    });
+  });
 });
 
 describe("generateForecastAssistanceWithLLM", () => {
@@ -237,6 +275,7 @@ describe("generateForecastAssistanceWithLLM", () => {
     expect(request?.prompt).not.toContain("Test User");
     expect(request?.prompt).not.toContain("Bank A personal account");
     expect(request?.prompt).not.toContain("500000");
+    expect(request?.prompt).toContain("direction、matchedSignals");
     expect(request?.prompt).toContain('"amountBand": "large"');
     expect(result).toMatchObject({ classification: "salary", confidence: 0.8 });
   });

--- a/packages/analytics/src/forecast-assistance.test.ts
+++ b/packages/analytics/src/forecast-assistance.test.ts
@@ -1,0 +1,213 @@
+import { generateText } from "ai";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { isLLMEnabled } from "./config.js";
+import {
+  assistForecastCandidate,
+  generateForecastAssistanceWithLLM,
+  getBusinessDayShiftCandidates,
+  type ForecastCandidateFeatures,
+  type ForecastLLMDecider,
+} from "./forecast-assistance.js";
+
+vi.mock("ai", () => ({
+  generateText: vi.fn<() => Promise<unknown>>(),
+  Output: {
+    object: vi.fn<(value: unknown) => unknown>((value) => value),
+  },
+}));
+
+vi.mock("./config.js", () => ({
+  getModel: vi.fn<() => string>(() => "mock-model"),
+  isLLMEnabled: vi.fn<() => boolean>(),
+}));
+
+const salaryCandidate: ForecastCandidateFeatures = {
+  candidateId: "candidate-a",
+  direction: "income",
+  occurrenceCount: 3,
+  observedDayRange: [24, 26],
+  amountBand: "large",
+  nominalDate: "2026-10-25",
+  matchedSignals: ["salary"],
+};
+
+describe("getBusinessDayShiftCandidates", () => {
+  test("25日が休日の場合は前営業日と翌営業日を候補にする", () => {
+    expect(getBusinessDayShiftCandidates("2026-10-25")).toEqual([
+      { date: "2026-10-23", adjustment: "previous_business_day" },
+      { date: "2026-10-26", adjustment: "next_business_day" },
+    ]);
+  });
+
+  test("追加の休日を飛ばして営業日を探す", () => {
+    expect(getBusinessDayShiftCandidates("2026-10-25", ["2026-10-26"])).toEqual([
+      { date: "2026-10-23", adjustment: "previous_business_day" },
+      { date: "2026-10-27", adjustment: "next_business_day" },
+    ]);
+  });
+
+  test("平日は元の日付だけを候補にする", () => {
+    expect(getBusinessDayShiftCandidates("2026-09-25")).toEqual([
+      { date: "2026-09-25", adjustment: "none" },
+    ]);
+  });
+});
+
+describe("assistForecastCandidate", () => {
+  test("LLMなしでもルール分類と休日ズレ候補を返す", async () => {
+    const llmDecider = vi.fn<ForecastLLMDecider>().mockResolvedValue(null);
+
+    const result = await assistForecastCandidate(salaryCandidate, llmDecider);
+
+    expect(result.classification).toEqual({
+      label: "salary",
+      confidence: 0.9,
+      reason: "匿名化済みのsalaryシグナルと過去3回の出現に基づく分類です。",
+      source: "rule",
+    });
+    expect(result.dateCandidates).toHaveLength(2);
+    expect(result.suggestedDateAdjustment).toBeNull();
+    expect(result.reviewRequired).toBe(false);
+  });
+
+  test("LLMありの場合は分類ラベル・信頼度・根拠と日付推奨を補強する", async () => {
+    const llmDecider = vi.fn<ForecastLLMDecider>().mockResolvedValue({
+      candidateId: "candidate-a",
+      classification: "salary",
+      confidence: 0.82,
+      reason: "月末前の定期入金で、休日は前営業日に寄る可能性があります。",
+      dateAdjustment: "previous_business_day",
+    });
+
+    const result = await assistForecastCandidate(salaryCandidate, llmDecider);
+
+    expect(result.classification).toEqual({
+      label: "salary",
+      confidence: 0.82,
+      reason: "月末前の定期入金で、休日は前営業日に寄る可能性があります。",
+      source: "llm",
+    });
+    expect(result.suggestedDateAdjustment).toBe("previous_business_day");
+    expect(result.dateCandidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ adjustment: "previous_business_day" }),
+        expect.objectContaining({ adjustment: "next_business_day" }),
+      ]),
+    );
+  });
+
+  test("直近1回のみの新規大口入金を要確認として説明する", async () => {
+    const result = await assistForecastCandidate(
+      {
+        ...salaryCandidate,
+        occurrenceCount: 1,
+        matchedSignals: [],
+      },
+      async () => null,
+    );
+
+    expect(result.reviewRequired).toBe(true);
+    expect(result.reviewReason).toContain("直近1回");
+    expect(result.classification).toMatchObject({
+      label: "other",
+      source: "rule",
+    });
+  });
+
+  test("LLM例外と曖昧または候補外の日付推奨は安全に無視する", async () => {
+    const failingResult = await assistForecastCandidate(salaryCandidate, async () => {
+      throw new Error("provider failure");
+    });
+    const invalidResult = await assistForecastCandidate(salaryCandidate, async () => ({
+      candidateId: "candidate-a",
+      classification: "salary",
+      confidence: 1,
+      reason: "unsupported adjustment",
+      dateAdjustment: "none",
+    }));
+    const ambiguousResult = await assistForecastCandidate(salaryCandidate, async () => ({
+      candidateId: "candidate-a",
+      classification: "salary",
+      confidence: 0.59,
+      reason: "low confidence",
+      dateAdjustment: "previous_business_day",
+    }));
+
+    expect(failingResult.classification.source).toBe("rule");
+    expect(invalidResult.classification.source).toBe("rule");
+    expect(ambiguousResult.classification.source).toBe("rule");
+  });
+});
+
+describe("generateForecastAssistanceWithLLM", () => {
+  beforeEach(() => {
+    vi.mocked(isLLMEnabled).mockReturnValue(true);
+    vi.mocked(generateText).mockReset();
+  });
+
+  test("LLM設定がない場合は呼び出さずnullを返す", async () => {
+    vi.mocked(isLLMEnabled).mockReturnValue(false);
+
+    const result = await generateForecastAssistanceWithLLM(salaryCandidate, [
+      { date: "2026-10-23", adjustment: "previous_business_day" },
+    ]);
+
+    expect(result).toBeNull();
+    expect(generateText).not.toHaveBeenCalled();
+  });
+
+  test("不正または候補と整合しない出力をschema validation後に無視する", async () => {
+    vi.mocked(generateText)
+      .mockResolvedValueOnce({
+        output: {
+          candidateId: "candidate-a",
+          classification: "salary",
+          confidence: 2,
+          reason: "invalid confidence",
+          dateAdjustment: "previous_business_day",
+        },
+      } as Awaited<ReturnType<typeof generateText>>)
+      .mockResolvedValueOnce({
+        output: {
+          candidateId: "candidate-b",
+          classification: "salary",
+          confidence: 0.8,
+          reason: "wrong candidate",
+          dateAdjustment: "previous_business_day",
+        },
+      } as Awaited<ReturnType<typeof generateText>>);
+    const dateCandidates = [{ date: "2026-10-23", adjustment: "previous_business_day" as const }];
+
+    expect(await generateForecastAssistanceWithLLM(salaryCandidate, dateCandidates)).toBeNull();
+    expect(await generateForecastAssistanceWithLLM(salaryCandidate, dateCandidates)).toBeNull();
+  });
+
+  test("プロンプトには匿名化済み特徴量だけを渡す", async () => {
+    const candidateWithUntrustedExtras = {
+      ...salaryCandidate,
+      description: "Test User 給与振込",
+      accountName: "Bank A personal account",
+      amount: 500_000,
+    };
+    vi.mocked(generateText).mockResolvedValue({
+      output: {
+        candidateId: "candidate-a",
+        classification: "salary",
+        confidence: 0.8,
+        reason: "定期的な大口入金です。",
+        dateAdjustment: "previous_business_day",
+      },
+    } as Awaited<ReturnType<typeof generateText>>);
+
+    const result = await generateForecastAssistanceWithLLM(candidateWithUntrustedExtras, [
+      { date: "2026-10-23", adjustment: "previous_business_day" },
+    ]);
+
+    const request = vi.mocked(generateText).mock.calls[0]?.[0];
+    expect(request?.prompt).not.toContain("Test User");
+    expect(request?.prompt).not.toContain("Bank A personal account");
+    expect(request?.prompt).not.toContain("500000");
+    expect(request?.prompt).toContain('"amountBand": "large"');
+    expect(result).toMatchObject({ classification: "salary", confidence: 0.8 });
+  });
+});

--- a/packages/analytics/src/forecast-assistance.ts
+++ b/packages/analytics/src/forecast-assistance.ts
@@ -156,6 +156,23 @@ function createDateCandidates(
   return getBusinessDayShiftCandidates(candidate.nominalDate, candidate.nonBusinessDates);
 }
 
+function createLLMDateCandidates(
+  candidate: ForecastCandidateFeatures,
+  ruleClassification: ForecastClassification,
+): ForecastDateCandidate[] {
+  const ruleCandidates = createDateCandidates(candidate, ruleClassification);
+  if (ruleClassification === "salary") return ruleCandidates;
+
+  const salaryCandidates = createDateCandidates(candidate, "salary");
+  return [
+    ...ruleCandidates,
+    ...salaryCandidates.filter(
+      ({ adjustment }) =>
+        !ruleCandidates.some((dateCandidate) => dateCandidate.adjustment === adjustment),
+    ),
+  ];
+}
+
 function isValidLLMDecision(
   decision: ForecastLLMDecision,
   candidate: ForecastCandidateFeatures,
@@ -165,7 +182,14 @@ function isValidLLMDecision(
   if (decision.classification === "other" || decision.confidence < minimumLLMConfidence) {
     return false;
   }
-  return dateCandidates.some(({ adjustment }) => adjustment === decision.dateAdjustment);
+  const adjustmentWasOffered = dateCandidates.some(
+    ({ adjustment }) => adjustment === decision.dateAdjustment,
+  );
+  const adjustmentMatchesClassification = createDateCandidates(
+    candidate,
+    decision.classification,
+  ).some(({ adjustment }) => adjustment === decision.dateAdjustment);
+  return adjustmentWasOffered && adjustmentMatchesClassification;
 }
 
 export async function generateForecastAssistanceWithLLM(
@@ -208,18 +232,21 @@ export async function assistForecastCandidate(
   llmDecider: ForecastLLMDecider = generateForecastAssistanceWithLLM,
 ): Promise<AssistedForecastCandidate> {
   const ruleClassification = createRuleClassification(candidate);
-  const dateCandidates = createDateCandidates(candidate, ruleClassification.label);
+  const llmDateCandidates = createLLMDateCandidates(candidate, ruleClassification.label);
 
   let llmDecision: ForecastLLMDecision | null = null;
   try {
-    llmDecision = await llmDecider(candidate, dateCandidates);
+    llmDecision = await llmDecider(candidate, llmDateCandidates);
   } catch {
     // The forecast must remain available when the optional LLM fails.
   }
 
-  if (llmDecision && !isValidLLMDecision(llmDecision, candidate, dateCandidates)) {
+  if (llmDecision && !isValidLLMDecision(llmDecision, candidate, llmDateCandidates)) {
     llmDecision = null;
   }
+
+  const classification = llmDecision?.classification ?? ruleClassification.label;
+  const dateCandidates = createDateCandidates(candidate, classification);
 
   const isNewLargeIncome =
     candidate.direction === "income" &&

--- a/packages/analytics/src/forecast-assistance.ts
+++ b/packages/analytics/src/forecast-assistance.ts
@@ -82,6 +82,15 @@ export interface AssistedForecastCandidate {
 const signalPriority: readonly ForecastSignal[] = ["salary", "card_payment", "rent", "loan", "tax"];
 
 const minimumLLMConfidence = 0.6;
+const defaultLLMTimeoutMs = 5_000;
+
+function isClassificationCompatible(
+  direction: ForecastCandidateFeatures["direction"],
+  classification: ForecastClassification,
+): boolean {
+  if (classification === "other") return true;
+  return classification === "salary" ? direction === "income" : direction === "expense";
+}
 
 function isBusinessDay(date: string, nonBusinessDates: ReadonlySet<string>): boolean {
   const dayOfWeek = getDayOfWeekIsoDateKey(date);
@@ -126,7 +135,11 @@ export function getBusinessDayShiftCandidates(
 function createRuleClassification(
   candidate: ForecastCandidateFeatures,
 ): ForecastClassificationDecision {
-  const label = signalPriority.find((signal) => candidate.matchedSignals.includes(signal));
+  const label = signalPriority.find(
+    (signal) =>
+      candidate.matchedSignals.includes(signal) &&
+      isClassificationCompatible(candidate.direction, signal),
+  );
   if (!label) {
     return {
       label: "other",
@@ -156,20 +169,15 @@ function createDateCandidates(
   return getBusinessDayShiftCandidates(candidate.nominalDate, candidate.nonBusinessDates);
 }
 
-function createLLMDateCandidates(
-  candidate: ForecastCandidateFeatures,
-  ruleClassification: ForecastClassification,
-): ForecastDateCandidate[] {
-  const ruleCandidates = createDateCandidates(candidate, ruleClassification);
-  if (ruleClassification === "salary") return ruleCandidates;
-
+function createLLMDateCandidates(candidate: ForecastCandidateFeatures): ForecastDateCandidate[] {
+  const nominalCandidate: ForecastDateCandidate = {
+    date: candidate.nominalDate,
+    adjustment: "none",
+  };
   const salaryCandidates = createDateCandidates(candidate, "salary");
   return [
-    ...ruleCandidates,
-    ...salaryCandidates.filter(
-      ({ adjustment }) =>
-        !ruleCandidates.some((dateCandidate) => dateCandidate.adjustment === adjustment),
-    ),
+    nominalCandidate,
+    ...salaryCandidates.filter(({ adjustment }) => adjustment !== nominalCandidate.adjustment),
   ];
 }
 
@@ -182,6 +190,7 @@ function isValidLLMDecision(
   if (decision.classification === "other" || decision.confidence < minimumLLMConfidence) {
     return false;
   }
+  if (!isClassificationCompatible(candidate.direction, decision.classification)) return false;
   const adjustmentWasOffered = dateCandidates.some(
     ({ adjustment }) => adjustment === decision.dateAdjustment,
   );
@@ -203,7 +212,7 @@ export async function generateForecastAssistanceWithLLM(
     output: Output.object({ schema: forecastLLMDecisionSchema }),
     system:
       "あなたは今月の銀行入出金予測候補を補助分類します。入力は匿名化済み特徴量です。分類・信頼度・短い根拠と候補内の日付調整だけを返し、金額計算や予測採否は行いません。",
-    prompt: `次の匿名化済みJSONを分類してください。matchedSignals、出現回数、日付範囲、金額帯だけを根拠にし、dateAdjustmentはdateCandidatesに存在する値を選んでください。\n\n${JSON.stringify(
+    prompt: `次の匿名化済みJSONを分類してください。direction、matchedSignals、出現回数、日付範囲、金額帯だけを根拠にし、dateAdjustmentはdateCandidatesに存在する値を選んでください。\n\n${JSON.stringify(
       {
         candidate: {
           candidateId: candidate.candidateId,
@@ -227,16 +236,36 @@ export async function generateForecastAssistanceWithLLM(
   return parsed.data;
 }
 
+function requestLLMDecision(
+  request: Promise<ForecastLLMDecision | null>,
+  timeoutMs: number,
+): Promise<ForecastLLMDecision | null> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => resolve(null), timeoutMs);
+    request.then(
+      (decision) => {
+        clearTimeout(timeout);
+        resolve(decision);
+      },
+      (error: unknown) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
 export async function assistForecastCandidate(
   candidate: ForecastCandidateFeatures,
   llmDecider: ForecastLLMDecider = generateForecastAssistanceWithLLM,
+  llmTimeoutMs = defaultLLMTimeoutMs,
 ): Promise<AssistedForecastCandidate> {
   const ruleClassification = createRuleClassification(candidate);
-  const llmDateCandidates = createLLMDateCandidates(candidate, ruleClassification.label);
+  const llmDateCandidates = createLLMDateCandidates(candidate);
 
   let llmDecision: ForecastLLMDecision | null = null;
   try {
-    llmDecision = await llmDecider(candidate, llmDateCandidates);
+    llmDecision = await requestLLMDecision(llmDecider(candidate, llmDateCandidates), llmTimeoutMs);
   } catch {
     // The forecast must remain available when the optional LLM fails.
   }

--- a/packages/analytics/src/forecast-assistance.ts
+++ b/packages/analytics/src/forecast-assistance.ts
@@ -1,0 +1,246 @@
+import {
+  addDaysToIsoDateKey,
+  getDayOfWeekIsoDateKey,
+  parseIsoDateKey,
+} from "@mf-dashboard/date-utils";
+import { generateText, Output } from "ai";
+import { z } from "zod";
+import { getModel, isLLMEnabled } from "./config.js";
+
+const forecastClassificationSchema = z.enum([
+  "salary",
+  "card_payment",
+  "rent",
+  "loan",
+  "tax",
+  "other",
+]);
+
+const forecastSignalSchema = z.enum(["salary", "card_payment", "rent", "loan", "tax"]);
+
+const dateAdjustmentSchema = z.enum(["none", "previous_business_day", "next_business_day"]);
+
+const forecastLLMDecisionSchema = z
+  .object({
+    candidateId: z.string().min(1),
+    classification: forecastClassificationSchema,
+    confidence: z.number().min(0).max(1),
+    reason: z.string().min(1).max(240),
+    dateAdjustment: dateAdjustmentSchema,
+  })
+  .strict();
+
+export type ForecastClassification = z.infer<typeof forecastClassificationSchema>;
+export type ForecastSignal = z.infer<typeof forecastSignalSchema>;
+export type ForecastDateAdjustment = z.infer<typeof dateAdjustmentSchema>;
+
+export interface ForecastCandidateFeatures {
+  candidateId: string;
+  direction: "income" | "expense";
+  occurrenceCount: number;
+  observedDayRange: readonly [number, number];
+  amountBand: "small" | "medium" | "large";
+  nominalDate: string;
+  matchedSignals: readonly ForecastSignal[];
+  nonBusinessDates?: readonly string[];
+}
+
+export interface ForecastClassificationDecision {
+  label: ForecastClassification;
+  confidence: number;
+  reason: string;
+  source: "rule" | "llm";
+}
+
+export interface ForecastDateCandidate {
+  date: string;
+  adjustment: ForecastDateAdjustment;
+}
+
+export interface ForecastLLMDecision {
+  candidateId: string;
+  classification: ForecastClassification;
+  confidence: number;
+  reason: string;
+  dateAdjustment: ForecastDateAdjustment;
+}
+
+export type ForecastLLMDecider = (
+  candidate: ForecastCandidateFeatures,
+  dateCandidates: readonly ForecastDateCandidate[],
+) => Promise<ForecastLLMDecision | null>;
+
+export interface AssistedForecastCandidate {
+  candidateId: string;
+  classification: ForecastClassificationDecision;
+  dateCandidates: ForecastDateCandidate[];
+  suggestedDateAdjustment: ForecastDateAdjustment | null;
+  reviewRequired: boolean;
+  reviewReason: string | null;
+}
+
+const signalPriority: readonly ForecastSignal[] = ["salary", "card_payment", "rent", "loan", "tax"];
+
+const minimumLLMConfidence = 0.6;
+
+function isBusinessDay(date: string, nonBusinessDates: ReadonlySet<string>): boolean {
+  const dayOfWeek = getDayOfWeekIsoDateKey(date);
+  return dayOfWeek !== 0 && dayOfWeek !== 6 && !nonBusinessDates.has(date);
+}
+
+function findBusinessDay(
+  nominalDate: string,
+  direction: -1 | 1,
+  nonBusinessDates: ReadonlySet<string>,
+): string {
+  let date = nominalDate;
+  do {
+    date = addDaysToIsoDateKey(date, direction);
+  } while (!isBusinessDay(date, nonBusinessDates));
+  return date;
+}
+
+export function getBusinessDayShiftCandidates(
+  nominalDate: string,
+  nonBusinessDates: readonly string[] = [],
+): ForecastDateCandidate[] {
+  parseIsoDateKey(nominalDate);
+  const excludedDates = new Set(nonBusinessDates);
+
+  if (isBusinessDay(nominalDate, excludedDates)) {
+    return [{ date: nominalDate, adjustment: "none" }];
+  }
+
+  return [
+    {
+      date: findBusinessDay(nominalDate, -1, excludedDates),
+      adjustment: "previous_business_day",
+    },
+    {
+      date: findBusinessDay(nominalDate, 1, excludedDates),
+      adjustment: "next_business_day",
+    },
+  ];
+}
+
+function createRuleClassification(
+  candidate: ForecastCandidateFeatures,
+): ForecastClassificationDecision {
+  const label = signalPriority.find((signal) => candidate.matchedSignals.includes(signal));
+  if (!label) {
+    return {
+      label: "other",
+      confidence: 0,
+      reason: "ルールに一致する分類シグナルがありません。",
+      source: "rule",
+    };
+  }
+
+  const occurrenceConfidence = candidate.occurrenceCount >= 3 ? 0.9 : 0.6;
+  return {
+    label,
+    confidence: candidate.occurrenceCount === 1 ? 0.35 : occurrenceConfidence,
+    reason: `匿名化済みの${label}シグナルと過去${candidate.occurrenceCount}回の出現に基づく分類です。`,
+    source: "rule",
+  };
+}
+
+function createDateCandidates(
+  candidate: ForecastCandidateFeatures,
+  classification: ForecastClassification,
+): ForecastDateCandidate[] {
+  if (classification !== "salary") {
+    return [{ date: candidate.nominalDate, adjustment: "none" }];
+  }
+
+  return getBusinessDayShiftCandidates(candidate.nominalDate, candidate.nonBusinessDates);
+}
+
+function isValidLLMDecision(
+  decision: ForecastLLMDecision,
+  candidate: ForecastCandidateFeatures,
+  dateCandidates: readonly ForecastDateCandidate[],
+): boolean {
+  if (decision.candidateId !== candidate.candidateId) return false;
+  if (decision.classification === "other" || decision.confidence < minimumLLMConfidence) {
+    return false;
+  }
+  return dateCandidates.some(({ adjustment }) => adjustment === decision.dateAdjustment);
+}
+
+export async function generateForecastAssistanceWithLLM(
+  candidate: ForecastCandidateFeatures,
+  dateCandidates: readonly ForecastDateCandidate[],
+): Promise<ForecastLLMDecision | null> {
+  if (!isLLMEnabled()) return null;
+
+  const result = await generateText({
+    model: getModel(),
+    output: Output.object({ schema: forecastLLMDecisionSchema }),
+    system:
+      "あなたは今月の銀行入出金予測候補を補助分類します。入力は匿名化済み特徴量です。分類・信頼度・短い根拠と候補内の日付調整だけを返し、金額計算や予測採否は行いません。",
+    prompt: `次の匿名化済みJSONを分類してください。matchedSignals、出現回数、日付範囲、金額帯だけを根拠にし、dateAdjustmentはdateCandidatesに存在する値を選んでください。\n\n${JSON.stringify(
+      {
+        candidate: {
+          candidateId: candidate.candidateId,
+          direction: candidate.direction,
+          occurrenceCount: candidate.occurrenceCount,
+          observedDayRange: candidate.observedDayRange,
+          amountBand: candidate.amountBand,
+          matchedSignals: candidate.matchedSignals,
+        },
+        dateCandidates,
+      },
+      null,
+      2,
+    )}`,
+  });
+
+  const parsed = forecastLLMDecisionSchema.safeParse(result.output);
+  if (!parsed.success || !isValidLLMDecision(parsed.data, candidate, dateCandidates)) {
+    return null;
+  }
+  return parsed.data;
+}
+
+export async function assistForecastCandidate(
+  candidate: ForecastCandidateFeatures,
+  llmDecider: ForecastLLMDecider = generateForecastAssistanceWithLLM,
+): Promise<AssistedForecastCandidate> {
+  const ruleClassification = createRuleClassification(candidate);
+  const dateCandidates = createDateCandidates(candidate, ruleClassification.label);
+
+  let llmDecision: ForecastLLMDecision | null = null;
+  try {
+    llmDecision = await llmDecider(candidate, dateCandidates);
+  } catch {
+    // The forecast must remain available when the optional LLM fails.
+  }
+
+  if (llmDecision && !isValidLLMDecision(llmDecision, candidate, dateCandidates)) {
+    llmDecision = null;
+  }
+
+  const isNewLargeIncome =
+    candidate.direction === "income" &&
+    candidate.occurrenceCount === 1 &&
+    candidate.amountBand === "large";
+
+  return {
+    candidateId: candidate.candidateId,
+    classification: llmDecision
+      ? {
+          label: llmDecision.classification,
+          confidence: llmDecision.confidence,
+          reason: llmDecision.reason,
+          source: "llm",
+        }
+      : ruleClassification,
+    dateCandidates,
+    suggestedDateAdjustment: llmDecision?.dateAdjustment ?? null,
+    reviewRequired: isNewLargeIncome,
+    reviewReason: isNewLargeIncome
+      ? "直近1回のみ確認された新規の大口入金候補のため、予測への採用前に確認が必要です。"
+      : null,
+  };
+}


### PR DESCRIPTION
# Summary

- add deterministic forecast candidate assistance that remains available without an LLM
- add optional AI SDK/Zod classification enrichment using anonymous normalized features only
- propose previous/next business-day shifts for holiday salary dates and flag one-off large income for review
- ignore invalid, ambiguous, mismatched, or failed LLM decisions without affecting forecast calculations

## Linear Issue

- [HIR-165](https://linear.app/hiroppy/issue/HIR-165/llm補助で今月予測の分類と休日ズレ推論を強化する)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | Classification, holiday shifts, and review explanations must match the forecast-assistance contract | Rule and LLM paths return the expected labels, confidence, reasons, and date candidates |
| Reliability | Optional or malformed LLM output must never stop deterministic forecasting | Disabled, failed, low-confidence, and invalid responses fall back to rules |
| Security | Transaction descriptions, account names, and exact amounts may contain personal data | Only anonymous IDs, ranges, bands, counts, and enum signals reach the prompt |
| Maintainability | LLM advice must not become coupled to balance calculation or final acceptance | Assistance is a standalone exported module with injected mock decider support |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Equivalence partitioning | LLM disabled/enabled/failed and valid/invalid/ambiguous output are distinct behaviors | Every fallback and enrichment partition |
| Boundary value analysis | Payday around weekends/holidays and the confidence threshold are boundary-sensitive | Previous/next business day, normal weekday, 0.59 rejection |
| Decision table testing | Direction, occurrence count, amount band, and signals determine review/classification | One-off large income and recurring salary cases |
| Error guessing / branch testing | Provider exceptions and mismatched candidate IDs are likely integration failures | Safe ignore paths and deterministic continuity |

### Primary Test Conditions

- LLM disabled returns rule classification without calling the provider
- October 25, 2026 proposes October 23 and October 26; injected holidays are skipped
- valid LLM output enriches classification and suggests only an existing date adjustment
- malformed, low-confidence, mismatched, and provider-failure outputs preserve rule results
- one-off large income is marked for review with an explanation
- prompt excludes extra description, account, and exact amount fields

### Out-of-Scope Risks

- End-to-end UI and balance calculation are implemented by sibling epic issues; this module deliberately exposes assistance without owning those deterministic calculations.
- National holidays are caller-provided because the repository has no holiday-calendar service; weekends are handled directly.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [ ] Storybook tests
- [ ] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/analytics test — 13 files / 156 tests passed
pnpm turbo typecheck — 8 packages passed
pnpm lint — passed
pnpm format:check — 556 files passed
git diff --check — passed
```

### Checks Not Run

- Storybook tests — no web component or story changed.
- E2E tests — no application route or crawler behavior changed; fallback and integration boundaries are covered by unit tests.