### PR TITLE
fix(crawler): await group navigation before scraping

### DIFF
--- a/apps/crawler/src/scrapers/group.test.ts
+++ b/apps/crawler/src/scrapers/group.test.ts
@@ -13,6 +13,7 @@ import { createGroupScope, NO_GROUP_ID, switchGroup } from "./group.js";
 
 function createFailingGroupPage(switchError: Error = new Error("private-group-id")) {
   const state = { currentGroupId: "private-group-id" };
+  const waitForNavigation = vi.fn<() => Promise<null>>(async () => null);
   const option = {
     count: vi.fn<() => Promise<number>>(async () => 1),
     textContent: vi.fn<() => Promise<string>>(async () => "Private Group Name"),
@@ -31,11 +32,11 @@ function createFailingGroupPage(switchError: Error = new Error("private-group-id
     goto: vi.fn<() => Promise<null>>(async () => null),
     isClosed: vi.fn<() => boolean>(() => false),
     locator: vi.fn<() => typeof select>(() => select),
-    waitForLoadState: vi.fn<() => Promise<void>>(async () => undefined),
+    waitForNavigation,
     waitForTimeout: vi.fn<() => Promise<void>>(async () => undefined),
   } as unknown as Page;
 
-  return { page, select, state };
+  return { page, select, state, waitForNavigation };
 }
 
 describe("createGroupScope", () => {
@@ -98,5 +99,23 @@ describe("switchGroup", () => {
 
     expect(error).toMatchObject({ message: "Group switch failed" });
     expect((error as Error).message).not.toContain("private-group-id");
+  });
+
+  test("選択操作より前からページ遷移を待機する", async () => {
+    const { page, select, state, waitForNavigation } = createFailingGroupPage();
+    const calls: string[] = [];
+    state.currentGroupId = NO_GROUP_ID;
+    waitForNavigation.mockImplementation(async () => {
+      calls.push("wait");
+      state.currentGroupId = "private-group-id";
+      return null;
+    });
+    select.selectOption = vi.fn<() => Promise<void>>(async () => {
+      calls.push("select");
+    });
+
+    await switchGroup(page, "private-group-id");
+
+    expect(calls).toEqual(["wait", "select"]);
   });
 });

--- a/apps/crawler/src/scrapers/group.ts
+++ b/apps/crawler/src/scrapers/group.ts
@@ -186,11 +186,11 @@ export async function switchGroup(page: Page, groupId: string): Promise<Group | 
   }
 
   try {
-    // グループを切り替え
-    await groupSelect.selectOption({ value: groupId });
-
-    // ページ遷移またはリロードを待つ
-    await page.waitForLoadState("domcontentloaded");
+    // 選択直後に始まる遷移を取り逃さないよう、操作前から待機する。
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: "domcontentloaded" }),
+      groupSelect.selectOption({ value: groupId }),
+    ]);
     // グループセレクタが更新されるまで待機
     await page.locator(GROUP_SELECTOR).waitFor({ state: "visible", timeout: 5000 });
 

--- a/apps/crawler/tests/e2e/group-state.ts
+++ b/apps/crawler/tests/e2e/group-state.ts
@@ -28,8 +28,10 @@ export async function switchGroupAnonymously(page: Page, groupId: string): Promi
     const selector = await getVisibleGroupSelector(page);
     if ((await selector.inputValue()) === groupId) return;
 
-    await selector.selectOption({ value: groupId });
-    await page.waitForLoadState("domcontentloaded");
+    await Promise.all([
+      page.waitForNavigation({ waitUntil: "domcontentloaded" }),
+      selector.selectOption({ value: groupId }),
+    ]);
 
     const updatedSelector = page.locator(GROUP_SELECTOR).first();
     await updatedSelector.waitFor({ state: "visible", timeout: 5000 });


### PR DESCRIPTION
# Summary

- Start waiting for the Money Forward group navigation before changing the group selection.
- Prevent a delayed `/accounts` navigation from interrupting the following asset-summary scrape.
- Add regression coverage for navigation wait ordering and align the authenticated E2E group helper.

## Linear Issue

- N/A

## QA Plan

### Selected Quality Characteristics

| Quality characteristic | Why it is relevant | Acceptance criteria |
| ---------------------- | ------------------ | ------------------- |
| Functional suitability | Each group must be active before its accounts and asset data are scraped | The selected group is verified only after its navigation completes |
| Reliability | A navigation race intermittently redirected the page while the next scraper was waiting for asset selectors | Group traversal completes without an `/accounts` navigation interrupting the asset-summary step |

### Test Techniques

| Test technique | Selection rationale | Expected coverage |
| -------------- | ------------------- | ----------------- |
| State transition testing | Group selection, navigation, DOM readiness, and scraping must happen in order | Navigation waiting is registered before selection and the resulting group is verified afterward |
| Regression testing | The failure appeared during a complete multi-group crawl | The authenticated all-groups E2E traverses the production workflow and validates every group result structurally |

### Primary Test Conditions

- A group selection that immediately starts a page navigation.
- Verification of the selected group after `domcontentloaded`.
- Authenticated traversal of every configured group, including the no-group state.

### Out-of-Scope Risks

- Future Money Forward selector changes outside the group-navigation race are not addressed.

## Verification

- [x] Unit tests
- [x] Type checking
- [x] Lint
- [ ] Storybook tests
- [x] E2E tests
- [x] Manual verification

### Commands Executed

```text
pnpm --filter @mf-dashboard/crawler test — passed, 390 tests
pnpm --filter @mf-dashboard/crawler typecheck — passed
pnpm lint — passed with 5 pre-existing web warnings
pnpm format:check — passed
pnpm --filter @mf-dashboard/crawler exec vitest run --project e2e tests/e2e/scrape-all-groups.test.ts — passed, 18 tests
read-only production structure probe across all groups — asset summary selectors present for every group
```

### Checks Not Run

- Storybook tests — no web components or stories changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved group switching reliability by ensuring page navigation is captured when changing groups.
  - Reduced the risk of missed navigation events during group selection.
- **Tests**
  - Added coverage verifying navigation begins before the group selection action.
  - Updated end-to-end checks for anonymous group switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->