### PR TITLE
feat(web): show balance sheet allocation ratios

### DIFF
--- a/apps/web/src/components/info/balance-sheet-chart.client.test.ts
+++ b/apps/web/src/components/info/balance-sheet-chart.client.test.ts
@@ -3,9 +3,10 @@ import { formatAssetShare, getBalanceSheetChartOrder } from "./balance-sheet-cha
 
 describe("formatAssetShare", () => {
   it.each([
-    [3_000_000, 12_000_000, "(25.0%)"],
-    [-100, 1_000, "(-10.0%)"],
-    [100, 0, "(0.0%)"],
+    [3_000_000, 12_000_000, "(025.0%)"],
+    [67, 1_000, "(006.7%)"],
+    [-100, 1_000, "(-010.0%)"],
+    [100, 0, "(000.0%)"],
   ])("%s円 / %s円を%sと表示する", (amount, totalAssets, expected) => {
     expect(formatAssetShare(amount, totalAssets)).toBe(expected);
   });

--- a/apps/web/src/components/info/balance-sheet-chart.client.test.ts
+++ b/apps/web/src/components/info/balance-sheet-chart.client.test.ts
@@ -3,10 +3,11 @@ import { formatAssetShare, getBalanceSheetChartOrder } from "./balance-sheet-cha
 
 describe("formatAssetShare", () => {
   it.each([
-    [3_000_000, 12_000_000, "(025.0%)"],
-    [67, 1_000, "(006.7%)"],
-    [-100, 1_000, "(-010.0%)"],
-    [100, 0, "(000.0%)"],
+    [3_000_000, 12_000_000, "(25.0%)"],
+    [67, 1_000, "(06.7%)"],
+    [1_000, 1_000, "(100.0%)"],
+    [-100, 1_000, "(-10.0%)"],
+    [100, 0, "(00.0%)"],
   ])("%s円 / %s円を%sと表示する", (amount, totalAssets, expected) => {
     expect(formatAssetShare(amount, totalAssets)).toBe(expected);
   });

--- a/apps/web/src/components/info/balance-sheet-chart.client.test.ts
+++ b/apps/web/src/components/info/balance-sheet-chart.client.test.ts
@@ -3,7 +3,7 @@ import { formatAssetShare, getBalanceSheetChartOrder } from "./balance-sheet-cha
 
 describe("formatAssetShare", () => {
   it.each([
-    [3_000_000, 11_500_000, "(26.1%)"],
+    [3_000_000, 12_000_000, "(25.0%)"],
     [-100, 1_000, "(-10.0%)"],
     [100, 0, "(0.0%)"],
   ])("%s円 / %s円を%sと表示する", (amount, totalAssets, expected) => {

--- a/apps/web/src/components/info/balance-sheet-chart.client.test.ts
+++ b/apps/web/src/components/info/balance-sheet-chart.client.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { getBalanceSheetChartOrder } from "./balance-sheet-chart.client";
+import { formatAssetShare, getBalanceSheetChartOrder } from "./balance-sheet-chart.client";
+
+describe("formatAssetShare", () => {
+  it.each([
+    [3_000_000, 11_500_000, "(26.1%)"],
+    [-100, 1_000, "(-10.0%)"],
+    [100, 0, "(0.0%)"],
+  ])("%s円 / %s円を%sと表示する", (amount, totalAssets, expected) => {
+    expect(formatAssetShare(amount, totalAssets)).toBe(expected);
+  });
+});
 
 describe("getBalanceSheetChartOrder", () => {
   it("凡例を金額降順、同額は項目名順にし、積み上げ順を反転する", () => {

--- a/apps/web/src/components/info/balance-sheet-chart.client.test.ts
+++ b/apps/web/src/components/info/balance-sheet-chart.client.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { formatAssetShare, getBalanceSheetChartOrder } from "./balance-sheet-chart.client";
+import { formatBalanceSheetShare, getBalanceSheetChartOrder } from "./balance-sheet-chart.client";
 
-describe("formatAssetShare", () => {
+describe("formatBalanceSheetShare", () => {
   it.each([
     [3_000_000, 12_000_000, "(25.0%)"],
     [67, 1_000, "(06.7%)"],
     [1_000, 1_000, "(100.0%)"],
     [-100, 1_000, "(-10.0%)"],
     [100, 0, "(00.0%)"],
-  ])("%s円 / %s円を%sと表示する", (amount, totalAssets, expected) => {
-    expect(formatAssetShare(amount, totalAssets)).toBe(expected);
+  ])("%s円 / %s円を%sと表示する", (amount, total, expected) => {
+    expect(formatBalanceSheetShare(amount, total)).toBe(expected);
   });
 });
 

--- a/apps/web/src/components/info/balance-sheet-chart.client.tsx
+++ b/apps/web/src/components/info/balance-sheet-chart.client.tsx
@@ -15,6 +15,7 @@ interface BalanceSheetChartProps {
   assets: Array<{ category: string; amount: number }>;
   liabilities: Array<{ category: string; amount: number }>;
   netAssets: number;
+  totalAssets: number;
 }
 
 export function formatAssetShare(amount: number, totalAssets: number) {
@@ -56,6 +57,7 @@ export function BalanceSheetChartClient({
   assets,
   liabilities,
   netAssets,
+  totalAssets,
 }: BalanceSheetChartProps) {
   const [isMobile, setIsMobile] = useState(false);
 
@@ -66,7 +68,6 @@ export function BalanceSheetChartClient({
     return () => window.removeEventListener("resize", checkMobile);
   }, []);
 
-  const totalAssets = assets.reduce((sum, a) => sum + a.amount, 0);
   const totalLiabilities = liabilities.reduce((sum, l) => sum + l.amount, 0);
   const { orderedAssets, stackedAssetKeys, legendKeys, stackedBalanceKeys } =
     getBalanceSheetChartOrder(assets, totalLiabilities, netAssets);

--- a/apps/web/src/components/info/balance-sheet-chart.client.tsx
+++ b/apps/web/src/components/info/balance-sheet-chart.client.tsx
@@ -6,7 +6,6 @@ import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } fro
 import { sortByAmountDescending } from "../../lib/amount-order";
 import { CHART_INITIAL_DIMENSION } from "../../lib/chart";
 import { getAssetCategoryColor, semanticColors } from "../../lib/colors";
-import { formatPercent } from "../../lib/format";
 import { ChartTooltipContent } from "../charts/chart-tooltip";
 import { AmountDisplay } from "../ui/amount-display";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
@@ -20,7 +19,9 @@ interface BalanceSheetChartProps {
 
 export function formatAssetShare(amount: number, totalAssets: number) {
   const percentage = totalAssets === 0 ? 0 : (amount / totalAssets) * 100;
-  return `(${formatPercent(percentage)})`;
+  const sign = percentage < 0 ? "-" : "";
+  const paddedPercentage = Math.abs(percentage).toFixed(1).padStart(5, "0");
+  return `(${sign}${paddedPercentage}%)`;
 }
 
 export function getBalanceSheetChartOrder(

--- a/apps/web/src/components/info/balance-sheet-chart.client.tsx
+++ b/apps/web/src/components/info/balance-sheet-chart.client.tsx
@@ -17,8 +17,8 @@ interface BalanceSheetChartProps {
   totalAssets: number;
 }
 
-export function formatAssetShare(amount: number, totalAssets: number) {
-  const percentage = totalAssets === 0 ? 0 : (amount / totalAssets) * 100;
+export function formatBalanceSheetShare(amount: number, total: number) {
+  const percentage = total === 0 ? 0 : (amount / total) * 100;
   const sign = percentage < 0 ? "-" : "";
   const paddedPercentage = Math.abs(percentage).toFixed(1).padStart(4, "0");
   return `(${sign}${paddedPercentage}%)`;
@@ -121,11 +121,9 @@ export function BalanceSheetChartClient({
             </span>
             <span className="flex items-baseline gap-1">
               <AmountDisplay amount={p.value} weight="medium" />
-              {isAssetSide && (
-                <span className="text-muted-foreground lining-nums tabular-nums">
-                  {formatAssetShare(p.value, totalAssets)}
-                </span>
-              )}
+              <span className="text-muted-foreground lining-nums tabular-nums">
+                {formatBalanceSheetShare(p.value, total)}
+              </span>
             </span>
           </div>
         ))}

--- a/apps/web/src/components/info/balance-sheet-chart.client.tsx
+++ b/apps/web/src/components/info/balance-sheet-chart.client.tsx
@@ -20,7 +20,7 @@ interface BalanceSheetChartProps {
 export function formatAssetShare(amount: number, totalAssets: number) {
   const percentage = totalAssets === 0 ? 0 : (amount / totalAssets) * 100;
   const sign = percentage < 0 ? "-" : "";
-  const paddedPercentage = Math.abs(percentage).toFixed(1).padStart(5, "0");
+  const paddedPercentage = Math.abs(percentage).toFixed(1).padStart(4, "0");
   return `(${sign}${paddedPercentage}%)`;
 }
 
@@ -122,7 +122,7 @@ export function BalanceSheetChartClient({
             <span className="flex items-baseline gap-1">
               <AmountDisplay amount={p.value} weight="medium" />
               {isAssetSide && (
-                <span className="text-muted-foreground">
+                <span className="text-muted-foreground lining-nums tabular-nums">
                   {formatAssetShare(p.value, totalAssets)}
                 </span>
               )}

--- a/apps/web/src/components/info/balance-sheet-chart.client.tsx
+++ b/apps/web/src/components/info/balance-sheet-chart.client.tsx
@@ -6,6 +6,7 @@ import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } fro
 import { sortByAmountDescending } from "../../lib/amount-order";
 import { CHART_INITIAL_DIMENSION } from "../../lib/chart";
 import { getAssetCategoryColor, semanticColors } from "../../lib/colors";
+import { formatPercent } from "../../lib/format";
 import { ChartTooltipContent } from "../charts/chart-tooltip";
 import { AmountDisplay } from "../ui/amount-display";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
@@ -14,6 +15,11 @@ interface BalanceSheetChartProps {
   assets: Array<{ category: string; amount: number }>;
   liabilities: Array<{ category: string; amount: number }>;
   netAssets: number;
+}
+
+export function formatAssetShare(amount: number, totalAssets: number) {
+  const percentage = totalAssets === 0 ? 0 : (amount / totalAssets) * 100;
+  return `(${formatPercent(percentage)})`;
 }
 
 export function getBalanceSheetChartOrder(
@@ -111,7 +117,14 @@ export function BalanceSheetChartClient({
               <span className="w-3 h-3 rounded-sm" style={{ backgroundColor: p.fill }} />
               {p.name}
             </span>
-            <AmountDisplay amount={p.value} weight="medium" />
+            <span className="flex items-baseline gap-1">
+              <AmountDisplay amount={p.value} weight="medium" />
+              {isAssetSide && (
+                <span className="text-muted-foreground">
+                  {formatAssetShare(p.value, totalAssets)}
+                </span>
+              )}
+            </span>
           </div>
         ))}
         <div className="flex justify-between gap-4 mt-2 pt-2 border-t font-bold">

--- a/apps/web/src/components/info/balance-sheet-chart.stories.tsx
+++ b/apps/web/src/components/info/balance-sheet-chart.stories.tsx
@@ -1,5 +1,8 @@
-import { getAssetBreakdownByCategory, getLiabilityBreakdownByCategory } from "@mf-dashboard/db";
-import { getLatestMonthlySummary } from "@mf-dashboard/db";
+import {
+  getAssetBreakdownByCategory,
+  getLatestTotalAssets,
+  getLiabilityBreakdownByCategory,
+} from "@mf-dashboard/db";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { mocked } from "storybook/test";
 import { BalanceSheetChart } from "./balance-sheet-chart";
@@ -25,12 +28,7 @@ export const Default: Story = {
       { category: "住宅ローン", amount: 3000000 },
       { category: "カードローン", amount: 500000 },
     ]);
-    mocked(getLatestMonthlySummary).mockResolvedValue({
-      month: "2025-01",
-      totalIncome: 500000,
-      totalExpense: 300000,
-      netIncome: 200000,
-    });
+    mocked(getLatestTotalAssets).mockResolvedValue(12000000);
   },
 };
 
@@ -38,7 +36,7 @@ export const Empty: Story = {
   beforeEach() {
     mocked(getAssetBreakdownByCategory).mockResolvedValue([]);
     mocked(getLiabilityBreakdownByCategory).mockResolvedValue([]);
-    mocked(getLatestMonthlySummary).mockResolvedValue(undefined);
+    mocked(getLatestTotalAssets).mockResolvedValue(null);
   },
 };
 
@@ -49,11 +47,6 @@ export const NoLiabilities: Story = {
       { category: "株式(現物)", amount: 2000000 },
     ]);
     mocked(getLiabilityBreakdownByCategory).mockResolvedValue([]);
-    mocked(getLatestMonthlySummary).mockResolvedValue({
-      month: "2025-01",
-      totalIncome: 500000,
-      totalExpense: 300000,
-      netIncome: 200000,
-    });
+    mocked(getLatestTotalAssets).mockResolvedValue(10000000);
   },
 };

--- a/apps/web/src/components/info/balance-sheet-chart.tsx
+++ b/apps/web/src/components/info/balance-sheet-chart.tsx
@@ -24,6 +24,11 @@ export async function BalanceSheetChart({ groupId }: BalanceSheetChartProps) {
   const netAssets = totalAssets - totalLiabilities;
 
   return (
-    <BalanceSheetChartClient assets={assets} liabilities={liabilities} netAssets={netAssets} />
+    <BalanceSheetChartClient
+      assets={assets}
+      liabilities={liabilities}
+      netAssets={netAssets}
+      totalAssets={totalAssets}
+    />
   );
 }


### PR DESCRIPTION
# Summary

Display each balance-sheet category’s share of its side total in the tooltip, immediately after the amount: assets use authoritative total assets, while liabilities and net assets use the combined right-side total.

- Formats shares with one decimal place and a minimum two-digit integer portion, such as `(06.7%)`, `(25.0%)`, and `(100.0%)`.
- Applies `lining-nums tabular-nums` for stable numeric glyph alignment.
- Returns `(00.0%)` when a tooltip total is zero, avoiding `NaN` and `Infinity`.\n- Shows the same ratio format for liabilities and net assets while preserving all total rows.

## Linear Issue

- [HIR-178](https://linear.app/hiroppy/issue/HIR-178/保有資産の各項目に全体比率を表示する)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | Each displayed share must use the category amount and the correct side total. | Every asset, liability, and net-assets tooltip row shows the correct one-decimal percentage in parentheses. |
| Reliability | A zero total can otherwise produce non-finite output. | Zero-total input renders `(00.0%)`; no `NaN` or `Infinity` appears. |
| Usability | Ratios must be easy to scan without unnecessary three-digit padding. | Values use a minimum two-digit integer portion and lining/tabular numerals next to the amount. |
| Compatibility | Both balance-sheet sides and the responsive chart layout must remain intact. | Assets, liabilities, and net assets retain their category and total layout; existing Storybook and E2E checks stay green. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Equivalence partitioning | Covers positive, negative, and zero-total calculation classes. | Representative sign and fallback behavior. |
| Boundary value analysis | Covers zero total, a one-digit share, the two-to-three-digit transition at 100%, and fractional rounding. | Correct width and finite output at formatting boundaries. |
| Checklist-based testing | The user-facing behavior is a hover interaction. | Amount/share association, total preservation, numeric styling, and balance-side non-regression. |

### Primary Test Conditions

- Ordinary shares render as `(25.0%)`; one-digit shares render as `(06.7%)`.
- A full share renders as `(100.0%)` without truncation.
- Negative input preserves its sign; zero total renders `(00.0%)`.
- The authoritative asset total remains the denominator when visible asset category totals differ.\n- Liability and net-assets rows use the combined right-side total; total amounts remain unchanged.
- Runtime computed style includes `lining-nums tabular-nums`.

### Identified Risks

- Filtered asset categories can sum to less than authoritative total assets; the server-provided total is therefore passed explicitly.
- Fixed-width padding can conflict with 100% values; minimum-width formatting allows three digits when required.
- Numeric glyph widths vary by font; lining and tabular numeral variants are both applied.

### Out-of-Scope Risks

- Authenticated Money Forward crawling and source-data correctness are unchanged and outside this presentation-only change.
- Percentages above 100% from anomalous source data are not clamped; preserving the calculated value is intentional.

## Manual QA Evidence

Storybook Default confirms the authoritative 12M asset denominator. The anonymous demo walkthrough confirms ratios across all three sections: asset ratios remain visible, while the right-side tooltip shows net assets `(97.5%)` and liabilities `(02.5%)` against the combined `5,259,382円` total.

![Balance-sheet asset ratios](https://raw.githubusercontent.com/hiroppy/mf-dashboard/c14047c/docs/pr-media/hir-178-bs-asset-ratios.png)

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [x] Storybook tests
- [x] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/web test:unit — passed (53 files, 718 tests)
pnpm --filter @mf-dashboard/web test:storybook — passed (81 files, 355 tests)
pnpm turbo typecheck — passed (8 packages)
pnpm lint — passed
pnpm format:check — passed (596 files)
Storybook Default Playwright walkthrough — passed (authoritative total 12M, four ratios, lining/tabular computed style)
GitHub CI E2E — passed (3/3 shards and merged report)
```

### Checks Not Run

- N/A — all relevant checks were run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Balance sheet chart tooltips now show accurate percentage shares for assets and liabilities, including negative, fractional, and zero-total values.
  * Percentage calculations now use the appropriate total asset values for more reliable chart details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
