### PR TITLE
feat(analytics): calculate monthly bank balance forecasts

### DIFF
--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -11,6 +11,7 @@
     "./config": "./src/config.ts",
     "./categorization": "./src/categorization.ts",
     "./forecast-assistance": "./src/forecast-assistance.ts",
+    "./bank-balance-forecast": "./src/bank-balance-forecast.ts",
     "./recurring-candidates": "./src/recurring-candidates.ts",
     "./types": "./src/types.ts"
   },

--- a/packages/analytics/src/bank-balance-forecast.test.ts
+++ b/packages/analytics/src/bank-balance-forecast.test.ts
@@ -183,8 +183,8 @@ describe("calculateMonthlyBankBalanceForecasts", () => {
     const [forecast] = calculateMonthlyBankBalanceForecasts(
       [accountA],
       [
-        event("previous-month", "2026-07-31", 50_000, "income", "actual"),
-        event("next-month", "2026-09-01", 50_000, "expense", "forecast"),
+        event("cached-forecast", "2026-07-31", 50_000, "income", "forecast"),
+        event("future-actual", "2026-09-01", 50_000, "expense", "actual"),
       ],
       currentDate,
     );

--- a/packages/analytics/src/bank-balance-forecast.test.ts
+++ b/packages/analytics/src/bank-balance-forecast.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from "vitest";
+import {
+  calculateMonthlyBankBalanceForecasts,
+  recurringCandidateToBankCashFlowEvent,
+  type BankBalanceAccount,
+  type BankCashFlowEventInput,
+} from "./bank-balance-forecast";
+
+const currentDate = "2026-08-03";
+const accountA: BankBalanceAccount = {
+  accountId: "account-a",
+  currentBalance: 100_000,
+  balanceAsOfDate: currentDate,
+};
+
+function event(
+  id: string,
+  date: string,
+  amount: number,
+  direction: "income" | "expense",
+  status: "actual" | "forecast" | "needs_review",
+  accountId: string | number = accountA.accountId,
+): BankCashFlowEventInput {
+  return { id, accountId, date, amount, direction, status };
+}
+
+describe("calculateMonthlyBankBalanceForecasts", () => {
+  it.each([
+    ["high", "forecast"],
+    ["medium", "forecast"],
+    ["low", "needs_review"],
+  ] as const)("maps a %s-confidence extracted candidate to %s", (confidence, status) => {
+    const candidate = recurringCandidateToBankCashFlowEvent("candidate", {
+      accountId: accountA.accountId,
+      type: "expense",
+      classification: "card",
+      confidence,
+      description: "Card payment",
+      predictedDate: "2026-08-31",
+      predictedAmount: 50_000,
+      evidence: {
+        lookbackMonths: 12,
+        occurrenceCount: 3,
+        dateRange: { from: "2026-05-31", to: "2026-07-31" },
+        amountRange: { min: 45_000, max: 55_000 },
+      },
+    });
+
+    expect(candidate).toMatchObject({
+      id: "candidate",
+      direction: "expense",
+      status,
+      classification: "card",
+      confidence,
+      evidence: { occurrenceCount: 3 },
+    });
+  });
+
+  it("reconstructs the month opening balance and calculates actual and forecast balances", () => {
+    const [forecast] = calculateMonthlyBankBalanceForecasts(
+      [accountA],
+      [
+        event("opening-income", "2026-08-01", 20_000, "income", "actual"),
+        event("actual-expense", currentDate, 5_000, "expense", "actual"),
+        event("forecast-income", "2026-08-20", 30_000, "income", "forecast"),
+        event("month-end-expense", "2026-08-31", 80_000, "expense", "needs_review"),
+      ],
+      currentDate,
+    );
+
+    expect(forecast).toMatchObject({
+      currentBalance: 100_000,
+      balanceAsOfDate: currentDate,
+      forecastBoundaryDate: currentDate,
+      monthStartDate: "2026-08-01",
+      monthEndDate: "2026-08-31",
+      openingBalance: 85_000,
+      monthEndBalance: 50_000,
+    });
+    expect(forecast.days.flatMap(({ events }) => events)).toMatchObject([
+      { id: "opening-income", status: "actual", balanceAfter: 105_000 },
+      { id: "actual-expense", status: "actual", balanceAfter: 100_000 },
+      { id: "forecast-income", status: "forecast", balanceAfter: 130_000 },
+      { id: "month-end-expense", status: "needs_review", balanceAfter: 50_000 },
+    ]);
+  });
+
+  it("preserves same-day detail order and returns daily totals", () => {
+    const [forecast] = calculateMonthlyBankBalanceForecasts(
+      [accountA],
+      [
+        event("first", "2026-08-10", 40_000, "expense", "forecast"),
+        event("second", "2026-08-10", 10_000, "income", "needs_review"),
+        event("third", "2026-08-10", 70_000, "expense", "forecast"),
+      ],
+      currentDate,
+    );
+
+    expect(forecast.days).toEqual([
+      {
+        date: "2026-08-10",
+        incomeTotal: 10_000,
+        expenseTotal: 110_000,
+        netChange: -100_000,
+        closingBalance: 0,
+        events: [
+          expect.objectContaining({ id: "first", balanceAfter: 60_000 }),
+          expect.objectContaining({ id: "second", balanceAfter: 70_000 }),
+          expect.objectContaining({ id: "third", balanceAfter: 0 }),
+        ],
+      },
+    ]);
+  });
+
+  it("keeps movements excluded by existing transfer and calculation flags separate", () => {
+    const excludedMovements: BankCashFlowEventInput[] = [
+      {
+        ...event("investment-transfer", "2026-08-15", 50_000, "expense", "forecast"),
+        description: "Investment transfer",
+        isTransfer: true,
+      },
+      {
+        ...event("family-scope", "2026-08-16", 30_000, "income", "forecast"),
+        description: "Family scope",
+        isExcludedFromCalculation: true,
+      },
+      {
+        ...event("corporate-scope", "2026-08-17", 20_000, "expense", "forecast"),
+        description: "Corporate scope",
+        isExcludedFromCalculation: true,
+      },
+      {
+        ...event("pension-transfer", "2026-08-18", 10_000, "income", "forecast"),
+        description: "Pension transfer",
+        isTransfer: true,
+      },
+    ];
+    const [forecast] = calculateMonthlyBankBalanceForecasts(
+      [accountA],
+      excludedMovements,
+      currentDate,
+    );
+
+    expect(forecast.days).toEqual([]);
+    expect(forecast.monthEndBalance).toBe(100_000);
+    expect(forecast.excludedEvents).toMatchObject([
+      { id: "investment-transfer", exclusionReason: "transfer" },
+      { id: "family-scope", exclusionReason: "excluded_from_calculation" },
+      { id: "corporate-scope", exclusionReason: "excluded_from_calculation" },
+      { id: "pension-transfer", exclusionReason: "transfer" },
+    ]);
+  });
+
+  it("separates accounts and applies actual events posted after a stale balance anchor", () => {
+    const accountB: BankBalanceAccount = {
+      accountId: 2,
+      currentBalance: 10_000,
+      balanceAsOfDate: "2026-08-02",
+    };
+    const result = calculateMonthlyBankBalanceForecasts(
+      [accountA, accountB],
+      [
+        event("account-a-event", "2026-08-04", 1_000, "income", "forecast"),
+        event("account-b-actual", currentDate, 4_000, "expense", "actual", 2),
+        event("account-b-forecast", "2026-08-31", 6_000, "expense", "forecast", 2),
+      ],
+      currentDate,
+    );
+
+    expect(
+      result.map(({ accountId, openingBalance, monthEndBalance }) => ({
+        accountId,
+        openingBalance,
+        monthEndBalance,
+      })),
+    ).toEqual([
+      { accountId: "account-a", openingBalance: 100_000, monthEndBalance: 101_000 },
+      { accountId: 2, openingBalance: 10_000, monthEndBalance: 0 },
+    ]);
+  });
+
+  it("ignores events outside the current month", () => {
+    const [forecast] = calculateMonthlyBankBalanceForecasts(
+      [accountA],
+      [
+        event("previous-month", "2026-07-31", 50_000, "income", "actual"),
+        event("next-month", "2026-09-01", 50_000, "expense", "forecast"),
+      ],
+      currentDate,
+    );
+
+    expect(forecast).toMatchObject({ days: [], openingBalance: 100_000, monthEndBalance: 100_000 });
+  });
+
+  it.each([
+    [event("future-actual", "2026-08-04", 1, "income", "actual"), "cannot be after"],
+    [event("past-forecast", "2026-08-02", 1, "income", "forecast"), "cannot be before"],
+    [event("negative", "2026-08-04", -1, "income", "forecast"), "must be non-negative"],
+    [
+      event("unsafe", "2026-08-04", Number.MAX_SAFE_INTEGER + 1, "income", "forecast"),
+      "safe integer",
+    ],
+  ])("rejects an invalid event boundary or amount", (invalidEvent, message) => {
+    expect(() =>
+      calculateMonthlyBankBalanceForecasts([accountA], [invalidEvent], currentDate),
+    ).toThrow(message);
+  });
+
+  it("allows today's overlapping boundary and orders actual events before forecasts", () => {
+    const [forecast] = calculateMonthlyBankBalanceForecasts(
+      [accountA],
+      [
+        event("today-forecast", currentDate, 100_000, "expense", "forecast"),
+        event("today-actual", currentDate, 5_000, "income", "actual"),
+      ],
+      currentDate,
+    );
+
+    expect(forecast).toMatchObject({ openingBalance: 95_000, monthEndBalance: 0 });
+    expect(forecast.days[0]?.events).toMatchObject([
+      { id: "today-actual", balanceAfter: 100_000 },
+      { id: "today-forecast", balanceAfter: 0 },
+    ]);
+  });
+
+  it.each([
+    {
+      name: "a future balance anchor",
+      accounts: [{ ...accountA, balanceAsOfDate: "2026-08-04" }],
+      events: [],
+      message: "cannot be in the future",
+    },
+    {
+      name: "a previous-month balance anchor",
+      accounts: [{ ...accountA, balanceAsOfDate: "2026-07-31" }],
+      events: [],
+      message: "must be in the current month",
+    },
+    {
+      name: "an unknown account",
+      accounts: [accountA],
+      events: [event("unknown", "2026-08-04", 1, "income", "forecast", "missing")],
+      message: "references an unknown account",
+    },
+  ])("rejects $name", ({ accounts, events, message }) => {
+    expect(() => calculateMonthlyBankBalanceForecasts(accounts, events, currentDate)).toThrow(
+      message,
+    );
+  });
+});

--- a/packages/analytics/src/bank-balance-forecast.ts
+++ b/packages/analytics/src/bank-balance-forecast.ts
@@ -1,0 +1,266 @@
+import { formatIsoDateKey, getDaysInMonth, parseIsoDateKey } from "@mf-dashboard/date-utils";
+import type {
+  RecurringCandidate,
+  RecurringCandidateClassification,
+  RecurringCandidateConfidence,
+  RecurringCandidateEvidence,
+} from "./recurring-candidates.js";
+
+export type BankAccountId = string | number;
+export type BankCashFlowDirection = "income" | "expense";
+export type BankCashFlowStatus = "actual" | "forecast" | "needs_review";
+export type BankCashFlowExclusionReason = "transfer" | "excluded_from_calculation";
+
+export interface BankBalanceAccount {
+  accountId: BankAccountId;
+  currentBalance: number;
+  balanceAsOfDate: string;
+}
+
+export interface BankCashFlowEventInput {
+  id: string;
+  accountId: BankAccountId;
+  date: string;
+  amount: number;
+  direction: BankCashFlowDirection;
+  status: BankCashFlowStatus;
+  description?: string | null;
+  classification?: RecurringCandidateClassification;
+  confidence?: RecurringCandidateConfidence;
+  evidence?: RecurringCandidateEvidence;
+  isTransfer?: boolean;
+  isExcludedFromCalculation?: boolean;
+}
+
+export interface CalculatedBankCashFlowEvent extends BankCashFlowEventInput {
+  balanceAfter: number;
+}
+
+export interface ExcludedBankCashFlowEvent extends BankCashFlowEventInput {
+  exclusionReason: BankCashFlowExclusionReason;
+}
+
+export interface BankCashFlowDay {
+  date: string;
+  incomeTotal: number;
+  expenseTotal: number;
+  netChange: number;
+  closingBalance: number;
+  events: CalculatedBankCashFlowEvent[];
+}
+
+export interface BankBalanceForecast {
+  accountId: BankAccountId;
+  currentBalance: number;
+  balanceAsOfDate: string;
+  forecastBoundaryDate: string;
+  monthStartDate: string;
+  monthEndDate: string;
+  openingBalance: number;
+  monthEndBalance: number;
+  days: BankCashFlowDay[];
+  excludedEvents: ExcludedBankCashFlowEvent[];
+}
+
+interface IndexedEvent {
+  event: BankCashFlowEventInput;
+  index: number;
+}
+
+function compareIndexedEvents(left: IndexedEvent, right: IndexedEvent): number {
+  const dateComparison = left.event.date.localeCompare(right.event.date);
+  if (dateComparison !== 0) return dateComparison;
+
+  const leftIsActual = left.event.status === "actual";
+  const rightIsActual = right.event.status === "actual";
+  if (leftIsActual !== rightIsActual) return leftIsActual ? -1 : 1;
+  return left.index - right.index;
+}
+
+export function recurringCandidateToBankCashFlowEvent(
+  id: string,
+  candidate: RecurringCandidate,
+): BankCashFlowEventInput {
+  return {
+    id,
+    accountId: candidate.accountId,
+    date: candidate.predictedDate,
+    amount: candidate.predictedAmount,
+    direction: candidate.type,
+    status: candidate.confidence === "low" ? "needs_review" : "forecast",
+    description: candidate.description,
+    classification: candidate.classification,
+    confidence: candidate.confidence,
+    evidence: candidate.evidence,
+  };
+}
+
+function assertMoney(value: number, name: string): void {
+  if (!Number.isSafeInteger(value)) {
+    throw new Error(`${name} must be a safe integer`);
+  }
+}
+
+function addMoney(left: number, right: number, name: string): number {
+  const result = left + right;
+  assertMoney(result, name);
+  return result;
+}
+
+function signedAmount(event: BankCashFlowEventInput): number {
+  return event.direction === "income" ? event.amount : -event.amount;
+}
+
+function getExclusionReason(event: BankCashFlowEventInput): BankCashFlowExclusionReason | null {
+  if (event.isTransfer) return "transfer";
+  if (event.isExcludedFromCalculation) return "excluded_from_calculation";
+  return null;
+}
+
+function validateEvent(event: BankCashFlowEventInput, currentDate: string): void {
+  parseIsoDateKey(event.date);
+  assertMoney(event.amount, `Event ${event.id} amount`);
+  if (event.amount < 0) {
+    throw new Error(`Event ${event.id} amount must be non-negative`);
+  }
+  if (event.status === "actual" && event.date > currentDate) {
+    throw new Error(`Actual event ${event.id} cannot be after the forecast boundary`);
+  }
+  if (event.status !== "actual" && event.date < currentDate) {
+    throw new Error(`Forecast event ${event.id} cannot be before the forecast boundary`);
+  }
+}
+
+function calculateAccountForecast(
+  account: BankBalanceAccount,
+  indexedEvents: IndexedEvent[],
+  currentDate: string,
+  monthStartDate: string,
+  monthEndDate: string,
+): BankBalanceForecast {
+  parseIsoDateKey(account.balanceAsOfDate);
+  assertMoney(account.currentBalance, `Account ${String(account.accountId)} currentBalance`);
+  if (account.balanceAsOfDate > currentDate) {
+    throw new Error(`Account ${String(account.accountId)} balanceAsOfDate cannot be in the future`);
+  }
+  if (account.balanceAsOfDate < monthStartDate) {
+    throw new Error(
+      `Account ${String(account.accountId)} balanceAsOfDate must be in the current month`,
+    );
+  }
+
+  const monthEvents = indexedEvents
+    .filter(({ event }) => event.date >= monthStartDate && event.date <= monthEndDate)
+    .sort(compareIndexedEvents);
+  const includedEvents = monthEvents.filter(({ event }) => !getExclusionReason(event));
+  const actualChangeThroughBalanceDate = includedEvents
+    .filter(({ event }) => event.status === "actual" && event.date <= account.balanceAsOfDate)
+    .reduce(
+      (total, { event }) =>
+        addMoney(total, signedAmount(event), "Actual balance change through balanceAsOfDate"),
+      0,
+    );
+  const openingBalance = addMoney(
+    account.currentBalance,
+    -actualChangeThroughBalanceDate,
+    "Opening balance",
+  );
+
+  let runningBalance = openingBalance;
+  const days: BankCashFlowDay[] = [];
+  for (const { event } of includedEvents) {
+    runningBalance = addMoney(
+      runningBalance,
+      signedAmount(event),
+      `Balance after event ${event.id}`,
+    );
+    const calculatedEvent = { ...event, balanceAfter: runningBalance };
+    const currentDay = days.at(-1);
+
+    if (currentDay?.date === event.date) {
+      currentDay.events.push(calculatedEvent);
+      if (event.direction === "income") {
+        currentDay.incomeTotal = addMoney(currentDay.incomeTotal, event.amount, "Daily income");
+      } else {
+        currentDay.expenseTotal = addMoney(currentDay.expenseTotal, event.amount, "Daily expense");
+      }
+      currentDay.netChange = addMoney(
+        currentDay.incomeTotal,
+        -currentDay.expenseTotal,
+        "Daily net change",
+      );
+      currentDay.closingBalance = runningBalance;
+      continue;
+    }
+
+    days.push({
+      date: event.date,
+      incomeTotal: event.direction === "income" ? event.amount : 0,
+      expenseTotal: event.direction === "expense" ? event.amount : 0,
+      netChange: signedAmount(event),
+      closingBalance: runningBalance,
+      events: [calculatedEvent],
+    });
+  }
+
+  const excludedEvents = monthEvents.flatMap(({ event }) => {
+    const exclusionReason = getExclusionReason(event);
+    return exclusionReason ? [{ ...event, exclusionReason }] : [];
+  });
+
+  return {
+    accountId: account.accountId,
+    currentBalance: account.currentBalance,
+    balanceAsOfDate: account.balanceAsOfDate,
+    forecastBoundaryDate: currentDate,
+    monthStartDate,
+    monthEndDate,
+    openingBalance,
+    monthEndBalance: runningBalance,
+    days,
+    excludedEvents,
+  };
+}
+
+export function calculateMonthlyBankBalanceForecasts(
+  accounts: BankBalanceAccount[],
+  events: BankCashFlowEventInput[],
+  currentDate: string,
+): BankBalanceForecast[] {
+  const { year, month } = parseIsoDateKey(currentDate);
+  const monthStartDate = formatIsoDateKey({ year, month, day: 1 });
+  const monthEndDate = formatIsoDateKey({ year, month, day: getDaysInMonth(year, month) });
+  const accountIds = new Set<BankAccountId>();
+  for (const account of accounts) {
+    if (accountIds.has(account.accountId)) {
+      throw new Error(`Duplicate accountId: ${String(account.accountId)}`);
+    }
+    accountIds.add(account.accountId);
+  }
+
+  const eventIds = new Set<string>();
+  const eventsByAccount = new Map<BankAccountId, IndexedEvent[]>();
+  events.forEach((event, index) => {
+    validateEvent(event, currentDate);
+    if (eventIds.has(event.id)) {
+      throw new Error(`Duplicate event id: ${event.id}`);
+    }
+    eventIds.add(event.id);
+    if (!accountIds.has(event.accountId)) {
+      throw new Error(`Event ${event.id} references an unknown account`);
+    }
+    const accountEvents = eventsByAccount.get(event.accountId) ?? [];
+    accountEvents.push({ event, index });
+    eventsByAccount.set(event.accountId, accountEvents);
+  });
+
+  return accounts.map((account) =>
+    calculateAccountForecast(
+      account,
+      eventsByAccount.get(account.accountId) ?? [],
+      currentDate,
+      monthStartDate,
+      monthEndDate,
+    ),
+  );
+}

--- a/packages/analytics/src/bank-balance-forecast.ts
+++ b/packages/analytics/src/bank-balance-forecast.ts
@@ -118,7 +118,6 @@ function getExclusionReason(event: BankCashFlowEventInput): BankCashFlowExclusio
 }
 
 function validateEvent(event: BankCashFlowEventInput, currentDate: string): void {
-  parseIsoDateKey(event.date);
   assertMoney(event.amount, `Event ${event.id} amount`);
   if (event.amount < 0) {
     throw new Error(`Event ${event.id} amount must be non-negative`);
@@ -241,6 +240,8 @@ export function calculateMonthlyBankBalanceForecasts(
   const eventIds = new Set<string>();
   const eventsByAccount = new Map<BankAccountId, IndexedEvent[]>();
   events.forEach((event, index) => {
+    parseIsoDateKey(event.date);
+    if (event.date < monthStartDate || event.date > monthEndDate) return;
     validateEvent(event, currentDate);
     if (eventIds.has(event.id)) {
       throw new Error(`Duplicate event id: ${event.id}`);


### PR DESCRIPTION
# Summary

- add a pure monthly bank-balance forecast calculator anchored to each account current balance
- combine actual, forecast, and needs-review events into per-day totals and per-event running balances
- preserve excluded transfers and calculation-excluded movements as a separate result set
- adapt recurring-candidate extraction output into forecast events without delegating arithmetic to an LLM

## Linear Issue

- [HIR-163](https://linear.app/hiroppy/issue/HIR-163)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | Forecast balances and event states must match deterministic cash-flow rules | Current, per-event, daily, and month-end balances are correct per bank account |
| Reliability | Boundary dates, stale anchors, exclusions, and near-zero balances can otherwise produce misleading results | Invalid state/date combinations fail explicitly; excluded events do not affect balances |
| Maintainability | The UI integration ticket needs a stable, pure API with explicit boundary metadata | Typed inputs/outputs expose balance and forecast boundaries and recurring evidence |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Equivalence partitioning | Separate actual, forecast, needs-review, included, and excluded event classes | Status mapping and balance participation rules |
| Boundary value analysis | Month start/end, today overlap, stale anchor, and zero balance are high-risk edges | Inclusive date boundaries and balance behavior around zero |
| Decision table testing | Direction, status, and exclusion flags jointly determine ordering and calculation | Income/expense signs, actual-before-forecast ordering, exclusion reasons |
| Error guessing / branch testing | Bad IDs, dates, unknown accounts, and unsafe money values risk silent corruption | Explicit validation failures and arithmetic overflow protection |

### Primary Test Conditions

- Reconstruct month-opening balance from the current balance and actual events through the anchor date.
- Calculate running and month-end balances across multiple accounts and same-day details.
- Map low-confidence recurring candidates to needs-review while retaining evidence.
- Keep investment/family/corporate/pension movements marked by existing transfer/exclusion flags outside totals.
- Ignore out-of-month events and reject invalid actual/forecast boundaries.

### Out-of-Scope Risks

- Data fetching and top-page presentation are handled by the follow-on UI integration ticket.
- Timing differences between upstream account balances and transactions remain visible through balanceAsOfDate and forecastBoundaryDate rather than being inferred.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [ ] Storybook tests — no component or story changes
- [ ] E2E tests — pure analytics calculation only
- [ ] Manual verification — no user-facing runtime path in this ticket

### Commands Executed

```text
pnpm --filter @mf-dashboard/analytics test -- bank-balance-forecast.test.ts — 15 files / 304 tests passed
pnpm --filter @mf-dashboard/analytics typecheck — passed
pnpm turbo typecheck — 8/8 tasks passed
pnpm lint — passed
pnpm format:check — 563 files passed
```

### Checks Not Run

- Storybook, E2E, and runtime media validation: no app or UI behavior changed.