### PR TITLE
fix(crawler): refetch previous month transactions

### DIFF
--- a/apps/crawler/src/crawler-phases.test.ts
+++ b/apps/crawler/src/crawler-phases.test.ts
@@ -301,16 +301,23 @@ describe("runCashFlowHistoryPhase", () => {
   });
 
   test("history mode では未取得の最古月までの履歴取得範囲を維持する", async () => {
+    const now = new Date("2026-01-15T00:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
     vi.mocked(hasTransactionsForMonth).mockResolvedValue(false);
     vi.mocked(scrapeCashFlowHistory).mockResolvedValue([]);
 
-    await runCashFlowHistoryPhase({} as never, {} as never, { isHistoryMode: true });
+    try {
+      await runCashFlowHistoryPhase({} as never, {} as never, { isHistoryMode: true });
 
-    expect(scrapeCashFlowHistory).toHaveBeenCalledWith(
-      {},
-      getHistoryMaxMonths(new Date()),
-      expect.any(Object),
-    );
+      expect(scrapeCashFlowHistory).toHaveBeenCalledWith(
+        {},
+        getHistoryMaxMonths(now),
+        expect.any(Object),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("初期 navigation 失敗を対象月 step に記録する", async () => {

--- a/apps/crawler/src/crawler-phases.test.ts
+++ b/apps/crawler/src/crawler-phases.test.ts
@@ -20,6 +20,7 @@ import {
 } from "./crawler-phases.js";
 import { createCrawlerProgressReporter } from "./crawler-progress.js";
 import { buildGroupOnlyScrapedData, buildScrapedData } from "./data-builder.js";
+import { getHistoryMaxMonths } from "./history-months.js";
 import type { ScrapeResult } from "./scraper.js";
 import { scrapeCashFlowHistory } from "./scrapers/cash-flow-history.js";
 import { switchGroup } from "./scrapers/group.js";
@@ -281,6 +282,37 @@ describe("runSavePhase", () => {
 });
 
 describe("runCashFlowHistoryPhase", () => {
+  test("month mode でも遅延反映に備えて当月と前月を再取得する", async () => {
+    vi.mocked(scrapeCashFlowHistory).mockResolvedValue([]);
+
+    await runCashFlowHistoryPhase({} as never, {} as never, { isHistoryMode: false });
+
+    expect(scrapeCashFlowHistory).toHaveBeenCalledWith({}, 2, expect.any(Object));
+    expect(hasTransactionsForMonth).not.toHaveBeenCalled();
+  });
+
+  test("history mode で前月に既存明細があっても当月と前月を再取得する", async () => {
+    vi.mocked(hasTransactionsForMonth).mockResolvedValue(true);
+    vi.mocked(scrapeCashFlowHistory).mockResolvedValue([]);
+
+    await runCashFlowHistoryPhase({} as never, {} as never, { isHistoryMode: true });
+
+    expect(scrapeCashFlowHistory).toHaveBeenCalledWith({}, 2, expect.any(Object));
+  });
+
+  test("history mode では未取得の最古月までの履歴取得範囲を維持する", async () => {
+    vi.mocked(hasTransactionsForMonth).mockResolvedValue(false);
+    vi.mocked(scrapeCashFlowHistory).mockResolvedValue([]);
+
+    await runCashFlowHistoryPhase({} as never, {} as never, { isHistoryMode: true });
+
+    expect(scrapeCashFlowHistory).toHaveBeenCalledWith(
+      {},
+      getHistoryMaxMonths(new Date()),
+      expect.any(Object),
+    );
+  });
+
   test("初期 navigation 失敗を対象月 step に記録する", async () => {
     const tempDir = await mkdtemp(path.join(os.tmpdir(), "crawler-history-setup-failure-"));
     try {

--- a/apps/crawler/src/crawler-phases.ts
+++ b/apps/crawler/src/crawler-phases.ts
@@ -265,20 +265,16 @@ export async function runCashFlowHistoryPhase(
 ): Promise<void> {
   phase("Cash Flow History");
 
-  if (!config.isHistoryMode) {
-    log("Skipping cash flow history (SCRAPE_MODE is not history)");
-    await publishHistory([]);
-    return;
-  }
-
   const now = new Date();
-  const maxMonths = getHistoryMaxMonths(now);
+  let monthsToFetch = 2;
 
-  let monthsToFetch = 1;
-  for (let i = 1; i < maxMonths; i++) {
-    const month = getHistoryMonth(now, i);
-    if (!(await hasTransactionsForMonth(db, month))) {
-      monthsToFetch = i + 1;
+  if (config.isHistoryMode) {
+    const maxMonths = getHistoryMaxMonths(now);
+    for (let i = 2; i < maxMonths; i++) {
+      const month = getHistoryMonth(now, i);
+      if (!(await hasTransactionsForMonth(db, month))) {
+        monthsToFetch = i + 1;
+      }
     }
   }
 


### PR DESCRIPTION
# Summary

- Refetch the current and previous cash-flow months during normal month-mode crawler runs.
- Keep history mode's existing backfill range while always refreshing at least two months.
- Add regression coverage for month mode, an already-populated previous month, and initial history backfills.

## Linear Issue

- [HIR-167](https://linear.app/hiroppy/issue/HIR-167)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | Delayed card transactions must be imported from the previous calendar month. | Month and history modes both refetch the current and previous months. |
| Reliability | Repeated crawls must remain complete without duplicating transactions or shrinking initial backfills. | Month replacement remains atomic and history mode reaches the oldest missing month. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Decision table testing | Fetch behavior depends on mode and whether older transactions exist. | Month mode, populated history, and empty history combinations. |
| Boundary value analysis | The defect occurs at month boundaries, including year changes. | Previous-month calculation and year-boundary behavior. |
| Regression testing | Existing full-history and replacement behavior must remain intact. | Crawler unit suite and DB repository suite. |

### Primary Test Conditions

- Month mode fetches exactly the current and previous months without scanning the DB.
- History mode fetches at least two months even when the previous month already has transactions.
- History mode still fetches through the oldest missing month on an initial backfill.
- Replacing a previously saved month does not create duplicates.
- Calendar-month calculations remain correct at month-end and year boundaries.

### Out-of-Scope Risks

- Authenticated Money Forward E2E was not run because the changed decision logic is DOM-independent and the repository guidance prioritizes unit coverage for it.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [ ] Storybook tests
- [ ] E2E tests
- [ ] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/crawler test — 294 passed
pnpm --filter @mf-dashboard/db test -- src/repositories/transactions.test.ts — 368 passed, 18 skipped
pnpm turbo typecheck — 8 packages passed
pnpm lint — passed
pnpm format:check — 554 files passed
```

### Checks Not Run

- Storybook — no web UI changes.
- E2E and manual verification — the affected month-selection branch is DOM-independent and covered deterministically by unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cash-flow data now refreshes the latest two months consistently, including when recent transactions already exist.
  * History mode continues retrieving the configured maximum historical range while filling in missing older months.
  * Improved reliability when history mode is disabled by ensuring recent cash-flow periods are still fetched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->