### PR TITLE
fix(crawler): support scheduled withdrawal total label

### DIFF
--- a/apps/crawler/src/scrapers/scheduled-withdrawals.test.ts
+++ b/apps/crawler/src/scrapers/scheduled-withdrawals.test.ts
@@ -9,6 +9,7 @@ describe("parseScheduledWithdrawalSummary", () => {
     ["引き落とし予定額：42,000円", { amount: 42_000, confirmed: true }],
     [" 引き落とし予定額： １２，０００円 ", { amount: 12_000, confirmed: true }],
     ["引き落とし予定額：未定", { amount: 0, confirmed: false }],
+    ["引き落とし予定額合計：42,000円", { amount: 42_000, confirmed: true }],
     ["利用残高：42,000円", undefined],
   ])("合計見出し %s を解析する", (text, expected) => {
     expect(parseScheduledWithdrawalSummary(text)).toEqual(expected);

--- a/apps/crawler/src/scrapers/scheduled-withdrawals.ts
+++ b/apps/crawler/src/scrapers/scheduled-withdrawals.ts
@@ -2,7 +2,7 @@ import type { RegisteredAccounts } from "@mf-dashboard/db/types";
 import type { Page } from "playwright";
 import { parseJapaneseNumber } from "../parsers.js";
 
-const WITHDRAWAL_SUMMARY_PREFIX = "引き落とし予定額：";
+const WITHDRAWAL_SUMMARY_PREFIXES = ["引き落とし予定額：", "引き落とし予定額合計："];
 
 export interface ScheduledWithdrawalStatus {
   amount: number;
@@ -13,9 +13,10 @@ export function parseScheduledWithdrawalSummary(
   text: string,
 ): ScheduledWithdrawalStatus | undefined {
   const normalized = text.trim();
-  if (!normalized.startsWith(WITHDRAWAL_SUMMARY_PREFIX)) return undefined;
+  const prefix = WITHDRAWAL_SUMMARY_PREFIXES.find((label) => normalized.startsWith(label));
+  if (!prefix) return undefined;
 
-  const value = normalized.slice(WITHDRAWAL_SUMMARY_PREFIX.length).trim().normalize("NFKC");
+  const value = normalized.slice(prefix.length).trim().normalize("NFKC");
   if (!/\d/u.test(value)) return { amount: 0, confirmed: false };
   return { amount: Math.max(0, parseJapaneseNumber(value)), confirmed: true };
 }

--- a/apps/crawler/tests/e2e/accounts-structure.test.ts
+++ b/apps/crawler/tests/e2e/accounts-structure.test.ts
@@ -65,7 +65,7 @@ describe("accounts page structure", () => {
 
       const summaryCount = await page
         .locator("h1.heading-small")
-        .filter({ hasText: "引き落とし予定額：" })
+        .filter({ hasText: /引き落とし予定額(?:合計)?：/u })
         .count();
       expect(summaryCount).toBe(1);
     });


### PR DESCRIPTION
## Summary
- support MoneyForward card detail headings that use `引き落とし予定額合計：`
- keep compatibility with the existing `引き落とし予定額：` heading
- update crawler E2E structure check to accept both heading variants

## Verification
- `pnpm --filter @mf-dashboard/crawler test -- src/scrapers/scheduled-withdrawals.test.ts`
- `pnpm --filter @mf-dashboard/crawler exec tsc --noEmit`
- `pnpm --filter @mf-dashboard/crawler exec vitest run --project e2e tests/e2e/accounts-structure.test.ts`
- `pnpm --filter @mf-dashboard/crawler test:e2e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduled withdrawal amount parsing to recognize multiple Japanese summary heading formats.
  * Updated account validation to support both withdrawal amount heading variations.
  * Added coverage confirming correct parsing of a 42,000-yen scheduled withdrawal amount.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->