### PR TITLE
test(web): cover bank forecast dashboard integration

### DIFF
--- a/apps/web/e2e/app-flows.test.ts
+++ b/apps/web/e2e/app-flows.test.ts
@@ -57,6 +57,43 @@ test.describe("App flows", () => {
     expect(releaseWarnings).toEqual([]);
   });
 
+  test("shows the monthly bank cash flow forecast on default and group dashboards", async ({
+    page,
+  }) => {
+    for (const path of ["/", "/demo_group_002"]) {
+      await test.step(`Inspect bank cash flow forecast at ${path}`, async () => {
+        await page.goto(path);
+        await expectHeading(page, "ダッシュボード");
+
+        await expect(page.getByText(/^\d+月の銀行別予測$/)).toBeVisible();
+        await expect(page.getByText("現在残高").first()).toBeVisible();
+        await expect(page.getByText("月末予測残高").first()).toBeVisible();
+        await expect(
+          page.getByText("過去月表示と任意月への切替は対象外です。", {
+            exact: false,
+          }),
+        ).toBeVisible();
+        await expect(page.getByRole("combobox", { name: "月を選択" })).toHaveCount(0);
+
+        const bank = page.getByRole("region", { name: "三井住友銀行" });
+        const details = bank.getByRole("button", { name: /入出金の詳細/ });
+        await expect(details).toHaveAttribute("aria-expanded", "false");
+        await expect(bank.getByText("給与振込")).toHaveCount(0);
+
+        await details.click();
+
+        await expect(details).toHaveAttribute("aria-expanded", "true");
+        await expect(bank.getByText("給与振込")).toBeVisible();
+        await expect(bank.getByText("予測").first()).toBeVisible();
+        await expect(bank.getByText(/入出金後残高:/).first()).toBeVisible();
+
+        const actualBank = page.getByRole("region", { name: "楽天銀行" });
+        await actualBank.getByRole("button", { name: /入出金の詳細/ }).click();
+        await expect(actualBank.getByText("実績").first()).toBeVisible();
+      });
+    }
+  });
+
   test("navigates between primary pages from the sidebar", async ({ page }) => {
     // This scenario compiles and visits six routes. WebKit on CI can exceed
     // Playwright's 30-second default while the Next.js dev server warms up.

--- a/apps/web/e2e/app-flows.test.ts
+++ b/apps/web/e2e/app-flows.test.ts
@@ -92,6 +92,13 @@ test.describe("App flows", () => {
         await expect(actualBank.getByText("実績").first()).toBeVisible();
       });
     }
+
+    await test.step("Exclude banks outside the selected group", async () => {
+      await page.goto("/demo_group_001");
+      await expectHeading(page, "ダッシュボード");
+      await expect(page.getByText(/^\d+月の銀行別予測$/)).toHaveCount(0);
+      await expect(page.getByRole("region", { name: "三井住友銀行" })).toHaveCount(0);
+    });
   });
 
   test("navigates between primary pages from the sidebar", async ({ page }) => {

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -14,6 +14,7 @@ import { existsSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { parseArgs } from "node:util";
 import { createClient } from "@libsql/client";
+import { getJstYearMonthKey, parseYearMonthKey } from "@mf-dashboard/date-utils";
 import { drizzle } from "drizzle-orm/libsql";
 import { migrate } from "drizzle-orm/libsql/migrator";
 import * as schema from "./schema/schema";
@@ -89,9 +90,7 @@ if (period && !/^\d{4}-\d{2}$/.test(period)) {
   console.error("--period must be in YYYY-MM format (e.g., --period=2026-03)");
   process.exit(1);
 }
-const currentDate = new Date();
-const YEAR_END = period ? Number(period.split("-")[0]) : currentDate.getFullYear();
-const MONTH_END = period ? Number(period.split("-")[1]) : currentDate.getMonth() + 1;
+const { year: YEAR_END, month: MONTH_END } = parseYearMonthKey(period ?? getJstYearMonthKey());
 const DEMO_FORECAST_AS_OF_DAY = 3;
 const today = new Date(dateStr(YEAR_END, MONTH_END, DEMO_FORECAST_AS_OF_DAY));
 fixedTimestamp = `${dateStr(YEAR_END, MONTH_END, DEMO_FORECAST_AS_OF_DAY)}T00:00:00.000Z`;


### PR DESCRIPTION
# Summary

- 今月の銀行別キャッシュフロー予測について、通常トップ `/` と生活グループトップ `/demo_group_002` の統合 E2E を追加
- サマリの現在残高・月末予測残高、詳細の閉→開、予測/実績、入出金後残高を匿名 demo DB で検証
- 銀行予測カードに過去月切替 UI が混入しないことを検証
- demo seed の既定期間を dashboard と同じ JST 月境界に統一

## Linear Issue

- [HIR-161](https://linear.app/hiroppy/issue/HIR-161/今月の銀行別キャッシュフロー予測をトップに追加する)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| 機能適合性 | 通常/グループ別トップで銀行別予測が正しいスコープと状態で表示される必要がある | 両経路で現在残高、月末予測残高、実績/予測、入出金後残高を確認できる |
| 使用性 | 予測を実績と誤認せず、初期情報量を抑えて詳細へ進める必要がある | 詳細は初期状態で閉じ、操作後に状態ラベルと明細が表示される |
| アクセシビリティ | キーボード/支援技術から詳細状態を識別できる必要がある | 銀行 region、操作名、`aria-expanded` の閉→開が確認できる |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| 同値分割 | 通常トップとグループ別トップを代表経路として選ぶ | groupId なし/ありのデータスコープ |
| 状態遷移 | 詳細の閉状態と開状態で表示要素が変わる | `aria-expanded=false` から `true`、明細の出現 |
| チェックリストベース | 親 Issue の UI 受入条件を漏れなく統合確認する | 現在/月末残高、実績/予測、入出金後残高、過去月 UI 不在 |
| エラー推測 | 既存の月次収支用 UI が予測カードへ混入する誤解を防ぐ | 「月を選択」combobox が銀行予測に存在しないこと |

### Primary Test Conditions

- `/` と `/demo_group_002` に今月の銀行別予測を表示する
- 三井住友銀行の詳細が初期状態で閉じ、展開後に予測候補と入出金後残高を表示する
- 楽天銀行の詳細で当月実績を表示する
- 過去月表示/任意月切替が対象外と説明され、月選択 UI を表示しない

### Out-of-Scope Risks

- 本 PR は統合 E2E の追加のみで、候補抽出・残高計算・UI 実装は HIR-162〜166 の既存単体/Storybook テストで検証済み
- 本番金融機関の同期遅延・未取得取引は匿名 demo DB では再現せず、既存 UI の限界説明で扱う

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [x] Storybook tests
- [x] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/analytics test -- src/recurring-candidates.test.ts src/forecast-assistance.test.ts src/bank-balance-forecast.test.ts — 15 files / 304 tests passed
pnpm --filter @mf-dashboard/web test:unit -- src/components/info/bank-cashflow-forecast-data.test.ts src/components/info/bank-cashflow-forecast.client.test.tsx — 45 files / 596 tests passed
pnpm --filter @mf-dashboard/web test:storybook — 79 files / 346 tests passed
pnpm --filter @mf-dashboard/web exec playwright test e2e/app-flows.test.ts --grep 'monthly bank cash flow forecast' — 3 projects passed
pnpm turbo typecheck — 8 packages passed
pnpm lint — passed
pnpm format:check — passed
pnpm --filter @mf-dashboard/db build:demo + local Next.js launch — `/` and `/demo_group_002` verified with anonymous demo data
```

### Checks Not Run

- N/A — all relevant checks were run
