### PR TITLE
fix(crawler): derive deposit table columns from their headers

### DIFF
--- a/apps/crawler/src/scrapers/portfolio.test.ts
+++ b/apps/crawler/src/scrapers/portfolio.test.ts
@@ -15,6 +15,7 @@ import {
   parseOptionalJapaneseNumber,
   parsePnsPortfolioItem,
   parseStockPortfolioItem,
+  resolveDepositColumns,
   resolveDepositTableCategory,
   selectLinkedPnsAccounts,
   selectLinkedPnsPortfolioItems,
@@ -312,6 +313,42 @@ describe("identifyTableTypeFromTitle", () => {
   test("不明なタイトルは「不明」を返す", () => {
     expect(identifyTableTypeFromTitle("")).toBe("不明");
     expect(identifyTableTypeFromTitle("不明なカテゴリ")).toBe("不明");
+  });
+});
+
+describe("resolveDepositColumns", () => {
+  test("resolves the standard deposit layout", () => {
+    expect(resolveDepositColumns(["種類・名称", "残高", "保有金融機関", "変更", "削除"])).toEqual({
+      NAME: 0,
+      BALANCE: 1,
+      INSTITUTION: 2,
+    });
+  });
+
+  // 「株式(信用)」は .table-depo だが列順が異なる。既定の列順で読むと
+  // 金融機関名と金額が入れ替わる。
+  test("resolves the margin-stock layout that reorders the columns", () => {
+    expect(resolveDepositColumns(["保有金融機関", "名称", "残高", "変更", "削除"])).toEqual({
+      NAME: 1,
+      BALANCE: 2,
+      INSTITUTION: 0,
+    });
+  });
+
+  test("tolerates surrounding whitespace", () => {
+    expect(resolveDepositColumns([" 保有金融機関 ", " 名称 ", " 残高 "])).toEqual({
+      NAME: 1,
+      BALANCE: 2,
+      INSTITUTION: 0,
+    });
+  });
+
+  test.each([
+    ["missing headers", []],
+    ["an unknown layout", ["列A", "列B", "列C"]],
+    ["a partial match", ["名称", "残高"]],
+  ])("falls back to the default layout for %s", (_case, headers) => {
+    expect(resolveDepositColumns(headers)).toEqual({ NAME: 0, BALANCE: 1, INSTITUTION: 2 });
   });
 });
 

--- a/apps/crawler/src/scrapers/portfolio.ts
+++ b/apps/crawler/src/scrapers/portfolio.ts
@@ -24,6 +24,14 @@ export const PNS_CORE_COLUMN_COUNT = 6;
 const CELL_TIMEOUT = 1000;
 
 const DEPOSIT_COLUMNS = { NAME: 0, BALANCE: 1, INSTITUTION: 2 } as const;
+type DepositColumns = { NAME: number; BALANCE: number; INSTITUTION: number };
+// `.table-depo` は預金以外の区分でも使われ、列順が同じとは限らない。
+// 例: 「株式(信用)」は [保有金融機関, 名称, 残高]、預金は [種類・名称, 残高, 保有金融機関]。
+const DEPOSIT_HEADER_LABELS = {
+  NAME: ["種類・名称", "名称"],
+  BALANCE: ["残高"],
+  INSTITUTION: ["保有金融機関"],
+} as const;
 const STOCK_COLUMNS = {
   CODE: 0,
   NAME: 1,
@@ -107,6 +115,24 @@ async function getPrecedingSectionTitle(table: Locator): Promise<string> {
   });
 }
 
+/**
+ * ヘッダー行の文言から列位置を決める。列順が既定と異なるテーブル(株式(信用)など)を
+ * 預金の列順で読むと、金融機関名と金額が入れ替わったまま保存されてしまうため。
+ * 判別できない場合は既定の列順にフォールバックする。
+ */
+export function resolveDepositColumns(headers: readonly string[]): DepositColumns {
+  const normalized = headers.map((header) => header.trim());
+  const indexOf = (labels: readonly string[]) =>
+    normalized.findIndex((header) => labels.includes(header));
+
+  const NAME = indexOf(DEPOSIT_HEADER_LABELS.NAME);
+  const BALANCE = indexOf(DEPOSIT_HEADER_LABELS.BALANCE);
+  const INSTITUTION = indexOf(DEPOSIT_HEADER_LABELS.INSTITUTION);
+
+  if (NAME < 0 || BALANCE < 0 || INSTITUTION < 0) return DEPOSIT_COLUMNS;
+  return { NAME, BALANCE, INSTITUTION };
+}
+
 export function resolveDepositTableCategory(titleText: string): string {
   const category = titleText.trim();
   return DEPOSIT_TABLE_CATEGORIES.has(category) ? category : "預金・現金";
@@ -143,6 +169,14 @@ async function parseDeposits(page: Page): Promise<PortfolioItem[]> {
     const category = resolveDepositTableCategory(sectionTitle);
     debug(`  .table-depo[${t}] title: "${sectionTitle}" -> ${category}`);
 
+    const headers = await table.locator("thead th").allTextContents();
+    const columns = resolveDepositColumns(headers);
+    if (columns === DEPOSIT_COLUMNS && headers.length > 0) {
+      warn(
+        `  .table-depo[${t}] unrecognized headers, using default columns: ${headers.join(", ")}`,
+      );
+    }
+
     const rows = table.locator("tbody tr");
     const count = await rows.count();
 
@@ -150,10 +184,10 @@ async function parseDeposits(page: Page): Promise<PortfolioItem[]> {
       const cells = rows.nth(i).locator("td");
       // 並列取得
       const [name, institution, balanceText, accountMfId] = await Promise.all([
-        getCellText(cells, DEPOSIT_COLUMNS.NAME),
-        getInstitutionFromCell(cells, DEPOSIT_COLUMNS.INSTITUTION),
-        getCellText(cells, DEPOSIT_COLUMNS.BALANCE, "0"),
-        getAccountMfIdFromCell(cells, DEPOSIT_COLUMNS.INSTITUTION),
+        getCellText(cells, columns.NAME),
+        getInstitutionFromCell(cells, columns.INSTITUTION),
+        getCellText(cells, columns.BALANCE, "0"),
+        getAccountMfIdFromCell(cells, columns.INSTITUTION),
       ]);
       const item = parseDepositPortfolioItem(category, name, institution, balanceText, accountMfId);
       if (item) items.push(item);


### PR DESCRIPTION
## 概要

信用取引の口座を連携していると、ポートフォリオの保存処理が必ず失敗し、DB に一切データが保存されません。原因は `.table-depo` の列位置を決め打ちしていることです。

## 原因

`.table-depo` は預金以外の区分でも使われますが、列順が同じとは限りません。実際のポートフォリオ画面で各テーブルのヘッダー行を確認したところ、以下のようになっていました。

| セクション | ヘッダー行 |
| --- | --- |
| 預金・現金 | `種類・名称` / `残高` / `保有金融機関` / `変更` / `削除` |
| 暗号資産 | `種類・名称` / `残高` / `保有金融機関` / `変更` / `削除` |
| **株式(信用)** | **`保有金融機関` / `名称` / `残高`** / `変更` / `削除` |

`株式(信用)` だけ `保有金融機関` が先頭で、`名称` と `残高` が 1 つずつ後ろにずれています。

現在の実装は `DEPOSIT_COLUMNS = { NAME: 0, BALANCE: 1, INSTITUTION: 2 }` を全テーブルに適用するため、`株式(信用)` の行では

- `name` に保有金融機関名が入る
- `institution` に残高（`123,456円` のような金額文字列）が入る

という取り違えが起きます。

なお `resolveDepositTableCategory()` は未知の見出しを `預金・現金` に丸めるため、`株式(信用)` テーブルも預金として扱われ、この取り違えたまま後段へ渡ります。

## 影響

取り違えた項目は `normalizePortfolioCategories()` の下記チェックに到達し、例外で保存トランザクション全体が中断します。

```
Error: Cannot classify a deposit without a unique current account category
    at normalizePortfolioCategories (packages/db/src/repositories/save-scraped-data.ts:85)
    at saveScrapedDataBatch (packages/db/src/repositories/save-scraped-data.ts:146)
```

`institution` が金額文字列なので登録口座名と一致せず、口座カテゴリを解決できないためです。スクレイピング自体は最後まで成功しているのに保存だけが落ちるため、DB は空のままになります。

このチェックは #270 で追加されたものなので、それ以降のバージョンで信用取引口座を持つ利用者は同じ箇所で失敗するはずです。

## 修正

ヘッダー行の文言から列位置を解決するようにしました。

- `種類・名称` または `名称` → NAME
- `残高` → BALANCE
- `保有金融機関` → INSTITUTION

3 つすべてを特定できない場合は従来の固定列順にフォールバックし、`warn` を出します。将来 MF 側のレイアウトが変わった場合に、黙って誤解析されるのではなくログに現れるようにする意図です。

`resolveDepositColumns()` として切り出し、両レイアウト・空ヘッダー・未知ヘッダー・部分一致のケースにユニットテストを追加しています。

## 動作確認

信用取引口座を含む実アカウントに対して実行し、以下を確認しました。

- 修正前: 保存フェーズで上記例外が発生し、DB は空のまま
- 修正後: クロールが完走し、`信用保証金` 系の保有 2 件が正しい保有金融機関・残高で保存される
- 既存のポートフォリオ関連ユニットテスト（43 件）が通過

## 関連

#151 で「信用をやっておらず MF の UI が作れない」とのコメントがあったため、こちらで再現・修正しました。

ただし #151 の要望そのもの（信用建玉のサイズと保有株情報の取得）はこの PR には含まれていません。本 PR は「信用取引口座があると保存が落ちる」不具合の修正のみです。建玉サイズの取得は別途対応が必要です。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portfolio data extraction across different deposit table layouts.
  * Correctly identifies name, balance, and financial institution columns even when their order varies.
  * Handles surrounding whitespace and provides a safe fallback when headers are missing or unrecognized.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->