### PR TITLE
fix(crawler): reject incomplete MoneyForward login

### DIFF
--- a/apps/crawler/src/auth/login.test.ts
+++ b/apps/crawler/src/auth/login.test.ts
@@ -1,0 +1,70 @@
+import type { Page } from "playwright";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const { debug, getCredentials, log } = vi.hoisted(() => ({
+  debug: vi.fn<(...args: unknown[]) => void>(),
+  getCredentials: vi.fn<() => Promise<{ password: string; username: string }>>(),
+  log: vi.fn<(...args: unknown[]) => void>(),
+}));
+
+vi.mock("../logger.js", () => ({ debug, log }));
+vi.mock("./credentials.js", () => ({
+  getCredentials,
+  getOTP: vi.fn<() => Promise<string>>(),
+}));
+
+import { login } from "./login.js";
+
+function createPage(url: string): Page {
+  const locator = {
+    click: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    fill: vi.fn<(value: string) => Promise<void>>().mockResolvedValue(undefined),
+    first: vi.fn<() => unknown>(),
+    waitFor: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  };
+  locator.first.mockReturnValue(locator);
+
+  const otpLocator = {
+    ...locator,
+    first: vi.fn<() => unknown>(),
+    waitFor: vi.fn<() => Promise<void>>().mockRejectedValue(new Error("OTP input is not visible")),
+  };
+  otpLocator.first.mockReturnValue(otpLocator);
+
+  return {
+    goto: vi.fn<() => Promise<null>>().mockResolvedValue(null),
+    locator: vi.fn<(selector: string) => unknown>((selector) =>
+      selector.includes("one-time-code") ? otpLocator : locator,
+    ),
+    url: vi.fn<() => string>(() => url),
+    waitForURL: vi.fn<(matcher: unknown) => Promise<void>>((matcher) => {
+      if (typeof matcher === "function") {
+        return Promise.reject(new Error("URL did not change"));
+      }
+      return Promise.resolve();
+    }),
+  } as unknown as Page;
+}
+
+describe("login", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCredentials.mockResolvedValue({
+      username: "user-a@example.com",
+      password: "test-password",
+    });
+  });
+
+  test("rejects when the browser remains on the MFID sign-in page", async () => {
+    const page = createPage("https://id.moneyforward.com/sign_in");
+
+    await expect(login(page)).rejects.toThrow("Login failed");
+    expect(log).not.toHaveBeenCalledWith("Login successful!");
+  });
+
+  test("resolves when the browser reaches Money Forward ME", async () => {
+    const page = createPage("https://moneyforward.com/");
+
+    await expect(login(page)).resolves.toBeUndefined();
+  });
+});

--- a/apps/crawler/src/auth/login.test.ts
+++ b/apps/crawler/src/auth/login.test.ts
@@ -37,6 +37,8 @@ function createPage(finalUrl: string, viaPassword = false): Page {
     goto: vi.fn<(url: string) => Promise<null>>().mockImplementation(async (url) => {
       if (url === mfUrls.signIn) {
         currentUrl = viaPassword ? mfUrls.auth.password : finalUrl;
+      } else if (url === mfUrls.accounts) {
+        currentUrl = finalUrl;
       }
       return null;
     }),
@@ -73,10 +75,17 @@ describe("login", () => {
   });
 
   test("resolves when the browser reaches Money Forward ME", async () => {
-    const page = createPage(mfUrls.home, true);
+    const page = createPage(mfUrls.accounts, true);
 
     await expect(login(page)).resolves.toBeUndefined();
     expect(log).toHaveBeenCalledWith("Login successful!");
+  });
+
+  test("rejects the public Money Forward home page", async () => {
+    const page = createPage(mfUrls.home);
+
+    await expect(login(page)).rejects.toThrow("Login failed");
+    expect(log).not.toHaveBeenCalledWith("Login successful!");
   });
 
   test("rejects a lookalike Money Forward origin", async () => {

--- a/apps/crawler/src/auth/login.test.ts
+++ b/apps/crawler/src/auth/login.test.ts
@@ -1,3 +1,4 @@
+import { mfUrls } from "@mf-dashboard/meta/urls";
 import type { Page } from "playwright";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -15,7 +16,8 @@ vi.mock("./credentials.js", () => ({
 
 import { login } from "./login.js";
 
-function createPage(url: string): Page {
+function createPage(finalUrl: string, viaPassword = false): Page {
+  let currentUrl: string = mfUrls.auth.signIn;
   const locator = {
     click: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     fill: vi.fn<(value: string) => Promise<void>>().mockResolvedValue(undefined),
@@ -32,14 +34,22 @@ function createPage(url: string): Page {
   otpLocator.first.mockReturnValue(otpLocator);
 
   return {
-    goto: vi.fn<() => Promise<null>>().mockResolvedValue(null),
+    goto: vi.fn<(url: string) => Promise<null>>().mockImplementation(async (url) => {
+      if (url === mfUrls.signIn) {
+        currentUrl = viaPassword ? mfUrls.auth.password : finalUrl;
+      }
+      return null;
+    }),
     locator: vi.fn<(selector: string) => unknown>((selector) =>
       selector.includes("one-time-code") ? otpLocator : locator,
     ),
-    url: vi.fn<() => string>(() => url),
+    url: vi.fn<() => string>(() => currentUrl),
     waitForURL: vi.fn<(matcher: unknown) => Promise<void>>((matcher) => {
       if (typeof matcher === "function") {
         return Promise.reject(new Error("URL did not change"));
+      }
+      if (typeof matcher === "string") {
+        currentUrl = finalUrl;
       }
       return Promise.resolve();
     }),
@@ -63,8 +73,16 @@ describe("login", () => {
   });
 
   test("resolves when the browser reaches Money Forward ME", async () => {
-    const page = createPage("https://moneyforward.com/");
+    const page = createPage(mfUrls.home, true);
 
     await expect(login(page)).resolves.toBeUndefined();
+    expect(log).toHaveBeenCalledWith("Login successful!");
+  });
+
+  test("rejects a lookalike Money Forward origin", async () => {
+    const page = createPage("https://moneyforward.com.attacker.example/");
+
+    await expect(login(page)).rejects.toThrow("Login failed");
+    expect(log).not.toHaveBeenCalledWith("Login successful!");
   });
 });

--- a/apps/crawler/src/auth/login.test.ts
+++ b/apps/crawler/src/auth/login.test.ts
@@ -16,8 +16,12 @@ vi.mock("./credentials.js", () => ({
 
 import { login } from "./login.js";
 
-function createPage(finalUrl: string, viaPassword = false): Page {
+function createPage(
+  finalUrl: string,
+  { abortAccountsOnce = false, viaPassword = false } = {},
+): Page {
   let currentUrl: string = mfUrls.auth.signIn;
+  let accountsNavigationAborted = false;
   const locator = {
     click: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     fill: vi.fn<(value: string) => Promise<void>>().mockResolvedValue(undefined),
@@ -38,14 +42,21 @@ function createPage(finalUrl: string, viaPassword = false): Page {
       if (url === mfUrls.signIn) {
         currentUrl = viaPassword ? mfUrls.auth.password : finalUrl;
       } else if (url === mfUrls.accounts) {
+        if (abortAccountsOnce && !accountsNavigationAborted) {
+          accountsNavigationAborted = true;
+          throw new Error("page.goto: net::ERR_ABORTED");
+        }
         currentUrl = finalUrl;
       }
       return null;
     }),
+    isClosed: vi.fn<() => boolean>(() => false),
     locator: vi.fn<(selector: string) => unknown>((selector) =>
       selector.includes("one-time-code") ? otpLocator : locator,
     ),
     url: vi.fn<() => string>(() => currentUrl),
+    waitForLoadState: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+    waitForTimeout: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     waitForURL: vi.fn<(matcher: unknown) => Promise<void>>((matcher) => {
       if (typeof matcher === "function") {
         return Promise.reject(new Error("URL did not change"));
@@ -75,7 +86,7 @@ describe("login", () => {
   });
 
   test("resolves when the browser reaches Money Forward ME", async () => {
-    const page = createPage(mfUrls.accounts, true);
+    const page = createPage(mfUrls.accounts, { viaPassword: true });
 
     await expect(login(page)).resolves.toBeUndefined();
     expect(log).toHaveBeenCalledWith("Login successful!");
@@ -86,6 +97,16 @@ describe("login", () => {
 
     await expect(login(page)).rejects.toThrow("Login failed");
     expect(log).not.toHaveBeenCalledWith("Login successful!");
+  });
+
+  test("retries the authenticated-page probe after aborted navigation", async () => {
+    const page = createPage(mfUrls.accounts, {
+      abortAccountsOnce: true,
+      viaPassword: true,
+    });
+
+    await expect(login(page)).resolves.toBeUndefined();
+    expect(log).toHaveBeenCalledWith("Login successful!");
   });
 
   test("rejects a lookalike Money Forward origin", async () => {

--- a/apps/crawler/src/auth/login.ts
+++ b/apps/crawler/src/auth/login.ts
@@ -243,5 +243,9 @@ export async function login(page: Page): Promise<void> {
     debug("Already redirected to ME (session exists)");
   }
 
+  if (!isLoggedInUrl(page.url())) {
+    throw new Error("Login failed: browser did not reach Money Forward ME");
+  }
+
   log("Login successful!");
 }

--- a/apps/crawler/src/auth/login.ts
+++ b/apps/crawler/src/auth/login.ts
@@ -12,6 +12,8 @@ const TIMEOUTS = {
   login: 30000,
 };
 
+const MONEY_FORWARD_ME_ORIGIN = new URL(mfUrls.home).origin;
+
 const SELECTORS = {
   mfidEmail: 'input[name="mfid_user[email]"]',
   mfidPassword: 'input[name="mfid_user[password]"]',
@@ -23,11 +25,14 @@ const SELECTORS = {
 };
 
 function isLoggedInUrl(url: string): boolean {
-  return (
-    url.includes("moneyforward.com") &&
-    !url.includes("id.moneyforward.com") &&
-    !url.includes("/sign_in")
-  );
+  try {
+    const currentUrl = new URL(url);
+    return (
+      currentUrl.origin === MONEY_FORWARD_ME_ORIGIN && !currentUrl.pathname.includes("/sign_in")
+    );
+  } catch {
+    return false;
+  }
 }
 
 function buildAccountSelector(username: string): string {

--- a/apps/crawler/src/auth/login.ts
+++ b/apps/crawler/src/auth/login.ts
@@ -13,6 +13,7 @@ const TIMEOUTS = {
 };
 
 const MONEY_FORWARD_ME_ORIGIN = new URL(mfUrls.home).origin;
+const AUTHENTICATED_PATHNAME = new URL(mfUrls.accounts).pathname;
 
 const SELECTORS = {
   mfidEmail: 'input[name="mfid_user[email]"]',
@@ -28,7 +29,9 @@ function isLoggedInUrl(url: string): boolean {
   try {
     const currentUrl = new URL(url);
     return (
-      currentUrl.origin === MONEY_FORWARD_ME_ORIGIN && !currentUrl.pathname.includes("/sign_in")
+      currentUrl.origin === MONEY_FORWARD_ME_ORIGIN &&
+      (currentUrl.pathname === AUTHENTICATED_PATHNAME ||
+        currentUrl.pathname.startsWith(`${AUTHENTICATED_PATHNAME}/`))
     );
   } catch {
     return false;
@@ -85,8 +88,9 @@ async function isSessionValid(page: Page): Promise<boolean> {
   debug("Checking if session is valid...");
 
   try {
-    // Navigate to Money Forward home
-    await page.goto(mfUrls.home, {
+    // Navigate to a page that requires an authenticated Money Forward ME session.
+    // The public home page cannot prove that the session is valid.
+    await page.goto(mfUrls.accounts, {
       waitUntil: "domcontentloaded",
       timeout: TIMEOUTS.long,
     });
@@ -247,6 +251,14 @@ export async function login(page: Page): Promise<void> {
   } else {
     debug("Already redirected to ME (session exists)");
   }
+
+  // Recheck against an authenticated-only page. moneyforward.com/ itself is
+  // publicly accessible and therefore cannot be used as proof of login.
+  await page.goto(mfUrls.accounts, {
+    waitUntil: "domcontentloaded",
+    timeout: TIMEOUTS.long,
+  });
+  await waitForUrlChange(page);
 
   if (!isLoggedInUrl(page.url())) {
     throw new Error("Login failed: browser did not reach Money Forward ME");

--- a/apps/crawler/src/auth/login.ts
+++ b/apps/crawler/src/auth/login.ts
@@ -1,6 +1,7 @@
 import { mfUrls } from "@mf-dashboard/meta/urls";
 import type { BrowserContext, Page } from "playwright";
 import { log, debug } from "../logger.js";
+import { navigateToAccountsPage } from "../scrapers/refresh.js";
 import { getCredentials, getOTP } from "./credentials.js";
 import { hasAuthState, saveAuthState } from "./state.js";
 
@@ -90,10 +91,7 @@ async function isSessionValid(page: Page): Promise<boolean> {
   try {
     // Navigate to a page that requires an authenticated Money Forward ME session.
     // The public home page cannot prove that the session is valid.
-    await page.goto(mfUrls.accounts, {
-      waitUntil: "domcontentloaded",
-      timeout: TIMEOUTS.long,
-    });
+    await navigateToAccountsPage(page);
 
     // Wait a bit for potential redirects
     await waitForUrlChange(page);
@@ -254,10 +252,7 @@ export async function login(page: Page): Promise<void> {
 
   // Recheck against an authenticated-only page. moneyforward.com/ itself is
   // publicly accessible and therefore cannot be used as proof of login.
-  await page.goto(mfUrls.accounts, {
-    waitUntil: "domcontentloaded",
-    timeout: TIMEOUTS.long,
-  });
+  await navigateToAccountsPage(page);
   await waitForUrlChange(page);
 
   if (!isLoggedInUrl(page.url())) {

--- a/apps/crawler/src/run.test.ts
+++ b/apps/crawler/src/run.test.ts
@@ -110,6 +110,26 @@ afterEach(async () => {
 });
 
 describe("runCrawler progress", () => {
+  test("認証失敗時はスクレイプを開始しない", async () => {
+    const authError = new Error("Login failed");
+    vi.mocked(runAuthPhase).mockRejectedValueOnce(authError);
+    const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
+      id: "run-a",
+      source: "test",
+      startedAt: "2026-07-01T00:00:00.000Z",
+    });
+
+    await expect(runCrawler(progress)).rejects.toBe(authError);
+
+    expect(runScrapePhase).not.toHaveBeenCalled();
+    expect(createGroupScope).not.toHaveBeenCalled();
+    expect(handleCrawlerFailure).toHaveBeenCalledWith(
+      authError,
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
   test("atomic database save失敗を database save step に記録する", async () => {
     const progress = await createCrawlerProgressReporter(path.join(tempDir, "state.json"), {
       id: "run-a",


### PR DESCRIPTION
# Summary

MoneyForward のログイン処理完了時に、ブラウザが認証必須の MoneyForward ME /accounts へ到達したことを検証します。公開トップ、MFID のサインイン画面、lookalike origin、その他の未認識 URL に残留した場合は明示的な例外を送出し、crawler が後続スクレイプへ進まないようにしました。

Fixes #367

## Linear Issue

- [HIR-190](https://linear.app/hiroppy/issue/HIR-190/バグ修正)

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| 機能適合性 | 未ログイン状態や公開ページ、URL 部分一致を成功として扱わないことが主要要件 | MoneyForward ME の exact origin かつ認証必須 /accounts path のみ許可し、公開トップ・MFID・lookalike origin を拒否する |
| 信頼性 | 認証失敗後のスクレイプ継続は誤データや二次障害につながる | session validation と login 完了確認の両方で認証必須 page を使い、ERR_ABORTED は既存 helper で再試行する。認証失敗時は group scope と scrape を開始せず failure handler を実行する |
| 保守性 | 外部認証フローと URL 形状の分岐は将来の変更で回帰しやすい | 成功・公開トップ・MFID・lookalike URL と caller の停止動作を単体テストで固定する |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| 同値分割 | 最終状態を認証済み accounts、公開トップ、未ログイン MFID、lookalike origin に分ける | 正常 URL、公開 URL、認証失敗 URL、不正な URL 形状の代表ケース |
| 分岐テスト | 最終 URL ガードの成功・失敗分岐を直接実行する | authenticated path での正常 return と不一致時の例外送出 |
| 状態遷移テスト | password から accounts、認証失敗から crawler 停止への遷移を確認する | 正常ログインの最終ガード、scrape/group 未開始、failure handler 実行 |
| エラー推測 | 公開トップへのリダイレクト、リダイレクト未完了、hostname 部分一致を再現する | 従来の誤成功、公開 page の誤認、lookalike origin の回帰防止 |

### Primary Test Conditions

- MFID サインイン URL に残留した場合、login() が Login failed を送出し成功ログを出さない
- password 経由で認証必須 /accounts へ到達した場合、新しい最終ガードを通過して成功ログを出す
- 公開 MoneyForward home はログイン証明として扱わず拒否する
- 認証必須 page の初回遷移が net::ERR_ABORTED でも 1 回再試行して成功する
- moneyforward.com.attacker.example のような lookalike origin を拒否する
- 認証フェーズが reject した場合、crawler は scrape と group scope の作成を開始せず、failure handler を呼ぶ
- 正常認証時の既存 crawler 成功フローは全単体テストで維持される

### Out-of-Scope Risks

- 実サービスの OTP、account selector、DOM selector の認証シナリオは個人情報・外部認証状態に依存し、今回変更した URL 判定に対して非決定的なため対象外
- 認証成功後の scrape/save/notification の downstream failure path は既存テストの責務であり、今回の認証停止条件の変更対象外
- URL の query/fragment は origin と pathname に影響せず、ログイン状態判定要件の対象外

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [ ] Storybook tests
- [ ] E2E tests
- [ ] Manual verification

### Commands Executed

pnpm --filter @mf-dashboard/crawler exec vitest run --project unit src/auth/login.test.ts src/run.test.ts — 3 files \/ 27 tests passed

pnpm --filter @mf-dashboard/crawler test — 33 files \/ 374 tests passed

pnpm --filter @mf-dashboard/crawler typecheck — passed

pnpm lint — passed

pnpm format:check — passed

git diff --check — passed

### Checks Not Run

- Storybook tests — N/A: UI コンポーネントの変更なし
- E2E tests — 実 MoneyForward 認証と個人情報を必要とし、変更した URL 判定分岐は匿名 Page モックで決定的に検証済み
- Manual verification — 実サービス認証を必要とし、個人情報を扱わない自動テストを優先