### PR TITLE
fix(web): simplify header update timestamp

### DIFF
--- a/apps/web/src/components/layout/action-icons.test.tsx
+++ b/apps/web/src/components/layout/action-icons.test.tsx
@@ -107,12 +107,12 @@ afterEach(() => {
 describe("ActionIcons", () => {
   it("shows only the last updated date and time without a divider or label", () => {
     const { container } = render(
-      <ActionIcons variant="header" lastScrapedAt="2025-04-30T10:30:00" />,
+      <ActionIcons variant="header" lastScrapedAt="2025-04-30T01:30:00.000Z" />,
     );
 
     const time = screen.getByText("4/30 10:30");
     expect(time.tagName).toBe("TIME");
-    expect(time.getAttribute("datetime")).toBe("2025-04-30T10:30:00");
+    expect(time.getAttribute("datetime")).toBe("2025-04-30T01:30:00.000Z");
     expect(screen.getByLabelText("最終更新 4/30 10:30")).toBe(time);
     expect(time.closest(".border-l")).toBeNull();
     expect(screen.queryByText("更新")).toBeNull();

--- a/apps/web/src/components/layout/action-icons.test.tsx
+++ b/apps/web/src/components/layout/action-icons.test.tsx
@@ -105,6 +105,25 @@ afterEach(() => {
 });
 
 describe("ActionIcons", () => {
+  it("shows only the last updated date and time without a divider or label", () => {
+    const { container } = render(
+      <ActionIcons variant="header" lastScrapedAt="2025-04-30T10:30:00" />,
+    );
+
+    const time = screen.getByText("4/30 10:30");
+    expect(time.tagName).toBe("TIME");
+    expect(time.getAttribute("datetime")).toBe("2025-04-30T10:30:00");
+    expect(time.closest(".border-l")).toBeNull();
+    expect(screen.queryByText("更新")).toBeNull();
+    expect(container.querySelectorAll("time")).toHaveLength(1);
+  });
+
+  it("does not show the last updated area when no date is available", () => {
+    const { container } = render(<ActionIcons variant="header" lastScrapedAt={null} />);
+
+    expect(container.querySelector("time")).toBeNull();
+  });
+
   it("describes the in-app AI assistant in the help dialog", () => {
     render(<ActionIcons variant="header" />);
 

--- a/apps/web/src/components/layout/action-icons.test.tsx
+++ b/apps/web/src/components/layout/action-icons.test.tsx
@@ -113,6 +113,7 @@ describe("ActionIcons", () => {
     const time = screen.getByText("4/30 10:30");
     expect(time.tagName).toBe("TIME");
     expect(time.getAttribute("datetime")).toBe("2025-04-30T10:30:00");
+    expect(screen.getByLabelText("最終更新 4/30 10:30")).toBe(time);
     expect(time.closest(".border-l")).toBeNull();
     expect(screen.queryByText("更新")).toBeNull();
     expect(container.querySelectorAll("time")).toHaveLength(1);

--- a/apps/web/src/components/layout/action-icons.tsx
+++ b/apps/web/src/components/layout/action-icons.tsx
@@ -372,12 +372,12 @@ function LastUpdatedAt({ lastScrapedAt }: LastUpdatedAtProps) {
   }
 
   return (
-    <div className="flex shrink-0 items-center gap-0.5 border-l pl-2">
-      <span className="whitespace-nowrap text-[11px] text-muted-foreground">
-        <span className="hidden sm:inline">更新 </span>
-        <time dateTime={lastScrapedAt ?? undefined}>{formattedLastScrapedAt}</time>
-      </span>
-    </div>
+    <time
+      className="shrink-0 whitespace-nowrap text-[11px] text-muted-foreground"
+      dateTime={lastScrapedAt ?? undefined}
+    >
+      {formattedLastScrapedAt}
+    </time>
   );
 }
 

--- a/apps/web/src/components/layout/action-icons.tsx
+++ b/apps/web/src/components/layout/action-icons.tsx
@@ -375,6 +375,7 @@ function LastUpdatedAt({ lastScrapedAt }: LastUpdatedAtProps) {
     <time
       className="shrink-0 whitespace-nowrap text-[11px] text-muted-foreground"
       dateTime={lastScrapedAt ?? undefined}
+      aria-label={`最終更新 ${formattedLastScrapedAt}`}
     >
       {formattedLastScrapedAt}
     </time>


### PR DESCRIPTION
# Summary

- Remove the visual divider and `更新` label from the header timestamp.
- Render the semantic `time` element directly while preserving timestamp formatting and missing-value behavior.
- Add regression coverage for timestamps with and without data.

## Linear Issue

- [HIR-180](https://linear.app/hiroppy/issue/HIR-180/headerの更新日時表示からと更新を削除)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | The visible timestamp must match the requested content exactly. | Header shows only the formatted date/time, without a divider or `更新`. |
| Usability | Removing redundant decoration should make the compact header clearer. | Timestamp remains readable and aligned with adjacent header actions. |
| Maintainability | The presentation should stay simple and regression-protected. | The timestamp uses one semantic element and focused tests cover both data states. |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| Equivalence partitioning | Timestamp presence determines whether the element renders. | Covers valid timestamp and absent timestamp partitions. |
| Checklist-based testing | The request has two exact visual removals and one retained value. | Confirms no divider, no label, and unchanged formatted date/time. |
| Regression testing | Header controls share the same component. | Confirms existing ActionIcons and Header tests remain green. |

### Primary Test Conditions

- A valid `lastScrapedAt` renders one `time` element with `4/30 10:30` and the original `datetime` value.
- The timestamp has no `border-l` ancestor and no `更新` label.
- A null timestamp renders no `time` element.
- The demo dashboard renders `8/3 09:00` in the header with no divider or label.

### Out-of-Scope Risks

- Responsive visual checks on every viewport are not included; the removed label was already hidden on smaller screens and the focused Storybook suite covers component rendering.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [x] Storybook tests
- [ ] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/web exec vitest run --project unit src/components/layout/action-icons.test.tsx src/components/layout/header.test.tsx — 2 files / 27 tests passed
pnpm --filter @mf-dashboard/web test:storybook — 81 files / 355 tests passed
pnpm --filter @mf-dashboard/web typecheck — passed
pnpm lint — passed
pnpm format:check — passed
pnpm knip — passed with one pre-existing configuration hint
pnpm --filter @mf-dashboard/db build:demo — demo database generated
pnpm --filter @mf-dashboard/web dev + Playwright inspection — header time `8/3 09:00`, no divider ancestor, no `更新` label
```

### Checks Not Run

- Full E2E suite — the change is isolated presentation logic covered by focused DOM assertions, the full Storybook suite, and a runtime Playwright inspection; CI will run repository E2E checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Simplified the header’s last-updated display by showing a styled date and time directly.
  * Removed the extra divider, padding, and visible “更新” label.
  * The display remains hidden when no update date is available.

* **Tests**
  * Added coverage for the updated timestamp display and its conditional visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->