### PR TITLE
fix(web): correct simulator withdrawal calculations

### DIFF
--- a/apps/web/src/components/charts/compound-simulator/calculate-compound.test.ts
+++ b/apps/web/src/components/charts/compound-simulator/calculate-compound.test.ts
@@ -677,10 +677,26 @@ describe("calculateCompound", () => {
       });
 
       const withdrawals = result.filter((p) => p.isWithdrawing);
-      // First year withdrawal should be slightly above 1.2M (inflated from month 1)
-      expect(withdrawals[0].yearlyWithdrawal).toBeGreaterThan(1_200_000);
-      // Later years should have even higher withdrawal
-      expect(withdrawals[4].yearlyWithdrawal).toBeGreaterThan(withdrawals[0].yearlyWithdrawal);
+      expect(withdrawals[0].yearlyWithdrawal).toBe(1_200_000);
+      expect(withdrawals[1].yearlyWithdrawal).toBe(1_236_000);
+      expect(withdrawals[4].yearlyWithdrawal).toBe(1_350_611);
+    });
+
+    it("should increase the withdrawal only at yearly boundaries", () => {
+      const result = calculateCompound({
+        initialAmount: 10_000_000,
+        monthlyContribution: 0,
+        annualReturnRate: 0,
+        contributionYears: 0,
+        withdrawalStartYear: 2,
+        monthlyWithdrawal: 100_000,
+        withdrawalYears: 2,
+        inflationRate: 10,
+        inflationAdjustedWithdrawal: true,
+      });
+
+      expect(result[3].yearlyWithdrawal).toBe(1_200_000);
+      expect(result[4].yearlyWithdrawal).toBe(1_320_000);
     });
 
     it("should deplete faster than non-adjusted withdrawal", () => {

--- a/apps/web/src/components/charts/compound-simulator/calculate-compound.ts
+++ b/apps/web/src/components/charts/compound-simulator/calculate-compound.ts
@@ -57,7 +57,6 @@ export function calculateCompound({
 
   let currentTotal = initialAmount;
   let totalPrincipal = initialAmount;
-  let currentMonthlyWithdrawal = monthlyWithdrawal;
   let rateBasedMonthlyWithdrawal = 0;
   let rateFirstWithdrawalYear = -1;
   let rateBasedWithdrawalSeeded = false;
@@ -106,21 +105,26 @@ export function calculateCompound({
         if (isRateMode) {
           baseWithdrawal = rateBasedMonthlyWithdrawal;
         } else {
-          baseWithdrawal = currentMonthlyWithdrawal;
-          if (inflationAdjustedWithdrawal) {
-            currentMonthlyWithdrawal *= monthlyInflationFactor;
-          }
+          const withdrawalYearIndex = year - withdrawalStartYear - 1;
+          baseWithdrawal = inflationAdjustedWithdrawal
+            ? monthlyWithdrawal * Math.pow(monthlyInflationFactor, withdrawalYearIndex * 12)
+            : monthlyWithdrawal;
         }
         const pensionActive = pensionStartYear != null && year >= pensionStartYear;
         const income = (pensionActive ? monthlyPensionIncome : 0) + monthlyOtherIncome;
-        const netWithdrawal = Math.max(baseWithdrawal - income, 0);
-        yearlyWithdrawalTotal += netWithdrawal;
+        const requestedNetWithdrawal = Math.max(baseWithdrawal - income, 0);
         const gainRatio =
           currentTotal > totalPrincipal ? (currentTotal - totalPrincipal) / currentTotal : 0;
-        const taxOnWithdrawal = netWithdrawal * gainRatio * taxRate;
-        const withdrawalRatio = Math.min(netWithdrawal / currentTotal, 1);
+        const effectiveTaxRate = gainRatio * taxRate;
+        const requiredGrossWithdrawal =
+          requestedNetWithdrawal / Math.max(1 - effectiveTaxRate, Number.EPSILON);
+        const grossWithdrawal = Math.min(requiredGrossWithdrawal, currentTotal);
+        const taxOnWithdrawal = grossWithdrawal * effectiveTaxRate;
+        const actualNetWithdrawal = grossWithdrawal - taxOnWithdrawal;
+        yearlyWithdrawalTotal += actualNetWithdrawal;
+        const withdrawalRatio = grossWithdrawal / currentTotal;
         totalPrincipal *= 1 - withdrawalRatio;
-        currentTotal -= netWithdrawal + taxOnWithdrawal;
+        currentTotal -= grossWithdrawal;
         if (currentTotal < 0) currentTotal = 0;
       }
     }

--- a/apps/web/src/components/charts/compound-simulator/generate-summary.test.tsx
+++ b/apps/web/src/components/charts/compound-simulator/generate-summary.test.tsx
@@ -175,6 +175,21 @@ describe("generateSummary", () => {
       expect(text).toContain("以降インフレ率に応じて増額します");
     });
 
+    test("uses the grossed-up tax rate in the effective withdrawal rate", () => {
+      const text = renderText({
+        ...baseInput,
+        withdrawalYears: 25,
+        withdrawalMode: "rate",
+        withdrawalRate: 4,
+        monthlyWithdrawal: 50_000,
+        finalTotal: 796_850,
+        finalPrincipal: 0,
+        finalInterest: 796_850,
+      });
+
+      expect(text).toContain("実質引出率は約5.0%");
+    });
+
     test("generates rate mode summary text without effective rate when taxFree", () => {
       const text = renderText({
         ...baseInput,

--- a/apps/web/src/components/charts/compound-simulator/generate-summary.tsx
+++ b/apps/web/src/components/charts/compound-simulator/generate-summary.tsx
@@ -199,7 +199,7 @@ export function generateSummary(input: SummaryInput): ReactNode {
           grossPortfolio > finalPrincipal && grossPortfolio > 0
             ? (grossPortfolio - finalPrincipal) / grossPortfolio
             : 0;
-        const effectiveRate = withdrawalRate * (1 + gainRatio * TAX_RATE);
+        const effectiveRate = withdrawalRate / (1 - gainRatio * TAX_RATE);
         const taxImpact =
           effectiveRate > withdrawalRate * 1.01
             ? `手取り年${withdrawalRate}%に利益部分への課税が加わり、`

--- a/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.test.ts
+++ b/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.test.ts
@@ -766,6 +766,28 @@ describe("simulateMonteCarlo", () => {
   });
 
   describe("inflation-adjusted withdrawal", () => {
+    it("should reset the real withdrawal at each annual boundary", () => {
+      const result = simulateMonteCarlo({
+        initialAmount: 10_000_000,
+        monthlyContribution: 0,
+        annualReturnRate: 3,
+        volatility: 0,
+        inflationRate: 3,
+        contributionYears: 0,
+        withdrawalStartYear: 0,
+        monthlyWithdrawal: 100_000,
+        withdrawalYears: 2,
+        inflationAdjustedWithdrawal: true,
+        taxFree: true,
+      });
+
+      const firstYearWithdrawal = result.yearlyData[0].p50 - result.yearlyData[1].p50;
+      const secondYearWithdrawal = result.yearlyData[1].p50 - result.yearlyData[2].p50;
+
+      expect(firstYearWithdrawal).toBeLessThan(1_200_000);
+      expect(secondYearWithdrawal).toBeCloseTo(firstYearWithdrawal, -1);
+    });
+
     it("should deplete faster with inflation-adjusted withdrawal", () => {
       const base = {
         initialAmount: 5_000_000,

--- a/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.test.ts
+++ b/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.test.ts
@@ -788,6 +788,30 @@ describe("simulateMonteCarlo", () => {
       expect(secondYearWithdrawal).toBeCloseTo(firstYearWithdrawal, -1);
     });
 
+    it("should deflate income with the withdrawal within each year", () => {
+      const base = {
+        initialAmount: 10_000_000,
+        monthlyContribution: 0,
+        annualReturnRate: 3,
+        volatility: 0,
+        inflationRate: 3,
+        contributionYears: 0,
+        withdrawalStartYear: 0,
+        monthlyWithdrawal: 100_000,
+        withdrawalYears: 2,
+        inflationAdjustedWithdrawal: true,
+        taxFree: true,
+      };
+      const withoutIncome = simulateMonteCarlo(base);
+      const withIncome = simulateMonteCarlo({ ...base, monthlyOtherIncome: 90_000 });
+      const firstYearIncome = withIncome.yearlyData[1].p50 - withoutIncome.yearlyData[1].p50;
+      const secondYearIncome =
+        withIncome.yearlyData[2].p50 - withoutIncome.yearlyData[2].p50 - firstYearIncome;
+
+      expect(firstYearIncome).toBeLessThan(90_000 * 12);
+      expect(secondYearIncome).toBeCloseTo(firstYearIncome, -1);
+    });
+
     it("should deplete faster with inflation-adjusted withdrawal", () => {
       const base = {
         initialAmount: 5_000_000,

--- a/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.test.ts
+++ b/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.test.ts
@@ -809,7 +809,7 @@ describe("simulateMonteCarlo", () => {
         withIncome.yearlyData[2].p50 - withoutIncome.yearlyData[2].p50 - firstYearIncome;
 
       expect(firstYearIncome).toBeLessThan(90_000 * 12);
-      expect(secondYearIncome).toBeCloseTo(firstYearIncome, -1);
+      expect(secondYearIncome).toBeCloseTo(firstYearIncome / 1.03, -1);
     });
 
     it("should deplete faster with inflation-adjusted withdrawal", () => {

--- a/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.test.ts
+++ b/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.test.ts
@@ -566,6 +566,28 @@ describe("simulateMonteCarlo", () => {
         expect(yd.medianYearlyWithdrawal).toBe(firstWithdrawal);
       }
     });
+
+    it("should match a standalone run for a withdrawal-rate sensitivity row", () => {
+      const base = {
+        initialAmount: 10_000_000,
+        monthlyContribution: 50_000,
+        annualReturnRate: 5,
+        volatility: 15,
+        inflationRate: 2,
+        contributionYears: 10,
+        withdrawalStartYear: 10,
+        annualWithdrawalRate: 4,
+        withdrawalYears: 25,
+      };
+      const sensitivity = simulateMonteCarlo({ ...base, rateDeltas: [-1] });
+      const standalone = simulateMonteCarlo({ ...base, annualWithdrawalRate: 3, rateDeltas: [0] });
+      const sensitivityRow = sensitivity.sensitivityRows!.find((row) => row.delta === -1)!;
+      const standaloneRow = standalone.sensitivityRows!.find((row) => row.delta === 0)!;
+
+      expect(sensitivityRow.depletionProbability).toBe(standaloneRow.depletionProbability);
+      expect(sensitivityRow.medianFinalBalance).toBe(standaloneRow.medianFinalBalance);
+      expect(sensitivityRow.securityScore).toBe(standaloneRow.securityScore);
+    });
   });
 
   describe("immediate withdrawal (no contribution)", () => {
@@ -1140,6 +1162,7 @@ describe("simulateMonteCarlo", () => {
       // Same z values, same computation → same results
       expect(row60kFromBase60k!.depletionProbability).toBe(row60kFromBase50k!.depletionProbability);
       expect(row60kFromBase60k!.medianFinalBalance).toBe(row60kFromBase50k!.medianFinalBalance);
+      expect(row60kFromBase60k!.securityScore).toBe(row60kFromBase50k!.securityScore);
     });
 
     it("returns undefined sensitivityRows when no deltas provided", () => {
@@ -1152,6 +1175,23 @@ describe("simulateMonteCarlo", () => {
   });
 
   describe("probability invariant", () => {
+    it("counts only withdrawals that the portfolio can actually fund", () => {
+      const result = simulateMonteCarlo({
+        initialAmount: 1_000_000,
+        monthlyContribution: 0,
+        annualReturnRate: -50,
+        volatility: 0,
+        inflationRate: 0,
+        contributionYears: 0,
+        withdrawalStartYear: 0,
+        monthlyWithdrawal: 10_000_000,
+        withdrawalYears: 1,
+      });
+
+      expect(result.depletionProbability).toBe(1);
+      expect(result.failureProbability).toBe(1);
+    });
+
     it("failureProbability accounts for cumulative withdrawals (total return metric)", () => {
       const result = simulateMonteCarlo({
         initialAmount: 5_000_000,

--- a/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.ts
+++ b/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.ts
@@ -108,11 +108,10 @@ export function simulateMonteCarlo({
   const monthlyDrift = (mu - ri - (sigma * sigma) / 2) / 12;
   const monthlySigma = sigma / Math.sqrt(12);
   const isRateMode = annualWithdrawalRate != null && annualWithdrawalRate > 0;
-  // MC operates in real (inflation-adjusted) terms.
-  // - Nominal fixed withdrawal decreases in real terms → deflate each month
-  // - Inflation-adjusted withdrawal stays constant in real terms → no adjustment
-  const monthlyRealWithdrawalFactor =
-    !isRateMode && !inflationAdjustedWithdrawal && ri > 0 ? 1 / Math.pow(1 + ri, 1 / 12) : 1;
+  // MC operates in real (inflation-adjusted) terms. A nominal withdrawal stays
+  // fixed within each year, so its real value declines monthly. An annually
+  // inflation-adjusted withdrawal resets to its starting real value each year.
+  const monthlyRealWithdrawalFactor = !isRateMode && ri > 0 ? 1 / Math.pow(1 + ri, 1 / 12) : 1;
 
   const totalYears = Math.max(contributionYears, withdrawalStartYear + withdrawalYears);
 
@@ -203,6 +202,9 @@ export function simulateMonteCarlo({
       year > withdrawalStartYear && year <= withdrawalStartYear + withdrawalYears;
 
     if (yearlyWithdrawals) yearlyWithdrawals.fill(0);
+    if (isWithdrawing && !isRateMode && inflationAdjustedWithdrawal) {
+      currentMonthlyWithdrawal = monthlyWithdrawal;
+    }
 
     if (isWithdrawing && isRateMode) {
       if (initialWithdrawalAmount && initialWithdrawalSeeded) {

--- a/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.ts
+++ b/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.ts
@@ -125,11 +125,15 @@ export function simulateMonteCarlo({
   const extraCostBasis: Float64Array[] = [];
   const extraInitialWithdrawal: (Float64Array | null)[] = [];
   const extraInitialWithdrawalSeeded: (Uint8Array | null)[] = [];
+  const extraCumulativeWithdrawals: Float64Array[] = [];
+  const extraWithdrawalNeeded: Uint8Array[] = [];
   for (let d = 0; d < numExtra; d++) {
     extraPaths.push(new Float64Array(NUM_SIMULATIONS).fill(initialAmount));
     extraCostBasis.push(new Float64Array(NUM_SIMULATIONS).fill(initialAmount));
     extraInitialWithdrawal.push(isRateMode ? new Float64Array(NUM_SIMULATIONS) : null);
     extraInitialWithdrawalSeeded.push(isRateMode ? new Uint8Array(NUM_SIMULATIONS) : null);
+    extraCumulativeWithdrawals.push(new Float64Array(NUM_SIMULATIONS));
+    extraWithdrawalNeeded.push(new Uint8Array(NUM_SIMULATIONS));
   }
 
   // Sensitivity analysis: rate variants (for rate mode)
@@ -142,11 +146,15 @@ export function simulateMonteCarlo({
   const rateCostBasis: Float64Array[] = [];
   const rateInitialW: Float64Array[] = [];
   const rateInitialWSeeded: Uint8Array[] = [];
+  const rateCumulativeWithdrawals: Float64Array[] = [];
+  const rateWithdrawalNeeded: Uint8Array[] = [];
   for (let d = 0; d < numRateExtra; d++) {
     ratePaths.push(new Float64Array(NUM_SIMULATIONS).fill(initialAmount));
     rateCostBasis.push(new Float64Array(NUM_SIMULATIONS).fill(initialAmount));
     rateInitialW.push(new Float64Array(NUM_SIMULATIONS));
     rateInitialWSeeded.push(new Uint8Array(NUM_SIMULATIONS));
+    rateCumulativeWithdrawals.push(new Float64Array(NUM_SIMULATIONS));
+    rateWithdrawalNeeded.push(new Uint8Array(NUM_SIMULATIONS));
   }
 
   const paths = new Float64Array(NUM_SIMULATIONS).fill(initialAmount);
@@ -179,6 +187,7 @@ export function simulateMonteCarlo({
   const initialWithdrawalSeeded = isRateMode ? new Uint8Array(NUM_SIMULATIONS) : null;
   // Track cumulative net withdrawals per path for total-return failure metric
   const cumulativeWithdrawals = new Float64Array(NUM_SIMULATIONS);
+  const withdrawalNeeded = new Uint8Array(NUM_SIMULATIONS);
   // Deflate nominal withdrawal by inflation accumulated before withdrawal starts.
   // MC operates in real terms: a nominal fixed withdrawal loses purchasing power
   // over time, so we must account for the inflation during the pre-withdrawal period.
@@ -245,7 +254,7 @@ export function simulateMonteCarlo({
           costBasis[i] += monthlyContribution;
         }
 
-        if (isWithdrawing && paths[i] > 0) {
+        if (isWithdrawing) {
           let baseWithdrawal: number;
           if (isRateMode && initialWithdrawalAmount) {
             baseWithdrawal = initialWithdrawalAmount[i];
@@ -254,15 +263,21 @@ export function simulateMonteCarlo({
           }
           const pensionActive = pensionStartYear != null && year >= pensionStartYear;
           const income = (pensionActive ? monthlyPensionIncome : 0) + monthlyOtherIncome;
-          const netWithdrawal = Math.max(baseWithdrawal - income, 0);
-          if (yearlyWithdrawals) yearlyWithdrawals[i] += netWithdrawal;
-          cumulativeWithdrawals[i] += netWithdrawal;
-          const gainRatio = paths[i] > costBasis[i] ? (paths[i] - costBasis[i]) / paths[i] : 0;
-          const taxOnWithdrawal = netWithdrawal * gainRatio * taxRate;
-          const withdrawalRatio = Math.min(netWithdrawal / paths[i], 1);
-          costBasis[i] *= 1 - withdrawalRatio;
-          paths[i] = paths[i] - netWithdrawal - taxOnWithdrawal;
-          if (paths[i] < 0) paths[i] = 0;
+          const requestedNetWithdrawal = Math.max(baseWithdrawal - income, 0);
+          if (requestedNetWithdrawal > 0) withdrawalNeeded[i] = 1;
+          if (paths[i] > 0) {
+            const gainRatio = paths[i] > costBasis[i] ? (paths[i] - costBasis[i]) / paths[i] : 0;
+            const effectiveTaxRate = gainRatio * taxRate;
+            const requiredGrossWithdrawal =
+              requestedNetWithdrawal / Math.max(1 - effectiveTaxRate, Number.EPSILON);
+            const grossWithdrawal = Math.min(requiredGrossWithdrawal, paths[i]);
+            const actualNetWithdrawal = grossWithdrawal * (1 - effectiveTaxRate);
+            if (yearlyWithdrawals) yearlyWithdrawals[i] += actualNetWithdrawal;
+            cumulativeWithdrawals[i] += actualNetWithdrawal;
+            const withdrawalRatio = grossWithdrawal / paths[i];
+            costBasis[i] *= 1 - withdrawalRatio;
+            paths[i] -= grossWithdrawal;
+          }
         }
 
         // Sensitivity analysis: extra contribution variants
@@ -273,7 +288,7 @@ export function simulateMonteCarlo({
             extraPaths[d][i] += mc;
             extraCostBasis[d][i] += mc;
           }
-          if (isWithdrawing && extraPaths[d][i] > 0) {
+          if (isWithdrawing) {
             let baseW: number;
             const ewa = extraInitialWithdrawal[d];
             if (isRateMode && ewa) {
@@ -284,16 +299,22 @@ export function simulateMonteCarlo({
             const pensionActiveExtra = pensionStartYear != null && year >= pensionStartYear;
             const incomeExtra =
               (pensionActiveExtra ? monthlyPensionIncome : 0) + monthlyOtherIncome;
-            const netW = Math.max(baseW - incomeExtra, 0);
-            const gr =
-              extraPaths[d][i] > extraCostBasis[d][i]
-                ? (extraPaths[d][i] - extraCostBasis[d][i]) / extraPaths[d][i]
-                : 0;
-            const tw = netW * gr * taxRate;
-            const wr = Math.min(netW / extraPaths[d][i], 1);
-            extraCostBasis[d][i] *= 1 - wr;
-            extraPaths[d][i] = extraPaths[d][i] - netW - tw;
-            if (extraPaths[d][i] < 0) extraPaths[d][i] = 0;
+            const requestedNetW = Math.max(baseW - incomeExtra, 0);
+            if (requestedNetW > 0) extraWithdrawalNeeded[d][i] = 1;
+            if (extraPaths[d][i] > 0) {
+              const gr =
+                extraPaths[d][i] > extraCostBasis[d][i]
+                  ? (extraPaths[d][i] - extraCostBasis[d][i]) / extraPaths[d][i]
+                  : 0;
+              const effectiveTaxRate = gr * taxRate;
+              const requiredGrossW = requestedNetW / Math.max(1 - effectiveTaxRate, Number.EPSILON);
+              const grossW = Math.min(requiredGrossW, extraPaths[d][i]);
+              const actualNetW = grossW * (1 - effectiveTaxRate);
+              extraCumulativeWithdrawals[d][i] += actualNetW;
+              const wr = grossW / extraPaths[d][i];
+              extraCostBasis[d][i] *= 1 - wr;
+              extraPaths[d][i] -= grossW;
+            }
           }
         }
 
@@ -304,21 +325,27 @@ export function simulateMonteCarlo({
             ratePaths[d][i] += monthlyContribution;
             rateCostBasis[d][i] += monthlyContribution;
           }
-          if (isWithdrawing && ratePaths[d][i] > 0) {
+          if (isWithdrawing) {
             const rwa = rateInitialW[d];
             const baseW = rwa[i];
             const pensionActiveR = pensionStartYear != null && year >= pensionStartYear;
             const incomeR = (pensionActiveR ? monthlyPensionIncome : 0) + monthlyOtherIncome;
-            const netW = Math.max(baseW - incomeR, 0);
-            const gr =
-              ratePaths[d][i] > rateCostBasis[d][i]
-                ? (ratePaths[d][i] - rateCostBasis[d][i]) / ratePaths[d][i]
-                : 0;
-            const tw = netW * gr * taxRate;
-            const wr = Math.min(netW / ratePaths[d][i], 1);
-            rateCostBasis[d][i] *= 1 - wr;
-            ratePaths[d][i] = ratePaths[d][i] - netW - tw;
-            if (ratePaths[d][i] < 0) ratePaths[d][i] = 0;
+            const requestedNetW = Math.max(baseW - incomeR, 0);
+            if (requestedNetW > 0) rateWithdrawalNeeded[d][i] = 1;
+            if (ratePaths[d][i] > 0) {
+              const gr =
+                ratePaths[d][i] > rateCostBasis[d][i]
+                  ? (ratePaths[d][i] - rateCostBasis[d][i]) / ratePaths[d][i]
+                  : 0;
+              const effectiveTaxRate = gr * taxRate;
+              const requiredGrossW = requestedNetW / Math.max(1 - effectiveTaxRate, Number.EPSILON);
+              const grossW = Math.min(requiredGrossW, ratePaths[d][i]);
+              const actualNetW = grossW * (1 - effectiveTaxRate);
+              rateCumulativeWithdrawals[d][i] += actualNetW;
+              const wr = grossW / ratePaths[d][i];
+              rateCostBasis[d][i] *= 1 - wr;
+              ratePaths[d][i] -= grossW;
+            }
           }
         }
       }
@@ -335,7 +362,7 @@ export function simulateMonteCarlo({
     if (isWithdrawing) {
       for (let i = 0; i < NUM_SIMULATIONS; i++) {
         // 枯渇 = ポートフォリオが0 かつ 実際に引出しが必要だった（収入だけではカバーできない）
-        if (paths[i] <= 0 && cumulativeWithdrawals[i] > 0) yearDepletionCount++;
+        if (paths[i] <= 0 && withdrawalNeeded[i] > 0) yearDepletionCount++;
       }
     }
 
@@ -379,7 +406,7 @@ export function simulateMonteCarlo({
 
   let depletedCnt = 0;
   for (let i = 0; i < NUM_SIMULATIONS; i++) {
-    if (paths[i] <= 0 && cumulativeWithdrawals[i] > 0) depletedCnt++;
+    if (paths[i] <= 0 && withdrawalNeeded[i] > 0) depletedCnt++;
   }
   if (depletedCnt > 0) {
     distribution.push({ rangeEnd: 0, count: depletedCnt, isDepleted: true });
@@ -434,8 +461,10 @@ export function simulateMonteCarlo({
       let rateFailureCount = 0;
       if (withdrawalYears > 0) {
         for (let i = 0; i < NUM_SIMULATIONS; i++) {
-          if (ratePaths[idx][i] <= 0) depletedCount++;
-          if (ratePaths[idx][i] + cumulativeWithdrawals[i] < totalPrincipal) rateFailureCount++;
+          if (ratePaths[idx][i] <= 0 && rateWithdrawalNeeded[idx][i] > 0) depletedCount++;
+          if (ratePaths[idx][i] + rateCumulativeWithdrawals[idx][i] < totalPrincipal) {
+            rateFailureCount++;
+          }
         }
       }
       const dp = withdrawalYears > 0 ? depletedCount / NUM_SIMULATIONS : 0;
@@ -471,12 +500,16 @@ export function simulateMonteCarlo({
         };
       }
       const idx = validExtraDeltas.indexOf(delta);
+      const adjustedTotalPrincipal =
+        initialAmount + (monthlyContribution + delta) * contributionYears * 12;
       let depletedCount = 0;
       let extraFailureCount = 0;
       if (withdrawalYears > 0) {
         for (let i = 0; i < NUM_SIMULATIONS; i++) {
-          if (extraPaths[idx][i] <= 0) depletedCount++;
-          if (extraPaths[idx][i] + cumulativeWithdrawals[i] < totalPrincipal) extraFailureCount++;
+          if (extraPaths[idx][i] <= 0 && extraWithdrawalNeeded[idx][i] > 0) depletedCount++;
+          if (extraPaths[idx][i] + extraCumulativeWithdrawals[idx][i] < adjustedTotalPrincipal) {
+            extraFailureCount++;
+          }
         }
       }
       const dp = withdrawalYears > 0 ? depletedCount / NUM_SIMULATIONS : 0;

--- a/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.ts
+++ b/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.ts
@@ -205,6 +205,7 @@ export function simulateMonteCarlo({
     if (isWithdrawing && !isRateMode && inflationAdjustedWithdrawal) {
       currentMonthlyWithdrawal = monthlyWithdrawal;
     }
+    let annualRealIncomeFactor = 1;
 
     if (isWithdrawing && isRateMode) {
       if (initialWithdrawalAmount && initialWithdrawalSeeded) {
@@ -244,6 +245,9 @@ export function simulateMonteCarlo({
     for (let month = 0; month < 12; month++) {
       if (isWithdrawing && !isRateMode) {
         currentMonthlyWithdrawal *= monthlyRealWithdrawalFactor;
+        if (inflationAdjustedWithdrawal) {
+          annualRealIncomeFactor *= monthlyRealWithdrawalFactor;
+        }
       }
       for (let i = 0; i < NUM_SIMULATIONS; i++) {
         const z = normalRandom(rng);
@@ -264,7 +268,8 @@ export function simulateMonteCarlo({
             baseWithdrawal = currentMonthlyWithdrawal;
           }
           const pensionActive = pensionStartYear != null && year >= pensionStartYear;
-          const income = (pensionActive ? monthlyPensionIncome : 0) + monthlyOtherIncome;
+          const nominalIncome = (pensionActive ? monthlyPensionIncome : 0) + monthlyOtherIncome;
+          const income = nominalIncome * annualRealIncomeFactor;
           const requestedNetWithdrawal = Math.max(baseWithdrawal - income, 0);
           if (requestedNetWithdrawal > 0) withdrawalNeeded[i] = 1;
           if (paths[i] > 0) {
@@ -299,8 +304,9 @@ export function simulateMonteCarlo({
               baseW = currentMonthlyWithdrawal;
             }
             const pensionActiveExtra = pensionStartYear != null && year >= pensionStartYear;
-            const incomeExtra =
+            const nominalIncomeExtra =
               (pensionActiveExtra ? monthlyPensionIncome : 0) + monthlyOtherIncome;
+            const incomeExtra = nominalIncomeExtra * annualRealIncomeFactor;
             const requestedNetW = Math.max(baseW - incomeExtra, 0);
             if (requestedNetW > 0) extraWithdrawalNeeded[d][i] = 1;
             if (extraPaths[d][i] > 0) {

--- a/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.ts
+++ b/apps/web/src/components/charts/compound-simulator/simulate-monte-carlo.ts
@@ -205,7 +205,9 @@ export function simulateMonteCarlo({
     if (isWithdrawing && !isRateMode && inflationAdjustedWithdrawal) {
       currentMonthlyWithdrawal = monthlyWithdrawal;
     }
-    let annualRealIncomeFactor = 1;
+    const withdrawalYearIndex = Math.max(year - withdrawalStartYear - 1, 0);
+    let annualRealIncomeFactor =
+      inflationAdjustedWithdrawal && ri > 0 ? Math.pow(1 + ri, -withdrawalYearIndex) : 1;
 
     if (isWithdrawing && isRateMode) {
       if (initialWithdrawalAmount && initialWithdrawalSeeded) {


### PR DESCRIPTION
# Summary

- Calculate taxable withdrawals by grossing up the requested net amount, while capping withdrawals at the available portfolio balance.
- Count only withdrawals actually funded by the portfolio in Monte Carlo return metrics.
- Track cumulative withdrawals, depletion state, and invested principal independently for every sensitivity scenario.
- Apply inflation adjustments to fixed withdrawals at yearly boundaries, matching the simulator UI description.
- Add regression coverage for depletion boundaries and standalone/sensitivity result consistency.

## Linear Issue

- N/A

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability — functional correctness | The change affects balances, withdrawal tax, depletion probability, and security scores. | Funded withdrawals never exceed available assets; sensitivity rows match equivalent standalone runs; inflation increases occur annually. |
| Reliability — fault tolerance | Depleted portfolios and extreme withdrawal requests are high-risk boundary states. | A portfolio that cannot fund a request remains at zero and records only the amount actually delivered without producing invalid probabilities. |
| Maintainability — analysability | Three Monte Carlo path families must use equivalent accounting rules. | Base, contribution-sensitivity, and rate-sensitivity paths use the same withdrawal and failure-accounting semantics, covered by cross-run tests. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Boundary value analysis | Portfolio depletion and annual inflation transitions are boundary-sensitive. | Withdrawal larger than balance; first and second inflation-adjusted years. |
| Equivalence partitioning | Base and sensitivity executions should be equivalent for identical effective inputs. | Contribution and withdrawal-rate sensitivity rows match standalone simulations. |
| Decision table testing | Taxable/tax-free, funded/depleted, and amount/rate modes select different calculation branches. | Existing simulator unit suite plus the new branch-specific regressions. |
| State transition testing | Accumulation, withdrawal, and depleted states change how balances and counters evolve. | Actual funded withdrawals and depletion state persist correctly across simulation periods. |

### Primary Test Conditions

- Fixed withdrawals adjusted for inflation remain constant during a year and increase at the next yearly boundary.
- Taxable withdrawals gross up the requested net amount and cannot exceed the current balance.
- An underperforming portfolio with an oversized withdrawal records depletion and principal loss.
- Contribution and rate sensitivity rows produce the same balance, depletion probability, and security score as equivalent standalone runs.
- Sensitivity scenarios compare recovered assets against their own invested principal.

### Out-of-Scope Risks

- Pension start-year bucket semantics were not changed because this PR is limited to the confirmed calculation defects.
- Monte Carlo model assumptions such as return distribution and fixed real contribution semantics were not changed.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [ ] Storybook tests
- [ ] E2E tests
- [ ] Manual verification

### Commands Executed

```text
pnpm exec vitest run --project unit src/components/charts/compound-simulator/calculate-compound.test.ts src/components/charts/compound-simulator/simulate-monte-carlo.test.ts — passed, 115 tests
pnpm --filter @mf-dashboard/web test:unit — passed, 47 files / 648 tests
pnpm --filter @mf-dashboard/web typecheck — passed
pnpm lint — passed
pnpm format:check — passed
pnpm test — simulator-related packages passed, but the run failed in packages/db/src/demo-data.test.ts because 21 demo asset-history rows are later than the current snapshot date; the parallel web task then exited with EPIPE
```

### Checks Not Run

- Storybook tests — no stories or rendered UI changed.
- E2E tests — calculation behavior is covered directly by deterministic unit tests.
- Manual verification — no browser-facing layout or interaction changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inflation-adjusted withdrawal calculations, ensuring annual increases occur at the correct times.
  * Corrected tax handling for withdrawals and accurately recorded the net amount received.
  * Prevented withdrawals from exceeding the available portfolio balance.
  * Improved portfolio depletion and failure calculations when withdrawals are unaffordable or unnecessary.

* **Tests**
  * Added coverage for withdrawal timing, tax adjustments, balance limits, and simulation consistency across varying withdrawal rates and contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->