### PR TITLE
feat(web): add monthly bank cash flow forecast

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,6 +2,7 @@ import { hasInvestmentHoldings } from "@mf-dashboard/db";
 import type { Metadata } from "next";
 import { AssetBreakdownChart } from "../components/info/asset-breakdown-chart";
 import { AssetHistoryChart } from "../components/info/asset-history-chart";
+import { BankCashFlowForecast } from "../components/info/bank-cashflow-forecast";
 import { DailyChangeCard } from "../components/info/daily-change-card";
 import { MonthlyBalanceCard } from "../components/info/monthly-balance-card";
 import { MonthlyIncomeExpenseChart } from "../components/info/monthly-income-expense-chart";
@@ -22,6 +23,8 @@ export async function DashboardContent({ groupId }: { groupId?: string }) {
       </div>
 
       {showDailyChange && <DailyChangeCard groupId={groupId} />}
+
+      <BankCashFlowForecast groupId={groupId} />
 
       <AssetHistoryChart groupId={groupId} />
 

--- a/apps/web/src/components/info/bank-cashflow-forecast-data.test.ts
+++ b/apps/web/src/components/info/bank-cashflow-forecast-data.test.ts
@@ -3,8 +3,20 @@ import { describe, expect, it } from "vitest";
 import { buildBankCashFlowForecastViews } from "./bank-cashflow-forecast-data";
 
 const accounts = [
-  { id: 1, name: "銀行 A", categoryName: "銀行", totalAssets: 100_000 },
-  { id: 2, name: "証券 A", categoryName: "証券", totalAssets: 500_000 },
+  {
+    id: 1,
+    name: "銀行 A",
+    categoryName: "銀行",
+    totalAssets: 100_000,
+    lastUpdated: "2026-08-03T08:00:00",
+  },
+  {
+    id: 2,
+    name: "証券 A",
+    categoryName: "証券",
+    totalAssets: 500_000,
+    lastUpdated: "2026-08-03T08:00:00",
+  },
 ];
 
 function transaction(
@@ -15,6 +27,8 @@ function transaction(
     amount: number;
     type: string;
     description: string | null;
+    category: string | null;
+    subCategory: string | null;
     isTransfer: boolean;
     isExcludedFromCalculation: boolean;
   }> = {},
@@ -76,7 +90,13 @@ describe("buildBankCashFlowForecastViews", () => {
 
   it("当月に記録済みの候補と過去日の予測を二重計上しない", () => {
     const forecasts = buildBankCashFlowForecastViews(accounts, [transaction(1)], "2026-08-03", [
-      candidate({ type: "income", classification: "salary", description: "給与振込" }),
+      candidate({
+        type: "income",
+        classification: "salary",
+        description: "給与振込",
+        predictedDate: "2026-08-03",
+        predictedAmount: 5_000,
+      }),
       candidate({ predictedDate: "2026-08-01" }),
     ]);
 
@@ -84,6 +104,84 @@ describe("buildBankCashFlowForecastViews", () => {
       { id: "actual-1", status: "actual" },
     ]);
     expect(forecasts[0]?.monthEndBalance).toBe(100_000);
+  });
+
+  it("残高更新日より後の実績を月末予測に反映する", () => {
+    const staleAccount = { ...accounts[0]!, lastUpdated: "2026-08-01T08:00:00" };
+
+    const forecasts = buildBankCashFlowForecastViews(
+      [staleAccount],
+      [transaction(1)],
+      "2026-08-03",
+      [],
+    );
+
+    expect(forecasts[0]).toMatchObject({
+      balanceAsOfDate: "2026-08-01",
+      openingBalance: 100_000,
+      monthEndBalance: 105_000,
+    });
+  });
+
+  it("説明なしの記録済み候補だけを一度だけ除外する", () => {
+    const actual = transaction(1, {
+      date: "2026-08-03",
+      amount: 10_000,
+      type: "expense",
+      description: null,
+      category: "家賃",
+      subCategory: null,
+    });
+    const forecasts = buildBankCashFlowForecastViews(accounts, [actual], "2026-08-03", [
+      candidate({ description: null, predictedDate: "2026-08-03" }),
+      candidate({ description: null, predictedDate: "2026-08-03" }),
+    ]);
+
+    expect(forecasts[0]?.days.flatMap(({ events }) => events)).toMatchObject([
+      { id: "actual-1", status: "actual" },
+      { id: "forecast-0", status: "forecast" },
+    ]);
+    expect(forecasts[0]?.monthEndBalance).toBe(90_000);
+  });
+
+  it("同じ説明でも金額または予定日が異なる候補は残す", () => {
+    const actual = transaction(1, {
+      date: "2026-08-03",
+      amount: -10_000,
+      type: "expense",
+      description: "口座振替",
+      category: null,
+      subCategory: null,
+    });
+    const forecasts = buildBankCashFlowForecastViews(accounts, [actual], "2026-08-03", [
+      candidate({
+        classification: "other",
+        description: "口座振替",
+        predictedDate: "2026-08-03",
+      }),
+      candidate({
+        classification: "other",
+        description: "口座振替",
+        predictedDate: "2026-08-20",
+        predictedAmount: 30_000,
+      }),
+    ]);
+
+    expect(forecasts[0]?.days.flatMap(({ events }) => events)).toMatchObject([
+      { id: "actual-1", status: "actual" },
+      { id: "forecast-0", status: "forecast", amount: 30_000 },
+    ]);
+  });
+
+  it("当月内の有効な残高更新日がない銀行口座は予測しない", () => {
+    expect(
+      buildBankCashFlowForecastViews(
+        [{ ...accounts[0]!, lastUpdated: "2026-07-31" }],
+        [transaction(1)],
+        "2026-08-03",
+        [],
+      ),
+    ).toEqual([]);
   });
 
   it("銀行口座がなければ予測を返さない", () => {

--- a/apps/web/src/components/info/bank-cashflow-forecast-data.test.ts
+++ b/apps/web/src/components/info/bank-cashflow-forecast-data.test.ts
@@ -1,0 +1,94 @@
+import type { RecurringCandidate } from "@mf-dashboard/analytics/recurring-candidates";
+import { describe, expect, it } from "vitest";
+import { buildBankCashFlowForecastViews } from "./bank-cashflow-forecast-data";
+
+const accounts = [
+  { id: 1, name: "銀行 A", categoryName: "銀行", totalAssets: 100_000 },
+  { id: 2, name: "証券 A", categoryName: "証券", totalAssets: 500_000 },
+];
+
+function transaction(
+  id: number,
+  overrides: Partial<{
+    accountId: number | null;
+    date: string;
+    amount: number;
+    type: string;
+    description: string | null;
+    isTransfer: boolean;
+    isExcludedFromCalculation: boolean;
+  }> = {},
+) {
+  return {
+    id,
+    accountId: 1,
+    date: "2026-08-02",
+    amount: 5_000,
+    type: "income",
+    description: "給与振込",
+    category: "収入",
+    subCategory: "給与",
+    isTransfer: false,
+    isExcludedFromCalculation: false,
+    ...overrides,
+  };
+}
+
+function candidate(overrides: Partial<RecurringCandidate> = {}): RecurringCandidate {
+  return {
+    accountId: 1,
+    type: "expense",
+    classification: "rent",
+    confidence: "high",
+    description: "家賃",
+    predictedDate: "2026-08-20",
+    predictedAmount: 10_000,
+    evidence: {
+      lookbackMonths: 12,
+      occurrenceCount: 3,
+      dateRange: { from: "2026-05-20", to: "2026-07-20" },
+      amountRange: { min: 10_000, max: 10_000 },
+    },
+    ...overrides,
+  };
+}
+
+describe("buildBankCashFlowForecastViews", () => {
+  it("銀行口座だけに当月実績と将来予測を反映する", () => {
+    const forecasts = buildBankCashFlowForecastViews(accounts, [transaction(1)], "2026-08-03", [
+      candidate(),
+      candidate({ accountId: 2 }),
+    ]);
+
+    expect(forecasts).toHaveLength(1);
+    expect(forecasts[0]).toMatchObject({
+      accountId: 1,
+      accountName: "銀行 A",
+      currentBalance: 100_000,
+      openingBalance: 95_000,
+      monthEndBalance: 90_000,
+    });
+    expect(forecasts[0]?.days.flatMap(({ events }) => events)).toMatchObject([
+      { id: "actual-1", status: "actual", balanceAfter: 100_000 },
+      { id: "forecast-0", status: "forecast", balanceAfter: 90_000 },
+    ]);
+  });
+
+  it("当月に記録済みの候補と過去日の予測を二重計上しない", () => {
+    const forecasts = buildBankCashFlowForecastViews(accounts, [transaction(1)], "2026-08-03", [
+      candidate({ type: "income", classification: "salary", description: "給与振込" }),
+      candidate({ predictedDate: "2026-08-01" }),
+    ]);
+
+    expect(forecasts[0]?.days.flatMap(({ events }) => events)).toMatchObject([
+      { id: "actual-1", status: "actual" },
+    ]);
+    expect(forecasts[0]?.monthEndBalance).toBe(100_000);
+  });
+
+  it("銀行口座がなければ予測を返さない", () => {
+    expect(
+      buildBankCashFlowForecastViews([accounts[1]!], [transaction(1)], "2026-08-03", []),
+    ).toEqual([]);
+  });
+});

--- a/apps/web/src/components/info/bank-cashflow-forecast-data.test.ts
+++ b/apps/web/src/components/info/bank-cashflow-forecast-data.test.ts
@@ -118,9 +118,33 @@ describe("buildBankCashFlowForecastViews", () => {
 
     expect(forecasts[0]).toMatchObject({
       balanceAsOfDate: "2026-08-01",
+      currentBalance: 105_000,
       openingBalance: 100_000,
       monthEndBalance: 105_000,
     });
+  });
+
+  it("候補生成と同じ正規化 identity で説明の月次差分を照合する", () => {
+    const actual = transaction(1, {
+      date: "2026-08-03",
+      amount: -10_000,
+      type: "expense",
+      description: "UTILITY INVOICE 1003",
+      category: null,
+      subCategory: null,
+    });
+    const forecasts = buildBankCashFlowForecastViews(accounts, [actual], "2026-08-03", [
+      candidate({
+        classification: "other",
+        description: "UTILITY INVOICE 1002",
+        recurringIdentity: "utility invoice",
+        predictedDate: "2026-08-03",
+      }),
+    ]);
+
+    expect(forecasts[0]?.days.flatMap(({ events }) => events)).toMatchObject([
+      { id: "actual-1", status: "actual" },
+    ]);
   });
 
   it("説明なしの記録済み候補だけを一度だけ除外する", () => {
@@ -133,8 +157,16 @@ describe("buildBankCashFlowForecastViews", () => {
       subCategory: null,
     });
     const forecasts = buildBankCashFlowForecastViews(accounts, [actual], "2026-08-03", [
-      candidate({ description: null, predictedDate: "2026-08-03" }),
-      candidate({ description: null, predictedDate: "2026-08-03" }),
+      candidate({
+        description: null,
+        recurringIdentity: "家賃categorysep",
+        predictedDate: "2026-08-03",
+      }),
+      candidate({
+        description: null,
+        recurringIdentity: "家賃categorysep",
+        predictedDate: "2026-08-03",
+      }),
     ]);
 
     expect(forecasts[0]?.days.flatMap(({ events }) => events)).toMatchObject([

--- a/apps/web/src/components/info/bank-cashflow-forecast-data.ts
+++ b/apps/web/src/components/info/bank-cashflow-forecast-data.ts
@@ -7,6 +7,7 @@ import {
 import {
   classifyRecurringTransaction,
   generateRecurringCandidates,
+  matchesRecurringCandidateIdentity,
   type RecurringCandidate,
   type RecurringTransaction,
 } from "@mf-dashboard/analytics/recurring-candidates";
@@ -69,10 +70,6 @@ function toActualEvent(transaction: ForecastTransaction): BankCashFlowEventInput
   };
 }
 
-function normalizeDescription(description: string | null | undefined): string {
-  return description?.normalize("NFKC").trim().toLocaleLowerCase("ja-JP") ?? "";
-}
-
 function getBalanceAsOfDate(lastUpdated: string | null, currentDate: string): string | null {
   const date = lastUpdated?.slice(0, 10);
   if (!date || date < `${currentDate.slice(0, 7)}-01` || date > currentDate) return null;
@@ -89,6 +86,8 @@ function matchesRecordedCandidate(
   candidate: RecurringCandidate,
   transaction: ForecastTransaction,
 ): boolean {
+  if (transaction.accountId === null) return false;
+
   const amountDifference = Math.abs(Math.abs(transaction.amount) - candidate.predictedAmount);
   const amountTolerance = Math.max(
     1,
@@ -100,12 +99,22 @@ function matchesRecordedCandidate(
   return (
     transaction.accountId === candidate.accountId &&
     transaction.type === candidate.type &&
-    normalizeDescription(transaction.description) === normalizeDescription(candidate.description) &&
+    matchesRecurringCandidateIdentity(candidate, transaction) &&
     classifyRecurringTransaction(transaction) === candidate.classification &&
     amountDifference <= amountTolerance &&
     transaction.date >= earliestDate &&
     transaction.date <= latestDate
   );
+}
+
+function getBalanceAtForecastBoundary(forecast: BankBalanceForecast): number {
+  let balance = forecast.openingBalance;
+  for (const day of forecast.days) {
+    for (const event of day.events) {
+      if (event.status === "actual") balance = event.balanceAfter;
+    }
+  }
+  return balance;
 }
 
 function excludeRecordedCandidates(
@@ -178,6 +187,7 @@ export function buildBankCashFlowForecastViews(
 
   return forecasts.map((forecast) => ({
     ...forecast,
+    currentBalance: getBalanceAtForecastBoundary(forecast),
     accountName: accountNames.get(Number(forecast.accountId)) ?? "銀行口座",
   }));
 }

--- a/apps/web/src/components/info/bank-cashflow-forecast-data.ts
+++ b/apps/web/src/components/info/bank-cashflow-forecast-data.ts
@@ -10,12 +10,14 @@ import {
   type RecurringCandidate,
   type RecurringTransaction,
 } from "@mf-dashboard/analytics/recurring-candidates";
+import { addDaysToIsoDateKey, parseIsoDateKey } from "@mf-dashboard/date-utils";
 
 interface ForecastAccount {
   id: number;
   name: string;
   categoryName: string;
   totalAssets: number;
+  lastUpdated: string | null;
 }
 
 interface ForecastTransaction {
@@ -34,6 +36,9 @@ interface ForecastTransaction {
 export interface BankCashFlowForecastView extends BankBalanceForecast {
   accountName: string;
 }
+
+const CANDIDATE_DATE_DRIFT_DAYS = 3;
+const CANDIDATE_AMOUNT_TOLERANCE_RATIO = 0.1;
 
 function isRecurringTransactionType(type: string): type is RecurringTransaction["type"] {
   return type === "income" || type === "expense" || type === "transfer";
@@ -68,19 +73,57 @@ function normalizeDescription(description: string | null | undefined): string {
   return description?.normalize("NFKC").trim().toLocaleLowerCase("ja-JP") ?? "";
 }
 
-function isCandidateAlreadyRecorded(
-  candidate: RecurringCandidate,
-  actualTransactions: ForecastTransaction[],
-): boolean {
-  const candidateDescription = normalizeDescription(candidate.description);
-  if (!candidateDescription) return false;
+function getBalanceAsOfDate(lastUpdated: string | null, currentDate: string): string | null {
+  const date = lastUpdated?.slice(0, 10);
+  if (!date || date < `${currentDate.slice(0, 7)}-01` || date > currentDate) return null;
 
-  return actualTransactions.some(
-    (transaction) =>
-      transaction.accountId === candidate.accountId &&
-      transaction.type === candidate.type &&
-      normalizeDescription(transaction.description) === candidateDescription,
+  try {
+    parseIsoDateKey(date);
+    return date;
+  } catch {
+    return null;
+  }
+}
+
+function matchesRecordedCandidate(
+  candidate: RecurringCandidate,
+  transaction: ForecastTransaction,
+): boolean {
+  const amountDifference = Math.abs(Math.abs(transaction.amount) - candidate.predictedAmount);
+  const amountTolerance = Math.max(
+    1,
+    Math.round(candidate.predictedAmount * CANDIDATE_AMOUNT_TOLERANCE_RATIO),
   );
+  const earliestDate = addDaysToIsoDateKey(candidate.predictedDate, -CANDIDATE_DATE_DRIFT_DAYS);
+  const latestDate = addDaysToIsoDateKey(candidate.predictedDate, CANDIDATE_DATE_DRIFT_DAYS);
+
+  return (
+    transaction.accountId === candidate.accountId &&
+    transaction.type === candidate.type &&
+    normalizeDescription(transaction.description) === normalizeDescription(candidate.description) &&
+    classifyRecurringTransaction(transaction) === candidate.classification &&
+    amountDifference <= amountTolerance &&
+    transaction.date >= earliestDate &&
+    transaction.date <= latestDate
+  );
+}
+
+function excludeRecordedCandidates(
+  candidates: RecurringCandidate[],
+  actualTransactions: ForecastTransaction[],
+): RecurringCandidate[] {
+  const matchedTransactionIndexes = new Set<number>();
+
+  return candidates.filter((candidate) => {
+    const matchIndex = actualTransactions.findIndex(
+      (transaction, index) =>
+        !matchedTransactionIndexes.has(index) && matchesRecordedCandidate(candidate, transaction),
+    );
+    if (matchIndex === -1) return true;
+
+    matchedTransactionIndexes.add(matchIndex);
+    return false;
+  });
 }
 
 export function buildBankCashFlowForecastViews(
@@ -89,7 +132,12 @@ export function buildBankCashFlowForecastViews(
   currentDate: string,
   candidates?: RecurringCandidate[],
 ): BankCashFlowForecastView[] {
-  const bankAccounts = accounts.filter(({ categoryName }) => categoryName === "銀行");
+  const bankAccounts = accounts.flatMap((account) => {
+    if (account.categoryName !== "銀行") return [];
+
+    const balanceAsOfDate = getBalanceAsOfDate(account.lastUpdated, currentDate);
+    return balanceAsOfDate ? [{ ...account, balanceAsOfDate }] : [];
+  });
   if (bankAccounts.length === 0) return [];
 
   const month = currentDate.slice(0, 7);
@@ -107,23 +155,21 @@ export function buildBankCashFlowForecastViews(
     const event = toActualEvent(transaction);
     return event ? [event] : [];
   });
-  const forecastEvents = forecastCandidates
-    .filter(
-      (candidate) =>
-        typeof candidate.accountId === "number" &&
-        bankAccountIds.has(candidate.accountId) &&
-        candidate.predictedDate >= currentDate &&
-        !isCandidateAlreadyRecorded(candidate, actualTransactions),
-    )
-    .map((candidate, index) =>
-      recurringCandidateToBankCashFlowEvent(`forecast-${index}`, candidate),
-    );
+  const eligibleCandidates = forecastCandidates.filter(
+    (candidate) =>
+      typeof candidate.accountId === "number" &&
+      bankAccountIds.has(candidate.accountId) &&
+      candidate.predictedDate >= currentDate,
+  );
+  const forecastEvents = excludeRecordedCandidates(eligibleCandidates, actualTransactions).map(
+    (candidate, index) => recurringCandidateToBankCashFlowEvent(`forecast-${index}`, candidate),
+  );
 
   const forecasts = calculateMonthlyBankBalanceForecasts(
-    bankAccounts.map(({ id, totalAssets }) => ({
+    bankAccounts.map(({ id, totalAssets, balanceAsOfDate }) => ({
       accountId: id,
       currentBalance: totalAssets,
-      balanceAsOfDate: currentDate,
+      balanceAsOfDate,
     })),
     [...actualEvents, ...forecastEvents],
     currentDate,

--- a/apps/web/src/components/info/bank-cashflow-forecast-data.ts
+++ b/apps/web/src/components/info/bank-cashflow-forecast-data.ts
@@ -1,0 +1,137 @@
+import {
+  calculateMonthlyBankBalanceForecasts,
+  recurringCandidateToBankCashFlowEvent,
+  type BankBalanceForecast,
+  type BankCashFlowEventInput,
+} from "@mf-dashboard/analytics/bank-balance-forecast";
+import {
+  classifyRecurringTransaction,
+  generateRecurringCandidates,
+  type RecurringCandidate,
+  type RecurringTransaction,
+} from "@mf-dashboard/analytics/recurring-candidates";
+
+interface ForecastAccount {
+  id: number;
+  name: string;
+  categoryName: string;
+  totalAssets: number;
+}
+
+interface ForecastTransaction {
+  id: number;
+  accountId: number | null;
+  date: string;
+  amount: number;
+  type: string;
+  description: string | null;
+  category: string | null;
+  subCategory: string | null;
+  isTransfer: boolean;
+  isExcludedFromCalculation: boolean;
+}
+
+export interface BankCashFlowForecastView extends BankBalanceForecast {
+  accountName: string;
+}
+
+function isRecurringTransactionType(type: string): type is RecurringTransaction["type"] {
+  return type === "income" || type === "expense" || type === "transfer";
+}
+
+function toRecurringTransactions(transactions: ForecastTransaction[]): RecurringTransaction[] {
+  return transactions.flatMap((transaction) => {
+    if (transaction.accountId === null || !isRecurringTransactionType(transaction.type)) return [];
+
+    return [{ ...transaction, accountId: transaction.accountId, type: transaction.type }];
+  });
+}
+
+function toActualEvent(transaction: ForecastTransaction): BankCashFlowEventInput | null {
+  if (transaction.accountId === null || !isRecurringTransactionType(transaction.type)) return null;
+
+  return {
+    id: `actual-${transaction.id}`,
+    accountId: transaction.accountId,
+    date: transaction.date,
+    amount: Math.abs(transaction.amount),
+    direction: transaction.type === "income" ? "income" : "expense",
+    status: "actual",
+    description: transaction.description,
+    classification: classifyRecurringTransaction(transaction),
+    isTransfer: transaction.isTransfer || transaction.type === "transfer",
+    isExcludedFromCalculation: transaction.isExcludedFromCalculation,
+  };
+}
+
+function normalizeDescription(description: string | null | undefined): string {
+  return description?.normalize("NFKC").trim().toLocaleLowerCase("ja-JP") ?? "";
+}
+
+function isCandidateAlreadyRecorded(
+  candidate: RecurringCandidate,
+  actualTransactions: ForecastTransaction[],
+): boolean {
+  const candidateDescription = normalizeDescription(candidate.description);
+  if (!candidateDescription) return false;
+
+  return actualTransactions.some(
+    (transaction) =>
+      transaction.accountId === candidate.accountId &&
+      transaction.type === candidate.type &&
+      normalizeDescription(transaction.description) === candidateDescription,
+  );
+}
+
+export function buildBankCashFlowForecastViews(
+  accounts: ForecastAccount[],
+  transactions: ForecastTransaction[],
+  currentDate: string,
+  candidates?: RecurringCandidate[],
+): BankCashFlowForecastView[] {
+  const bankAccounts = accounts.filter(({ categoryName }) => categoryName === "銀行");
+  if (bankAccounts.length === 0) return [];
+
+  const month = currentDate.slice(0, 7);
+  const bankAccountIds = new Set(bankAccounts.map(({ id }) => id));
+  const forecastCandidates =
+    candidates ?? generateRecurringCandidates(toRecurringTransactions(transactions), month);
+  const actualTransactions = transactions.filter(
+    ({ accountId, date }) =>
+      accountId !== null &&
+      bankAccountIds.has(accountId) &&
+      date.startsWith(month) &&
+      date <= currentDate,
+  );
+  const actualEvents = actualTransactions.flatMap((transaction) => {
+    const event = toActualEvent(transaction);
+    return event ? [event] : [];
+  });
+  const forecastEvents = forecastCandidates
+    .filter(
+      (candidate) =>
+        typeof candidate.accountId === "number" &&
+        bankAccountIds.has(candidate.accountId) &&
+        candidate.predictedDate >= currentDate &&
+        !isCandidateAlreadyRecorded(candidate, actualTransactions),
+    )
+    .map((candidate, index) =>
+      recurringCandidateToBankCashFlowEvent(`forecast-${index}`, candidate),
+    );
+
+  const forecasts = calculateMonthlyBankBalanceForecasts(
+    bankAccounts.map(({ id, totalAssets }) => ({
+      accountId: id,
+      currentBalance: totalAssets,
+      balanceAsOfDate: currentDate,
+    })),
+    [...actualEvents, ...forecastEvents],
+    currentDate,
+  );
+  const accountNames = new Map(bankAccounts.map(({ id, name }) => [id, name]));
+
+  return forecasts.map((forecast) => ({
+    ...forecast,
+    accountName: accountNames.get(Number(forecast.accountId)) ?? "銀行口座",
+  }));
+}

--- a/apps/web/src/components/info/bank-cashflow-forecast.client.test.tsx
+++ b/apps/web/src/components/info/bank-cashflow-forecast.client.test.tsx
@@ -61,5 +61,6 @@ describe("BankCashFlowForecastClient", () => {
     expect(screen.getByText("家賃")).toBeTruthy();
     expect(screen.getByText(/入出金後残高:/).textContent).toContain("90,000円");
     expect(screen.getByText(/過去3回/).textContent).toContain("10,000円");
+    expect(screen.getByText("-10,000円").className).not.toMatch(/text-(?:income|expense)/);
   });
 });

--- a/apps/web/src/components/info/bank-cashflow-forecast.client.test.tsx
+++ b/apps/web/src/components/info/bank-cashflow-forecast.client.test.tsx
@@ -1,0 +1,65 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { BankCashFlowForecastView } from "./bank-cashflow-forecast-data";
+import { BankCashFlowForecastClient } from "./bank-cashflow-forecast.client";
+
+afterEach(cleanup);
+
+const forecast: BankCashFlowForecastView = {
+  accountId: 1,
+  accountName: "銀行 A",
+  currentBalance: 100_000,
+  balanceAsOfDate: "2026-08-03",
+  forecastBoundaryDate: "2026-08-03",
+  monthStartDate: "2026-08-01",
+  monthEndDate: "2026-08-31",
+  openingBalance: 100_000,
+  monthEndBalance: 90_000,
+  excludedEvents: [],
+  days: [
+    {
+      date: "2026-08-20",
+      incomeTotal: 0,
+      expenseTotal: 10_000,
+      netChange: -10_000,
+      closingBalance: 90_000,
+      events: [
+        {
+          id: "forecast-1",
+          accountId: 1,
+          date: "2026-08-20",
+          amount: 10_000,
+          direction: "expense",
+          status: "forecast",
+          description: "家賃",
+          classification: "rent",
+          confidence: "high",
+          evidence: {
+            lookbackMonths: 12,
+            occurrenceCount: 3,
+            dateRange: { from: "2026-05-20", to: "2026-07-20" },
+            amountRange: { min: 10_000, max: 10_000 },
+          },
+          balanceAfter: 90_000,
+        },
+      ],
+    },
+  ],
+};
+
+describe("BankCashFlowForecastClient", () => {
+  it("詳細ボタンで日付別の入出金と入出金後残高を開閉する", () => {
+    render(<BankCashFlowForecastClient forecasts={[forecast]} />);
+
+    const trigger = screen.getByRole("button", { name: "入出金の詳細（1件）" });
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByText("家賃")).toBeNull();
+
+    fireEvent.click(trigger);
+
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("家賃")).toBeTruthy();
+    expect(screen.getByText(/入出金後残高:/).textContent).toContain("90,000円");
+    expect(screen.getByText(/過去3回/).textContent).toContain("10,000円");
+  });
+});

--- a/apps/web/src/components/info/bank-cashflow-forecast.client.tsx
+++ b/apps/web/src/components/info/bank-cashflow-forecast.client.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import type {
+  BankCashFlowStatus,
+  CalculatedBankCashFlowEvent,
+} from "@mf-dashboard/analytics/bank-balance-forecast";
+import type { RecurringCandidateClassification } from "@mf-dashboard/analytics/recurring-candidates";
+import { ChevronDown, Landmark } from "lucide-react";
+import { useId, useState } from "react";
+import { formatCurrency, formatDateShort } from "../../lib/format";
+import { cn } from "../../lib/utils";
+import { AmountDisplay } from "../ui/amount-display";
+import { Badge } from "../ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
+import type { BankCashFlowForecastView } from "./bank-cashflow-forecast-data";
+
+interface BankCashFlowForecastClientProps {
+  forecasts: BankCashFlowForecastView[];
+}
+
+const statusDetails: Record<
+  BankCashFlowStatus,
+  { label: string; variant: "success" | "secondary" | "warning" }
+> = {
+  actual: { label: "実績", variant: "success" },
+  forecast: { label: "予測", variant: "secondary" },
+  needs_review: { label: "要確認", variant: "warning" },
+};
+
+const classificationLabels: Record<RecurringCandidateClassification, string> = {
+  card: "カード支払い",
+  rent: "家賃",
+  loan: "ローン",
+  salary: "給与",
+  executive_compensation: "役員報酬",
+  tax: "税金",
+  other: "定期的な入出金",
+};
+
+function getEvidenceText(event: CalculatedBankCashFlowEvent): string {
+  if (event.status === "actual") return "Money Forwardの実績データ";
+
+  const classification = event.classification
+    ? classificationLabels[event.classification]
+    : classificationLabels.other;
+  const evidence = event.evidence;
+  if (!evidence) return `${classification}として推定`;
+
+  const amountRange =
+    evidence.amountRange.min === evidence.amountRange.max
+      ? formatCurrency(evidence.amountRange.min)
+      : `${formatCurrency(evidence.amountRange.min)}〜${formatCurrency(evidence.amountRange.max)}`;
+  return `${classification}の過去${evidence.occurrenceCount}回（${formatDateShort(evidence.dateRange.from)}〜${formatDateShort(evidence.dateRange.to)}、${amountRange}）から推定`;
+}
+
+function ForecastEvent({ event }: { event: CalculatedBankCashFlowEvent }) {
+  const status = statusDetails[event.status];
+  const signedAmount = event.direction === "income" ? event.amount : -event.amount;
+
+  return (
+    <li className="grid gap-2 border-t py-3 first:border-t-0 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
+      <div className="min-w-0 space-y-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant={status.variant}>{status.label}</Badge>
+          <span className="font-medium">{event.description || "入出金"}</span>
+        </div>
+        <p className="text-xs leading-relaxed text-muted-foreground">{getEvidenceText(event)}</p>
+      </div>
+      <div className="space-y-1 text-left sm:text-right">
+        <AmountDisplay amount={signedAmount} type={event.direction} showSign weight="semibold" />
+        <p className="text-xs text-muted-foreground">
+          入出金後残高: <AmountDisplay amount={event.balanceAfter} type="balance" size="sm" />
+        </p>
+      </div>
+    </li>
+  );
+}
+
+function BankForecastCard({ forecast }: { forecast: BankCashFlowForecastView }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const detailsId = useId();
+  const eventCount = forecast.days.reduce((count, day) => count + day.events.length, 0);
+
+  return (
+    <section className="rounded-lg border bg-background p-4" aria-labelledby={`${detailsId}-title`}>
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 id={`${detailsId}-title`} className="font-semibold">
+            {forecast.accountName}
+          </h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {formatDateShort(forecast.forecastBoundaryDate)}時点
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-x-6 gap-y-1 sm:text-right">
+          <span className="text-xs text-muted-foreground">現在残高</span>
+          <span className="text-xs text-muted-foreground">月末予測残高</span>
+          <AmountDisplay amount={forecast.currentBalance} type="balance" weight="semibold" />
+          <AmountDisplay amount={forecast.monthEndBalance} type="balance" weight="bold" />
+        </div>
+      </div>
+
+      {eventCount === 0 ? (
+        <p className="mt-4 border-t pt-4 text-sm text-muted-foreground">
+          今月の入出金実績・予測はありません。
+        </p>
+      ) : (
+        <>
+          <button
+            type="button"
+            className="mt-4 flex w-full items-center justify-between border-t pt-4 text-sm font-medium hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            aria-controls={detailsId}
+            aria-expanded={isOpen}
+            onClick={() => setIsOpen((open) => !open)}
+          >
+            <span>入出金の詳細（{eventCount}件）</span>
+            <ChevronDown
+              className={cn("h-4 w-4 transition-transform", isOpen && "rotate-180")}
+              aria-hidden="true"
+            />
+          </button>
+          {isOpen && (
+            <div id={detailsId} className="mt-2 space-y-4">
+              {forecast.days.map((day) => (
+                <section key={day.date} aria-labelledby={`${detailsId}-${day.date}`}>
+                  <div className="flex flex-wrap items-baseline justify-between gap-2 rounded-md bg-muted/50 px-3 py-2">
+                    <h4 id={`${detailsId}-${day.date}`} className="text-sm font-semibold">
+                      {formatDateShort(day.date)}
+                    </h4>
+                    <span className="text-xs text-muted-foreground">
+                      取引後残高:{" "}
+                      <AmountDisplay amount={day.closingBalance} type="balance" size="sm" />
+                    </span>
+                  </div>
+                  <ul className="px-3">
+                    {day.events.map((event) => (
+                      <ForecastEvent key={event.id} event={event} />
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+export function BankCashFlowForecastClient({ forecasts }: BankCashFlowForecastClientProps) {
+  const month = Number(forecasts[0]?.monthStartDate.slice(5, 7));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle icon={Landmark}>{month}月の銀行別予測</CardTitle>
+        <CardDescription>
+          現在残高と、定期的な入出金を反映した月末残高の見込みです。
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-4 lg:grid-cols-2">
+          {forecasts.map((forecast) => (
+            <BankForecastCard key={forecast.accountId} forecast={forecast} />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/info/bank-cashflow-forecast.client.tsx
+++ b/apps/web/src/components/info/bank-cashflow-forecast.client.tsx
@@ -67,7 +67,12 @@ function ForecastEvent({ event }: { event: CalculatedBankCashFlowEvent }) {
         <p className="text-xs leading-relaxed text-muted-foreground">{getEvidenceText(event)}</p>
       </div>
       <div className="space-y-1 text-left sm:text-right">
-        <AmountDisplay amount={signedAmount} type={event.direction} showSign weight="semibold" />
+        <AmountDisplay
+          amount={signedAmount}
+          type={event.status === "actual" ? event.direction : "neutral"}
+          showSign
+          weight="semibold"
+        />
         <p className="text-xs text-muted-foreground">
           入出金後残高: <AmountDisplay amount={event.balanceAfter} type="balance" size="sm" />
         </p>

--- a/apps/web/src/components/info/bank-cashflow-forecast.stories.tsx
+++ b/apps/web/src/components/info/bank-cashflow-forecast.stories.tsx
@@ -1,0 +1,152 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { userEvent, within } from "storybook/test";
+import type { BankCashFlowForecastView } from "./bank-cashflow-forecast-data";
+import { BankCashFlowForecastClient } from "./bank-cashflow-forecast.client";
+
+const evidence = {
+  lookbackMonths: 12,
+  occurrenceCount: 3,
+  dateRange: { from: "2026-05-25", to: "2026-07-25" },
+  amountRange: { min: 270_000, max: 290_000 },
+};
+
+const forecasts: BankCashFlowForecastView[] = [
+  {
+    accountId: "bank-a",
+    accountName: "銀行 A",
+    currentBalance: 420_000,
+    balanceAsOfDate: "2026-08-03",
+    forecastBoundaryDate: "2026-08-03",
+    monthStartDate: "2026-08-01",
+    monthEndDate: "2026-08-31",
+    openingBalance: 415_000,
+    monthEndBalance: 615_000,
+    excludedEvents: [],
+    days: [
+      {
+        date: "2026-08-02",
+        incomeTotal: 5_000,
+        expenseTotal: 0,
+        netChange: 5_000,
+        closingBalance: 420_000,
+        events: [
+          {
+            id: "actual-a",
+            accountId: "bank-a",
+            date: "2026-08-02",
+            amount: 5_000,
+            direction: "income",
+            status: "actual",
+            description: "利息",
+            balanceAfter: 420_000,
+          },
+        ],
+      },
+      {
+        date: "2026-08-25",
+        incomeTotal: 280_000,
+        expenseTotal: 80_000,
+        netChange: 200_000,
+        closingBalance: 620_000,
+        events: [
+          {
+            id: "forecast-a",
+            accountId: "bank-a",
+            date: "2026-08-25",
+            amount: 280_000,
+            direction: "income",
+            status: "forecast",
+            description: "給与振込",
+            classification: "salary",
+            confidence: "high",
+            evidence,
+            balanceAfter: 700_000,
+          },
+          {
+            id: "review-a",
+            accountId: "bank-a",
+            date: "2026-08-25",
+            amount: 80_000,
+            direction: "expense",
+            status: "needs_review",
+            description: "口座振替",
+            classification: "other",
+            confidence: "low",
+            evidence: {
+              ...evidence,
+              occurrenceCount: 1,
+              amountRange: { min: 80_000, max: 80_000 },
+            },
+            balanceAfter: 620_000,
+          },
+        ],
+      },
+      {
+        date: "2026-08-27",
+        incomeTotal: 0,
+        expenseTotal: 5_000,
+        netChange: -5_000,
+        closingBalance: 615_000,
+        events: [
+          {
+            id: "forecast-b",
+            accountId: "bank-a",
+            date: "2026-08-27",
+            amount: 5_000,
+            direction: "expense",
+            status: "forecast",
+            description: "ローン返済",
+            classification: "loan",
+            confidence: "medium",
+            evidence: { ...evidence, amountRange: { min: 5_000, max: 5_000 } },
+            balanceAfter: 615_000,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    accountId: "bank-b",
+    accountName: "銀行 B",
+    currentBalance: 85_000,
+    balanceAsOfDate: "2026-08-03",
+    forecastBoundaryDate: "2026-08-03",
+    monthStartDate: "2026-08-01",
+    monthEndDate: "2026-08-31",
+    openingBalance: 85_000,
+    monthEndBalance: 85_000,
+    days: [],
+    excludedEvents: [],
+  },
+];
+
+const meta = {
+  title: "Info/BankCashFlowForecast",
+  component: BankCashFlowForecastClient,
+  tags: ["autodocs"],
+} satisfies Meta<typeof BankCashFlowForecastClient>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { forecasts },
+  async play({ canvasElement }) {
+    await userEvent.click(
+      within(canvasElement).getByRole("button", { name: "入出金の詳細（4件）" }),
+    );
+  },
+};
+
+export const NegativeForecast: Story = {
+  args: {
+    forecasts: [
+      {
+        ...forecasts[0]!,
+        accountName: "銀行 C",
+        currentBalance: 20_000,
+        monthEndBalance: -60_000,
+      },
+    ],
+  },
+};

--- a/apps/web/src/components/info/bank-cashflow-forecast.tsx
+++ b/apps/web/src/components/info/bank-cashflow-forecast.tsx
@@ -1,0 +1,25 @@
+import { getJstTodayIsoDate } from "@mf-dashboard/date-utils";
+import { getAccountsWithAssets, getTransactions } from "@mf-dashboard/db";
+import { Landmark } from "lucide-react";
+import { EmptyState } from "../ui/empty-state";
+import { buildBankCashFlowForecastViews } from "./bank-cashflow-forecast-data";
+import { BankCashFlowForecastClient } from "./bank-cashflow-forecast.client";
+
+interface BankCashFlowForecastProps {
+  groupId?: string;
+}
+
+export async function BankCashFlowForecast({ groupId }: BankCashFlowForecastProps) {
+  const [accounts, transactions] = await Promise.all([
+    getAccountsWithAssets(groupId),
+    getTransactions({ groupId }),
+  ]);
+  const currentDate = getJstTodayIsoDate();
+  const forecasts = buildBankCashFlowForecastViews(accounts, transactions, currentDate);
+
+  if (forecasts.length === 0) {
+    return <EmptyState icon={Landmark} title="今月の銀行別予測" />;
+  }
+
+  return <BankCashFlowForecastClient forecasts={forecasts} />;
+}

--- a/apps/web/src/components/info/bank-cashflow-forecast.tsx
+++ b/apps/web/src/components/info/bank-cashflow-forecast.tsx
@@ -1,4 +1,4 @@
-import { getJstTodayIsoDate } from "@mf-dashboard/date-utils";
+import { getJstTodayIsoDate, shiftYearMonthKey } from "@mf-dashboard/date-utils";
 import { getAccountsWithAssets, getTransactions } from "@mf-dashboard/db";
 import { Landmark } from "lucide-react";
 import { EmptyState } from "../ui/empty-state";
@@ -10,11 +10,12 @@ interface BankCashFlowForecastProps {
 }
 
 export async function BankCashFlowForecast({ groupId }: BankCashFlowForecastProps) {
+  const currentDate = getJstTodayIsoDate();
+  const historyStartDate = `${shiftYearMonthKey(currentDate.slice(0, 7), -12)}-01`;
   const [accounts, transactions] = await Promise.all([
     getAccountsWithAssets(groupId),
-    getTransactions({ groupId }),
+    getTransactions({ groupId, startDate: historyStartDate }),
   ]);
-  const currentDate = getJstTodayIsoDate();
   const forecasts = buildBankCashFlowForecastViews(accounts, transactions, currentDate);
 
   if (forecasts.length === 0) {

--- a/packages/analytics/src/recurring-candidates.test.ts
+++ b/packages/analytics/src/recurring-candidates.test.ts
@@ -71,6 +71,7 @@ describe("generateRecurringCandidates", () => {
         classification: "other",
         confidence: "low",
         description: "新規振込",
+        recurringIdentity: "新規振込",
         predictedDate: "2026-08-10",
         predictedAmount: 150_000,
         evidence: {
@@ -86,6 +87,7 @@ describe("generateRecurringCandidates", () => {
         classification: "salary",
         confidence: "high",
         description: "給与 7月",
+        recurringIdentity: "給与",
         predictedDate: "2026-08-25",
         predictedAmount: 305_000,
         evidence: {
@@ -101,6 +103,7 @@ describe("generateRecurringCandidates", () => {
         classification: "rent",
         confidence: "medium",
         description: "家賃",
+        recurringIdentity: "家賃",
         predictedDate: "2026-08-28",
         predictedAmount: 81_000,
         evidence: {

--- a/packages/analytics/src/recurring-candidates.ts
+++ b/packages/analytics/src/recurring-candidates.ts
@@ -48,6 +48,7 @@ export interface RecurringCandidate {
   classification: RecurringCandidateClassification;
   confidence: RecurringCandidateConfidence;
   description: string | null;
+  recurringIdentity?: string;
   predictedDate: string;
   predictedAmount: number;
   evidence: RecurringCandidateEvidence;
@@ -72,6 +73,11 @@ interface NormalizedTransaction extends RecurringTransaction {
 interface TransactionGroup {
   transactions: NormalizedTransaction[];
 }
+
+type RecurringIdentitySource = Pick<
+  RecurringTransaction,
+  "category" | "description" | "subCategory"
+>;
 
 type AmountGroupsByDay = Map<number, Map<number, Set<TransactionGroup>>>;
 type AmountKeysByDay = Map<number, number[]>;
@@ -411,7 +417,7 @@ function conflictsWithPostingMonthSchedule(
   return getPostingMonthConflicts(transaction, transactions).length > 0;
 }
 
-function normalizeGroupingText(transaction: RecurringTransaction): string {
+function normalizeGroupingText(transaction: RecurringIdentitySource): string {
   const description = normalizeDescription(transaction.description);
   const normalizeCategoryPart = (value: string | null | undefined) =>
     normalizeCaseAndWidth(value).replace(/[\p{Punctuation}\p{Separator}\p{Symbol}]/gu, "");
@@ -420,6 +426,22 @@ function normalizeGroupingText(transaction: RecurringTransaction): string {
   if (!description) return category;
   if (!GENERIC_DESCRIPTIONS.has(description)) return description;
   return category ? `${description}descriptionsep${category}` : "";
+}
+
+export function matchesRecurringCandidateIdentity(
+  candidate: Pick<RecurringCandidate, "description" | "recurringIdentity">,
+  transaction: RecurringIdentitySource,
+): boolean {
+  const candidateIdentity =
+    candidate.recurringIdentity ?? normalizeDescription(candidate.description);
+  const transactionIdentity = normalizeGroupingText(transaction);
+  if (!candidateIdentity || !transactionIdentity) return candidateIdentity === transactionIdentity;
+
+  return (
+    haveMatchingNumericTokens(candidateIdentity, transactionIdentity) &&
+    calculateDescriptionSimilarity(candidateIdentity, transactionIdentity) >=
+      DEFAULT_OPTIONS.descriptionSimilarityThreshold
+  );
 }
 
 interface GroupMatchScore {
@@ -1343,6 +1365,7 @@ function createCandidate(
     classification: latest.classification,
     confidence,
     description: latest.description ?? null,
+    recurringIdentity: latest.normalizedDescription,
     predictedDate: formatIsoDateKey({ year, month, day: predictedDay }),
     predictedAmount: Math.round(median(amounts)),
     evidence: {

--- a/packages/db/src/queries/transaction.test.ts
+++ b/packages/db/src/queries/transaction.test.ts
@@ -123,6 +123,17 @@ describe("getTransactions", () => {
     expect(result).toHaveLength(1);
   });
 
+  it("startDateを指定した場合は対象日以降に制限される", async () => {
+    const accountId = await createTestAccount("Bank A");
+    await createTransaction({ accountId, date: "2025-04-15", amount: 1000, type: "expense" });
+    await createTransaction({ accountId, date: "2025-03-31", amount: 2000, type: "expense" });
+
+    const result = await getTransactions({ startDate: "2025-04-01" }, db);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].date).toBe("2025-04-15");
+  });
+
   it("グループがない場合は空配列を返す", async () => {
     await resetTestDb(db);
     expect(await getTransactions(undefined, db)).toEqual([]);

--- a/packages/db/src/queries/transaction.ts
+++ b/packages/db/src/queries/transaction.ts
@@ -4,7 +4,7 @@ import { resolveGroupId, getAccountIdsForGroup } from "../shared/group-filter";
 import { transformTransferToIncome } from "../shared/transfer";
 
 export async function getTransactions(
-  options?: { limit?: number; groupId?: string },
+  options?: { limit?: number; groupId?: string; startDate?: string },
   db: Db = getDb(),
 ) {
   const groupId = await resolveGroupId(db, options?.groupId);
@@ -31,7 +31,12 @@ export async function getTransactions(
     })
     .from(schema.transactions)
     .leftJoin(schema.accounts, eq(schema.accounts.id, schema.transactions.accountId))
-    .where(inArray(schema.transactions.accountId, accountIds))
+    .where(
+      and(
+        inArray(schema.transactions.accountId, accountIds),
+        options?.startDate ? gte(schema.transactions.date, options.startDate) : undefined,
+      ),
+    )
     .orderBy(desc(schema.transactions.date));
 
   if (options?.limit) {


### PR DESCRIPTION
# Summary

- トップページに、今月の銀行口座ごとの現在残高と月末予測残高を表示するカードを追加
- 当月実績と定期的な入出金候補から、日付別・明細別の残高推移、実績・予測・要確認バッジ、推定根拠を表示
- 通常トップとグループ別トップで共通利用し、詳細開閉だけを client component に分離
- 記録済み候補と過去日候補の二重計上を防ぐ unit test、interaction test、Storybook story を追加

## Linear Issue

- [HIR-164](https://linear.app/hiroppy/issue/HIR-164/トップページに今月の銀行別予測カードを追加する)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| 機能適合性 | 残高予測と明細別残高が正しく対応する必要がある | 現在残高、月末予測、日付・明細別の入出金後残高が一致する |
| 使用性 | トップ上で概要から根拠へ迷わず遷移できる必要がある | 各口座の詳細を開閉し、バッジと根拠を追える |
| アクセシビリティ | 金額と予測状態を色だけに依存せず識別する必要がある | テキストラベル、aria-expanded、キーボード操作、semantic color を備える |
| 保守性 | データ取得とインタラクションの責務を分離する必要がある | server component、純粋な合成ロジック、client component が分離される |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| 同値分割 | 通常トップとグループ別トップで同じ機能を別スコープで確認する | 全口座スコープとグループスコープ |
| 境界値分析 | 月境界と明細なし口座で誤計上しやすい | 当月以前の予測除外、明細なし表示 |
| 決定表 | 実績・予測・要確認で表示と根拠が異なる | 3状態のバッジ、根拠、金額表示 |
| 状態遷移 | 詳細の閉状態と開状態を検証する | aria-expanded と詳細内容の表示切替 |
| エラー推測 | 記録済み定期取引の予測重複が起きやすい | 当月記録済み候補の二重計上防止 |

### Primary Test Conditions

- 通常トップと生活グループトップに銀行別予測が表示される
- 各銀行カードに現在残高と月末予測残高が表示される
- 詳細開閉後、日付・明細・入出金額・明細後残高・日次残高が確認できる
- 実績・予測・要確認の各バッジと推定根拠が表示される
- 銀行口座なし、明細なし、記録済み候補、過去日候補を安全に処理する

### Out-of-Scope Risks

- 予測候補抽出と残高計算アルゴリズム自体は epic branch の既存実装を利用し、本 PR では変更しない
- 実サービスデータは個人情報を含むため runtime 検証には匿名 demo data のみを利用する

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [x] Storybook tests
- [ ] E2E tests
- [x] Manual verification

### Commands Executed

~~~text
pnpm --filter @mf-dashboard/web test:unit — 45 files / 588 tests passed
pnpm --filter @mf-dashboard/web test:storybook — 79 files / 346 tests passed
pnpm turbo typecheck — 8/8 tasks passed
pnpm lint — passed
pnpm format:check — passed
pnpm knip — passed（既存 configuration hint のみ）
pnpm --filter @mf-dashboard/db build:demo — passed
pnpm --filter @mf-dashboard/web dev --hostname 127.0.0.1 — / と /demo_group_002 を確認
~~~

### Checks Not Run

- Web E2E tests — 対象画面の決定的な状態・アクセシビリティは unit、Storybook interaction、匿名 demo runtime walkthrough で直接検証したため
